### PR TITLE
fix: Read/Write 오분류 및 멀티라인 shell unwrap 보강

### DIFF
--- a/services/aris-backend/src/runtime/actionType.ts
+++ b/services/aris-backend/src/runtime/actionType.ts
@@ -23,7 +23,7 @@ const FILE_WRITE_PATTERNS: RegExp[] = [
   /\binstall\b/,
   /\bcat\b[\s\S]*>>?/,
   /\b(?:echo|printf)\b[\s\S]*>>?/,
-  /(?:^|[\s;|&()])(?:\d+)?>>?(?=\S)/,
+  /(?:^|[\s;|&()])(?:\d+)?>>?\s*(?=\S)/,
 ];
 
 const FILE_READ_PATTERNS: RegExp[] = [
@@ -39,7 +39,7 @@ function unwrapShellCommand(raw: string): string {
     current = current.slice(2).trim();
   }
 
-  const wrappers = [/^(?:\/bin\/)?bash\s+-lc\s+(.+)$/i, /^(?:\/bin\/)?sh\s+-lc\s+(.+)$/i];
+  const wrappers = [/^(?:\/bin\/)?bash\s+-lc\s+([\s\S]+)$/i, /^(?:\/bin\/)?sh\s+-lc\s+([\s\S]+)$/i];
   for (const wrapper of wrappers) {
     const match = current.match(wrapper);
     if (!match) {

--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -548,12 +548,29 @@ function isMissingCodexThreadError(error: unknown): boolean {
 }
 
 function unwrapShellCommand(command: string): string {
-  const trimmed = command.trim();
-  const shellPrefix = "/bin/bash -lc '";
-  if (trimmed.startsWith(shellPrefix) && trimmed.endsWith("'")) {
-    return trimmed.slice(shellPrefix.length, -1);
+  let current = command.trim();
+  if (current.startsWith('$ ')) {
+    current = current.slice(2).trim();
   }
-  return trimmed;
+
+  const wrappers = [/^(?:\/bin\/)?bash\s+-lc\s+([\s\S]+)$/i, /^(?:\/bin\/)?sh\s+-lc\s+([\s\S]+)$/i];
+  for (const wrapper of wrappers) {
+    const match = current.match(wrapper);
+    if (!match) {
+      continue;
+    }
+    const inner = match[1]?.trim() ?? '';
+    if (
+      (inner.startsWith('"') && inner.endsWith('"'))
+      || (inner.startsWith("'") && inner.endsWith("'"))
+    ) {
+      current = inner.slice(1, -1).trim();
+    } else {
+      current = inner;
+    }
+  }
+
+  return current;
 }
 
 function normalizeCodexApprovalDecision(value: unknown): PermissionRisk {

--- a/services/aris-backend/tests/actionType.test.ts
+++ b/services/aris-backend/tests/actionType.test.ts
@@ -17,6 +17,16 @@ describe('inferActionTypeFromCommand', () => {
     expect(inferActionTypeFromCommand('/bin/bash -lc "printf %s\\\\n hello>>out.txt"')).toBe('file_write');
   });
 
+  it('classifies redirects with spaces as file_write', () => {
+    expect(inferActionTypeFromCommand('/bin/bash -lc "sed -n \'1,120p\' src/app.ts > out.txt"')).toBe('file_write');
+    expect(inferActionTypeFromCommand('/bin/bash -lc "awk \'{print $1}\' src/app.ts > out.txt"')).toBe('file_write');
+  });
+
+  it('unwraps multiline bash -lc commands before classification', () => {
+    const command = '/bin/bash -lc "echo hello > out.txt\\ncat out.txt"';
+    expect(inferActionTypeFromCommand(command)).toBe('file_write');
+  });
+
   it('does not treat quoted greater-than as redirect', () => {
     const command = "/bin/bash -lc 'echo \"a > b\"'";
     expect(inferActionTypeFromCommand(command)).toBe('command_execution');

--- a/services/aris-web/lib/happy/normalizer.ts
+++ b/services/aris-web/lib/happy/normalizer.ts
@@ -139,7 +139,7 @@ function unwrapShellCommand(raw: string): string {
     current = current.slice(2).trim();
   }
 
-  const wrappers = [/^(?:\/bin\/)?bash\s+-lc\s+(.+)$/i, /^(?:\/bin\/)?sh\s+-lc\s+(.+)$/i];
+  const wrappers = [/^(?:\/bin\/)?bash\s+-lc\s+([\s\S]+)$/i, /^(?:\/bin\/)?sh\s+-lc\s+([\s\S]+)$/i];
   for (const wrapper of wrappers) {
     const match = current.match(wrapper);
     if (!match) {
@@ -305,7 +305,7 @@ function hasWriteShellIntent(commandInput: string): boolean {
     || /\binstall\b/.test(unquoted)
     || /\bcat\b[\s\S]*>>?/.test(unquoted)
     || /\b(?:echo|printf)\b[\s\S]*>>?/.test(unquoted)
-    || /(?:^|[\s;|&()])(?:\d+)?>>?(?=\S)/.test(unquoted)
+    || /(?:^|[\s;|&()])(?:\d+)?>>?\s*(?=\S)/.test(unquoted)
   );
 }
 
@@ -388,7 +388,16 @@ export function classifyEventKind(input: { type?: string; text?: string; command
   const command = input.command ?? '';
 
   const kindFromType = pickKindFromMeta(null, type);
-  if (kindFromType === 'file_read' && hasWriteShellIntent(command)) {
+  if (
+    hasWriteShellIntent(command)
+    && (
+      kindFromType === null
+      || kindFromType === 'file_read'
+      || kindFromType === 'command_execution'
+      || kindFromType === 'run_execution'
+      || kindFromType === 'exec_execution'
+    )
+  ) {
     return 'file_write';
   }
   if (

--- a/services/aris-web/tests/normalizer.test.ts
+++ b/services/aris-web/tests/normalizer.test.ts
@@ -52,6 +52,22 @@ describe('classifyEventKind', () => {
     expect(printfKind).toBe('file_write');
   });
 
+  it('detects redirects with spaces as file_write', () => {
+    const kind = classifyEventKind({
+      type: 'command_execution',
+      command: '/bin/bash -lc "sed -n \'1,120p\' src/app.ts > out.txt"',
+    });
+    expect(kind).toBe('file_write');
+  });
+
+  it('detects multiline bash -lc writes as file_write', () => {
+    const kind = classifyEventKind({
+      type: 'command_execution',
+      command: '/bin/bash -lc "echo hello > out.txt\\ncat out.txt"',
+    });
+    expect(kind).toBe('file_write');
+  });
+
   it('does not treat quoted greater-than in echo as write intent', () => {
     const kind = classifyEventKind({
       type: 'file_read',
@@ -144,6 +160,19 @@ describe('normalizeEvents', () => {
         type: 'message',
         text: '$ /bin/bash -lc "cd /tmp/work && sed -n \'1,120p\' a.ts && mkdir -p prisma/migrations && cat > prisma/migrations/001_init.sql <<\'SQL\'"',
         meta: { actionType: 'file_read' },
+      },
+    ]);
+
+    expect(events[0].kind).toBe('file_write');
+  });
+
+  it('overrides command_execution meta when command contains redirect with spaces', () => {
+    const events = normalizeEvents([
+      {
+        id: 'e3d',
+        type: 'message',
+        text: '$ /bin/bash -lc "sed -n \'1,120p\' src/app.ts > out.txt"',
+        meta: { actionType: 'command_execution' },
       },
     ]);
 


### PR DESCRIPTION
## 변경 내용
- write intent 리다이렉션 패턴에 공백 케이스(`> out.txt`) 반영
- `bash -lc` unwrap 로직을 멀티라인 명령까지 처리하도록 보강
- 프론트 분류에서 write intent를 더 우선 적용하도록 보정
- 백엔드/프론트 회귀 테스트 추가

## 확인 사항
- 로컬 테스트 실행은 `vitest` 미설치로 수행하지 못했습니다.

## 관련 이슈
- #12
