### PR TITLE
fix: stale Claude resume ID 복구

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -8,7 +8,7 @@ import { inferActionTypeFromCommand, titleForActionType } from './actionType.js'
 import { summarizeDiffText, summarizeFileChangeDiff } from './diffStats.js';
 import { HappyEventLogger } from './happyEventLogger.js';
 import { resolveRuntimeModelSelection } from './modelPolicy.js';
-import { buildClaudeActionThreadId, recoverClaudeThreadIdFromMessages, runClaudeProviderTurn } from './providers/claude/claudeOrchestrator.js';
+import { recoverClaudeThreadIdFromMessages, runClaudeProviderTurn } from './providers/claude/claudeOrchestrator.js';
 import { looksLikeClaudeActionTranscript, parseClaudeStreamLine, parseClaudeStreamOutput } from './providers/claude/claudeProtocolMapper.js';
 import { ClaudeSessionRegistry } from './providers/claude/claudeSessionRegistry.js';
 import { extractClaudeSessionHintIds, scanClaudeSessionLogs } from './providers/claude/claudeSessionScanner.js';
@@ -3310,12 +3310,6 @@ export class HappyRuntimeStore {
         const nonCodexCwd = this.resolveExecutionCwd(session.metadata.path);
         let streamedActionIndex = 0;
         if (isClaude) {
-          const claudeActionThreadId = buildClaudeActionThreadId(
-            requestedThreadId,
-            storedClaudeThreadId,
-            session.id,
-            scopedChatId,
-          );
           const claudeResponse = await runClaudeProviderTurn({
             session,
             prompt,
@@ -3324,8 +3318,8 @@ export class HappyRuntimeStore {
             storedThreadId: storedClaudeThreadId,
             model: selectedModel,
             signal: controller.signal,
-            onAction: async (action) => {
-              await appendNonCodexAction(action, streamedActionIndex, nonCodexCwd, claudeActionThreadId);
+            onAction: async (action, meta) => {
+              await appendNonCodexAction(action, streamedActionIndex, nonCodexCwd, meta.threadId);
               streamedActionIndex += 1;
             },
             executeCommand: async ({ command, cwdHint, signal, onAction }) => this.runAgentCommand(

--- a/services/aris-backend/src/runtime/providers/claude/claudeLauncher.ts
+++ b/services/aris-backend/src/runtime/providers/claude/claudeLauncher.ts
@@ -61,6 +61,11 @@ export function isClaudeSessionInUseError(error: unknown): boolean {
   return message.includes('session id') && message.includes('already in use');
 }
 
+export function isClaudeMissingConversationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return message.includes('no conversation found with session id');
+}
+
 export async function runClaudeCommand(input: {
   prompt: string;
   approvalPolicy: ApprovalPolicy;

--- a/services/aris-backend/src/runtime/providers/claude/claudeOrchestrator.ts
+++ b/services/aris-backend/src/runtime/providers/claude/claudeOrchestrator.ts
@@ -1,6 +1,7 @@
 import { buildClaudeSessionId } from './claudeSessionSource.js';
+import { isClaudeMissingConversationError } from './claudeLauncher.js';
 import { runClaudeTurn } from './claudeRuntime.js';
-import type { ClaudeCommandExecutor, ClaudeRuntimeSession, ClaudeTurnResult } from './types.js';
+import type { ClaudeActionEvent, ClaudeCommandExecutor, ClaudeRuntimeSession, ClaudeTurnResult } from './types.js';
 import type { RuntimeMessage } from '../../../types.js';
 
 export function buildClaudeActionThreadId(
@@ -62,34 +63,41 @@ export async function runClaudeProviderTurn(input: {
   storedThreadId?: string;
   model?: string;
   signal?: AbortSignal;
-  onAction?: Parameters<ClaudeCommandExecutor>[0]['onAction'];
+  onAction?: (action: ClaudeActionEvent, meta: { threadId: string }) => Promise<void>;
   executeCommand: ClaudeCommandExecutor;
 }): Promise<ClaudeTurnResult & { actionThreadId?: string; messageMeta: Record<string, unknown> }> {
   const preferredThreadId = input.requestedThreadId ?? input.storedThreadId;
-  const actionThreadId = buildClaudeActionThreadId(
-    input.requestedThreadId,
-    input.storedThreadId,
-    input.session.id,
-    input.chatId,
-  );
-  const result = await runClaudeTurn({
-    session: input.session,
-    prompt: input.prompt,
-    chatId: input.chatId,
-    preferredThreadId,
-    model: input.model,
-    signal: input.signal,
-    onAction: input.onAction,
-    executeCommand: input.executeCommand,
+  const executeTurn = async (attemptedThreadId?: string) => {
+    const actionThreadId = attemptedThreadId ?? buildClaudeSessionId(input.session.id, input.chatId);
+    const result = await runClaudeTurn({
+      session: input.session,
+      prompt: input.prompt,
+      chatId: input.chatId,
+      preferredThreadId: attemptedThreadId,
+      model: input.model,
+      signal: input.signal,
+      onAction: input.onAction
+        ? async (action) => input.onAction?.(action, { threadId: actionThreadId })
+        : undefined,
+      executeCommand: input.executeCommand,
+    });
+    return { actionThreadId, result };
+  };
+
+  const executed = await executeTurn(preferredThreadId).catch(async (error) => {
+    if (!preferredThreadId || !isClaudeMissingConversationError(error)) {
+      throw error;
+    }
+    return executeTurn(undefined);
   });
 
   return {
-    ...result,
-    actionThreadId,
-    messageMeta: result.threadId
+    ...executed.result,
+    actionThreadId: executed.actionThreadId,
+    messageMeta: executed.result.threadId
       ? {
-        claudeSessionId: result.threadId,
-        threadIdSource: result.threadIdSource,
+        claudeSessionId: executed.result.threadId,
+        threadIdSource: executed.result.threadIdSource,
       }
       : {},
   };

--- a/services/aris-backend/tests/claudeProviderFlow.test.ts
+++ b/services/aris-backend/tests/claudeProviderFlow.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { runClaudeProviderTurn } from '../src/runtime/providers/claude/claudeOrchestrator.js';
 import { buildClaudeSessionId } from '../src/runtime/providers/claude/claudeSessionSource.js';
 
@@ -77,5 +77,62 @@ describe('Claude provider flow', () => {
       claudeSessionId: 'observed-session-1',
       threadIdSource: 'resume',
     });
+  });
+
+  it('falls back to a fresh synthetic Claude session when a stored resume id is missing', async () => {
+    const seenCommands: string[][] = [];
+    const onAction = vi.fn();
+    const session = {
+      id: 'runtime-session-2',
+      metadata: {
+        approvalPolicy: 'never',
+        path: '/tmp/claude-provider-flow',
+      },
+    };
+
+    const result = await runClaudeProviderTurn({
+      session,
+      prompt: 'follow up',
+      chatId: 'chat-2',
+      storedThreadId: 'bedc95ab-adf7-5709-938a-ad61199566f8',
+      onAction,
+      executeCommand: async ({ command, onAction: emitAction }) => {
+        seenCommands.push(command.args);
+        if (seenCommands.length === 1) {
+          throw new Error('No conversation found with session ID: bedc95ab-adf7-5709-938a-ad61199566f8');
+        }
+        await emitAction?.({
+          actionType: 'command_execution',
+          title: 'Run command',
+          command: 'pwd',
+          additions: 0,
+          deletions: 0,
+          hasDiffSignal: false,
+        });
+        return {
+          output: 'fresh response',
+          cwd: '/tmp/claude-provider-flow',
+          streamedActionsPersisted: false,
+          inferredActions: [],
+        };
+      },
+    });
+
+    expect(seenCommands).toHaveLength(2);
+    expect(seenCommands[0]).toContain('--resume');
+    expect(seenCommands[0]).toContain('bedc95ab-adf7-5709-938a-ad61199566f8');
+    expect(seenCommands[1]).toContain('--session-id');
+    expect(seenCommands[1]).toContain(buildClaudeSessionId('runtime-session-2', 'chat-2'));
+    expect(result.actionThreadId).toBe(buildClaudeSessionId('runtime-session-2', 'chat-2'));
+    expect(result.threadId).toBe(buildClaudeSessionId('runtime-session-2', 'chat-2'));
+    expect(result.threadIdSource).toBe('synthetic');
+    expect(result.messageMeta).toEqual({
+      claudeSessionId: buildClaudeSessionId('runtime-session-2', 'chat-2'),
+      threadIdSource: 'synthetic',
+    });
+    expect(onAction).toHaveBeenCalledWith(expect.objectContaining({
+      actionType: 'command_execution',
+      command: 'pwd',
+    }), { threadId: buildClaudeSessionId('runtime-session-2', 'chat-2') });
   });
 });


### PR DESCRIPTION
## 요약
- 다른 프로젝트에서 남은 stale Claude session ID로 `--resume`이 실패하던 문제를 수정했습니다.
- `No conversation found with session ID`가 발생하면 fresh synthetic session으로 재시도합니다.
- streamed action에도 실제 사용된 Claude thread ID를 전달하도록 맞췄습니다.

## 검증
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vitest run tests/claudeProviderFlow.test.ts
- ./node_modules/.bin/vitest run tests/claude*.test.ts

## 참고
- 후속 구조 개선 이슈: #60
- E2E 테스트는 레포에 별도 설정이 없어 이번에는 수행하지 못했습니다.
