### PR TITLE
happyevent 로그 구조 개선 및 empty response 디버그용 fallback 개선

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -2092,7 +2092,7 @@ export class HappyRuntimeStore {
           .map((line) => line.trim())
           .filter((line) => line && !parseJsonLine(line))
           .join('\n');
-        output = trimOutput(nonJsonStdout || cleanedStderr || '');
+        output = trimOutput(nonJsonStdout || cleanedStdout || cleanedStderr || '');
       }
     } else {
       output = trimOutput(cleanedStdout || cleanedStderr || '');

--- a/services/aris-backend/src/runtime/happyEventLogger.ts
+++ b/services/aris-backend/src/runtime/happyEventLogger.ts
@@ -2,8 +2,17 @@ import { appendFileSync, mkdirSync, readdirSync, statSync, unlinkSync } from 'no
 import * as path from 'node:path';
 
 const DEFAULT_MAX_BYTES = 1_024 * 1_024 * 1_024; // 1GB
-const RAW_LOG_FILE = 'happy-raw.ndjson';
-const PARSED_LOG_FILE = 'happy-parsed.ndjson';
+const RAW_FILE_SUFFIX = 'raw';
+const PARSED_FILE_SUFFIX = 'parsed';
+const DELETION_FILE = 'happy-prune-events.ndjson';
+
+type LogRecordType = 'raw' | 'parsed';
+type LogFileInfo = {
+  filePath: string;
+  name: string;
+  size: number;
+  mtimeMs: number;
+};
 
 type LogChannel = 'app_server' | 'exec_cli';
 type LogStage = 'incoming_raw' | 'incoming_payload' | 'parsed_append' | 'run_status' | 'turn_status';
@@ -11,6 +20,7 @@ type LogStage = 'incoming_raw' | 'incoming_payload' | 'parsed_append' | 'run_sta
 export type HappyRawLogRecord = {
   sessionId: string;
   chatId?: string;
+  threadId?: string;
   model?: string;
   turnStatus?: string;
   channel: LogChannel;
@@ -20,6 +30,7 @@ export type HappyRawLogRecord = {
 export type HappyParsedLogRecord = {
   sessionId: string;
   chatId?: string;
+  threadId?: string;
   model?: string;
   turnStatus?: string;
   channel: LogChannel;
@@ -40,17 +51,17 @@ export class HappyEventLogger {
   }
 
   logRaw(record: HappyRawLogRecord): void {
-    this.appendRecord(RAW_LOG_FILE, record);
+    this.appendRecord('raw', record);
   }
 
   logParsed(record: HappyParsedLogRecord): void {
-    this.appendRecord(PARSED_LOG_FILE, record);
+    this.appendRecord('parsed', record);
   }
 
-  private appendRecord(fileName: string, record: object): void {
+  private appendRecord(type: LogRecordType, record: object): void {
     try {
       this.ensureLogsDir();
-      const filePath = path.join(this.logsDir, fileName);
+      const filePath = this.getLogFilePath(type, record);
       const serialized = JSON.stringify({
         loggedAt: new Date().toISOString(),
         ...record,
@@ -71,21 +82,140 @@ export class HappyEventLogger {
     this.initialized = true;
   }
 
-  private pruneIfNeeded(): void {
-    const files = readdirSync(this.logsDir, { withFileTypes: true })
-      .filter((entry) => entry.isFile())
-      .filter((entry) => entry.name.endsWith('.ndjson'))
-      .map((entry) => {
-        const filePath = path.join(this.logsDir, entry.name);
-        const stats = statSync(filePath);
-        return {
-          filePath,
-          name: entry.name,
-          size: stats.size,
-          mtimeMs: stats.mtimeMs,
-        };
-      });
+  private getDateFolder(): string {
+    const date = new Date().toISOString().slice(0, 10);
+    return path.join(this.logsDir, date);
+  }
 
+  private getLogFilePath(type: LogRecordType, record: unknown): string {
+    const dateFolder = this.getDateFolder();
+    mkdirSync(dateFolder, { recursive: true });
+    const conversationKey = this.getConversationKey(record);
+    const suffix = type === 'raw' ? RAW_FILE_SUFFIX : PARSED_FILE_SUFFIX;
+    const fileName = `${conversationKey}-${suffix}.ndjson`;
+    return path.join(dateFolder, fileName);
+  }
+
+  private getConversationKey(record: unknown): string {
+    const parsedRecord = record as {
+      chatId?: unknown;
+      threadId?: unknown;
+      payload?: unknown;
+      sessionId?: unknown;
+    };
+    const sessionId = this.normalizeLogId(
+      typeof parsedRecord.sessionId === 'string'
+        ? parsedRecord.sessionId
+        : undefined,
+    );
+
+    const chatId = this.normalizeLogId(
+      typeof parsedRecord.chatId === 'string'
+        ? parsedRecord.chatId
+        : this.extractChatIdFromPayload(parsedRecord.payload),
+    );
+    const threadId = this.normalizeLogId(
+      typeof parsedRecord.threadId === 'string'
+        ? parsedRecord.threadId
+        : this.extractThreadIdFromPayload(parsedRecord.payload),
+    );
+
+    const safeChatId = chatId || 'no-chat';
+    const safeThreadId = threadId || sessionId || 'no-thread';
+
+    return `${safeChatId}-${safeThreadId}`;
+  }
+
+  private extractThreadIdFromPayload(payload: unknown): string | undefined {
+    if (!payload || typeof payload !== 'object') {
+      return undefined;
+    }
+
+    const directThreadId = (payload as { threadId?: unknown }).threadId;
+    if (typeof directThreadId === 'string') {
+      return directThreadId;
+    }
+
+    const nestedThread = (payload as { thread?: unknown }).thread;
+    if (nestedThread && typeof nestedThread === 'object') {
+      const nestedThreadId = (nestedThread as { id?: unknown }).id;
+      if (typeof nestedThreadId === 'string') {
+        return nestedThreadId;
+      }
+    }
+
+    const meta = (payload as { meta?: unknown }).meta;
+    if (meta && typeof meta === 'object') {
+      const metaThreadId = (meta as { threadId?: unknown }).threadId;
+      if (typeof metaThreadId === 'string') {
+        return metaThreadId;
+      }
+    }
+
+    return undefined;
+  }
+
+  private extractChatIdFromPayload(payload: unknown): string | undefined {
+    if (!payload || typeof payload !== 'object') {
+      return undefined;
+    }
+
+    const directChatId = (payload as { chatId?: unknown }).chatId;
+    if (typeof directChatId === 'string') {
+      return directChatId;
+    }
+
+    const meta = (payload as { meta?: unknown }).meta;
+    if (meta && typeof meta === 'object') {
+      const metaChatId = (meta as { chatId?: unknown }).chatId;
+      if (typeof metaChatId === 'string') {
+        return metaChatId;
+      }
+    }
+
+    return undefined;
+  }
+
+  private normalizeLogId(raw?: string): string | undefined {
+    if (!raw) {
+      return undefined;
+    }
+
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    const safe = trimmed
+      .replace(/[\\/:*?"<>|]+/g, '-')
+      .replace(/\s+/g, '_')
+      .replace(/[^a-zA-Z0-9._-]/g, '_')
+      .slice(0, 80);
+
+    return safe || 'invalid-id';
+  }
+
+  private recordDeletion(deletedFilePath: string, deletedSize: number, remainingSize: number): void {
+    const deletionPath = path.join(this.logsDir, DELETION_FILE);
+    const relativePath = path.relative(this.logsDir, deletedFilePath);
+    const payload = {
+      loggedAt: new Date().toISOString(),
+      action: 'delete_old_log_file',
+      deletedFile: relativePath || deletedFilePath,
+      deletedSize,
+      remainingSize,
+      maxBytes: this.maxBytes,
+    };
+    try {
+      appendFileSync(deletionPath, `${JSON.stringify(payload)}\n`, 'utf8');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`happy event deletion log write failed: ${message}`);
+    }
+  }
+
+  private pruneIfNeeded(): void {
+    const files = this.collectLogFiles();
     let totalBytes = files.reduce((sum, item) => sum + item.size, 0);
     if (totalBytes <= this.maxBytes) {
       return;
@@ -99,11 +229,48 @@ export class HappyEventLogger {
     });
 
     for (const file of files) {
-      unlinkSync(file.filePath);
-      totalBytes -= file.size;
-      if (totalBytes <= this.maxBytes) {
-        break;
+      try {
+        unlinkSync(file.filePath);
+        totalBytes -= file.size;
+        this.recordDeletion(file.filePath, file.size, totalBytes);
+        if (totalBytes <= this.maxBytes) {
+          break;
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`happy event log prune failed: ${message}`);
       }
     }
+  }
+
+  private collectLogFiles(): LogFileInfo[] {
+    const files: LogFileInfo[] = [];
+    const walk = (dirPath: string): void => {
+      const entries = readdirSync(dirPath, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = path.join(dirPath, entry.name);
+        if (entry.isDirectory()) {
+          walk(fullPath);
+          continue;
+        }
+        if (!entry.isFile() || !entry.name.endsWith('.ndjson')) {
+          continue;
+        }
+        try {
+          const stats = statSync(fullPath);
+          files.push({
+            filePath: fullPath,
+            name: entry.name,
+            size: stats.size,
+            mtimeMs: stats.mtimeMs,
+          });
+        } catch {
+          // Ignore transient file changes during pruning scan.
+        }
+      }
+    };
+
+    walk(this.logsDir);
+    return files;
   }
 }


### PR DESCRIPTION
요청사항 반영: Claude empty response 시 stream 출력 폴백을 원시 stdout으로 노출하도록 조정했고, happyEventLogger를 일간 폴더+채팅별 파일 분할 및 1GB 초과시 오래된 로그 삭제 + 삭제 기록 생성 방식으로 변경했습니다.  