### PR TITLE
feat(settings): Claude API 키 등록 및 모델 카탈로그 기능 추가

### DIFF
--- a/services/aris-web/app/SettingsTab.tsx
+++ b/services/aris-web/app/SettingsTab.tsx
@@ -5,7 +5,9 @@ import { CheckCircle2, ChevronDown, ChevronUp, FileKey, KeyRound, Settings2, Upl
 import { OpenAiApiKeyCard } from '@/components/settings/OpenAiApiKeyCard';
 import { CodexModelCatalogCard } from '@/components/settings/CodexModelCatalogCard';
 import {
+  DEFAULT_CLAUDE_MODEL_SELECTIONS,
   DEFAULT_CODEX_MODEL_SELECTIONS,
+  type ClaudeCatalogItem,
   type ModelSettingsResponse,
   type OpenAiCatalogItem,
   type ProviderId,
@@ -32,6 +34,7 @@ const DEFAULT_MODEL_SETTINGS: ModelSettingsResponse = {
   },
   secrets: {
     openAiApiKeyConfigured: false,
+    claudeApiKeyConfigured: false,
   },
 };
 
@@ -47,20 +50,38 @@ export function SettingsTab() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [modelSettings, setModelSettings] = useState<ModelSettingsResponse>(DEFAULT_MODEL_SETTINGS);
-  const [catalogItems, setCatalogItems] = useState<OpenAiCatalogItem[]>([]);
-  const [selectedCodexModelIds, setSelectedCodexModelIds] = useState<string[]>([...DEFAULT_CODEX_MODEL_SELECTIONS]);
-  const [modelSaving, setModelSaving] = useState(false);
-  const [modelFeedback, setModelFeedback] = useState<Feedback>(null);
-  const [catalogLoading, setCatalogLoading] = useState(false);
-  const [catalogError, setCatalogError] = useState<string | null>(null);
-  const [keySaving, setKeySaving] = useState(false);
-  const [keyDeleting, setKeyDeleting] = useState(false);
-  const [keyFeedback, setKeyFeedback] = useState<Feedback>(null);
   const [activeProvider, setActiveProvider] = useState<ProviderId>('codex');
+
+  // Codex 상태
+  const [codexCatalogItems, setCodexCatalogItems] = useState<OpenAiCatalogItem[]>([]);
+  const [selectedCodexModelIds, setSelectedCodexModelIds] = useState<string[]>([...DEFAULT_CODEX_MODEL_SELECTIONS]);
+  const [codexModelSaving, setCodexModelSaving] = useState(false);
+  const [codexModelFeedback, setCodexModelFeedback] = useState<Feedback>(null);
+  const [codexCatalogLoading, setCodexCatalogLoading] = useState(false);
+  const [codexCatalogError, setCodexCatalogError] = useState<string | null>(null);
+  const [codexKeySaving, setCodexKeySaving] = useState(false);
+  const [codexKeyDeleting, setCodexKeyDeleting] = useState(false);
+  const [codexKeyFeedback, setCodexKeyFeedback] = useState<Feedback>(null);
+
+  // Claude 상태
+  const [claudeCatalogItems, setClaudeCatalogItems] = useState<ClaudeCatalogItem[]>([]);
+  const [selectedClaudeModelIds, setSelectedClaudeModelIds] = useState<string[]>([...DEFAULT_CLAUDE_MODEL_SELECTIONS]);
+  const [claudeModelSaving, setClaudeModelSaving] = useState(false);
+  const [claudeModelFeedback, setClaudeModelFeedback] = useState<Feedback>(null);
+  const [claudeCatalogLoading, setClaudeCatalogLoading] = useState(false);
+  const [claudeCatalogError, setClaudeCatalogError] = useState<string | null>(null);
+  const [claudeKeySaving, setClaudeKeySaving] = useState(false);
+  const [claudeKeyDeleting, setClaudeKeyDeleting] = useState(false);
+  const [claudeKeyFeedback, setClaudeKeyFeedback] = useState<Feedback>(null);
 
   const syncCodexSelection = useCallback((settings: ModelSettingsResponse) => {
     const persisted = settings.providers.codex.selectedModelIds;
     setSelectedCodexModelIds(persisted.length > 0 ? persisted : [...DEFAULT_CODEX_MODEL_SELECTIONS]);
+  }, []);
+
+  const syncClaudeSelection = useCallback((settings: ModelSettingsResponse) => {
+    const persisted = settings.providers.claude.selectedModelIds;
+    setSelectedClaudeModelIds(persisted.length > 0 ? persisted : [...DEFAULT_CLAUDE_MODEL_SELECTIONS]);
   }, []);
 
   const loadModelSettings = useCallback(async (): Promise<ModelSettingsResponse | null> => {
@@ -72,31 +93,50 @@ export function SettingsTab() {
       }
       setModelSettings(data);
       syncCodexSelection(data);
+      syncClaudeSelection(data);
       return data;
     } catch (error) {
-      setModelFeedback({
+      setCodexModelFeedback({
         ok: false,
         msg: error instanceof Error ? error.message : '모델 설정을 불러오지 못했습니다.',
       });
       return null;
     }
-  }, [syncCodexSelection]);
+  }, [syncCodexSelection, syncClaudeSelection]);
 
-  const loadOpenAiCatalog = useCallback(async () => {
-    setCatalogLoading(true);
-    setCatalogError(null);
+  const loadCodexCatalog = useCallback(async () => {
+    setCodexCatalogLoading(true);
+    setCodexCatalogError(null);
     try {
       const response = await fetch('/api/settings/models/catalog/openai');
       const data = await response.json().catch(() => null);
       if (!response.ok || !data) {
         throw new Error('모델 카탈로그를 불러오지 못했습니다.');
       }
-      setCatalogItems(Array.isArray(data.items) ? data.items : []);
+      setCodexCatalogItems(Array.isArray(data.items) ? data.items : []);
     } catch (error) {
-      setCatalogItems([]);
-      setCatalogError(error instanceof Error ? error.message : '모델 카탈로그를 불러오지 못했습니다.');
+      setCodexCatalogItems([]);
+      setCodexCatalogError(error instanceof Error ? error.message : '모델 카탈로그를 불러오지 못했습니다.');
     } finally {
-      setCatalogLoading(false);
+      setCodexCatalogLoading(false);
+    }
+  }, []);
+
+  const loadClaudeCatalog = useCallback(async () => {
+    setClaudeCatalogLoading(true);
+    setClaudeCatalogError(null);
+    try {
+      const response = await fetch('/api/settings/models/catalog/claude');
+      const data = await response.json().catch(() => null);
+      if (!response.ok || !data) {
+        throw new Error('Claude 모델 카탈로그를 불러오지 못했습니다.');
+      }
+      setClaudeCatalogItems(Array.isArray(data.items) ? data.items : []);
+    } catch (error) {
+      setClaudeCatalogItems([]);
+      setClaudeCatalogError(error instanceof Error ? error.message : 'Claude 모델 카탈로그를 불러오지 못했습니다.');
+    } finally {
+      setClaudeCatalogLoading(false);
     }
   }, []);
 
@@ -111,10 +151,13 @@ export function SettingsTab() {
 
     void loadModelSettings().then((settings) => {
       if (settings?.secrets.openAiApiKeyConfigured) {
-        void loadOpenAiCatalog();
+        void loadCodexCatalog();
+      }
+      if (settings?.secrets.claudeApiKeyConfigured) {
+        void loadClaudeCatalog();
       }
     });
-  }, [loadModelSettings, loadOpenAiCatalog]);
+  }, [loadModelSettings, loadCodexCatalog, loadClaudeCatalog]);
 
   const loadFile = useCallback((file: File) => {
     if (!file) {
@@ -174,13 +217,14 @@ export function SettingsTab() {
     }
   };
 
-  const handleSaveOpenAiKey = useCallback(async (apiKey: string) => {
+  // Codex 키 핸들러
+  const handleSaveCodexKey = useCallback(async (apiKey: string) => {
     if (apiKey.trim().length < 20) {
-      setKeyFeedback({ ok: false, msg: '유효한 OpenAI API 키를 입력해 주세요.' });
+      setCodexKeyFeedback({ ok: false, msg: '유효한 OpenAI API 키를 입력해 주세요.' });
       return;
     }
-    setKeySaving(true);
-    setKeyFeedback(null);
+    setCodexKeySaving(true);
+    setCodexKeyFeedback(null);
     try {
       const response = await fetch('/api/settings/openai-key', {
         method: 'POST',
@@ -191,82 +235,123 @@ export function SettingsTab() {
       if (!response.ok) {
         throw new Error(typeof data.error === 'string' ? data.error : 'OpenAI API 키 저장에 실패했습니다.');
       }
-      setKeyFeedback({ ok: true, msg: 'OpenAI API 키가 저장되었습니다.' });
+      setCodexKeyFeedback({ ok: true, msg: 'OpenAI API 키가 저장되었습니다.' });
       const settings = await loadModelSettings();
       if (settings?.secrets.openAiApiKeyConfigured) {
-        await loadOpenAiCatalog();
+        await loadCodexCatalog();
       }
     } catch (error) {
-      setKeyFeedback({ ok: false, msg: error instanceof Error ? error.message : 'OpenAI API 키 저장에 실패했습니다.' });
+      setCodexKeyFeedback({ ok: false, msg: error instanceof Error ? error.message : 'OpenAI API 키 저장에 실패했습니다.' });
     } finally {
-      setKeySaving(false);
+      setCodexKeySaving(false);
     }
-  }, [loadModelSettings, loadOpenAiCatalog]);
+  }, [loadModelSettings, loadCodexCatalog]);
 
-  const handleDeleteOpenAiKey = useCallback(async () => {
-    setKeyDeleting(true);
-    setKeyFeedback(null);
+  const handleDeleteCodexKey = useCallback(async () => {
+    setCodexKeyDeleting(true);
+    setCodexKeyFeedback(null);
     try {
-      const response = await fetch('/api/settings/openai-key', {
-        method: 'DELETE',
-      });
+      const response = await fetch('/api/settings/openai-key', { method: 'DELETE' });
       const data = await response.json().catch(() => ({}));
       if (!response.ok) {
         throw new Error(typeof data.error === 'string' ? data.error : 'OpenAI API 키 제거에 실패했습니다.');
       }
-      setCatalogItems([]);
-      setCatalogError(null);
-      setKeyFeedback({ ok: true, msg: '등록된 OpenAI API 키를 제거했습니다.' });
+      setCodexCatalogItems([]);
+      setCodexCatalogError(null);
+      setCodexKeyFeedback({ ok: true, msg: '등록된 OpenAI API 키를 제거했습니다.' });
       await loadModelSettings();
     } catch (error) {
-      setKeyFeedback({ ok: false, msg: error instanceof Error ? error.message : 'OpenAI API 키 제거에 실패했습니다.' });
+      setCodexKeyFeedback({ ok: false, msg: error instanceof Error ? error.message : 'OpenAI API 키 제거에 실패했습니다.' });
     } finally {
-      setKeyDeleting(false);
+      setCodexKeyDeleting(false);
     }
   }, [loadModelSettings]);
 
+  // Claude 키 핸들러
+  const handleSaveClaudeKey = useCallback(async (apiKey: string) => {
+    if (apiKey.trim().length < 20) {
+      setClaudeKeyFeedback({ ok: false, msg: '유효한 Anthropic API 키를 입력해 주세요.' });
+      return;
+    }
+    setClaudeKeySaving(true);
+    setClaudeKeyFeedback(null);
+    try {
+      const response = await fetch('/api/settings/claude-key', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(typeof data.error === 'string' ? data.error : 'Anthropic API 키 저장에 실패했습니다.');
+      }
+      setClaudeKeyFeedback({ ok: true, msg: 'Anthropic API 키가 저장되었습니다.' });
+      const settings = await loadModelSettings();
+      if (settings?.secrets.claudeApiKeyConfigured) {
+        await loadClaudeCatalog();
+      }
+    } catch (error) {
+      setClaudeKeyFeedback({ ok: false, msg: error instanceof Error ? error.message : 'Anthropic API 키 저장에 실패했습니다.' });
+    } finally {
+      setClaudeKeySaving(false);
+    }
+  }, [loadModelSettings, loadClaudeCatalog]);
+
+  const handleDeleteClaudeKey = useCallback(async () => {
+    setClaudeKeyDeleting(true);
+    setClaudeKeyFeedback(null);
+    try {
+      const response = await fetch('/api/settings/claude-key', { method: 'DELETE' });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(typeof data.error === 'string' ? data.error : 'Anthropic API 키 제거에 실패했습니다.');
+      }
+      setClaudeCatalogItems([]);
+      setClaudeCatalogError(null);
+      setClaudeKeyFeedback({ ok: true, msg: '등록된 Anthropic API 키를 제거했습니다.' });
+      await loadModelSettings();
+    } catch (error) {
+      setClaudeKeyFeedback({ ok: false, msg: error instanceof Error ? error.message : 'Anthropic API 키 제거에 실패했습니다.' });
+    } finally {
+      setClaudeKeyDeleting(false);
+    }
+  }, [loadModelSettings]);
+
+  // Codex 모델 토글 / 권장 / 저장
   const handleToggleCodexModel = useCallback((modelId: string) => {
     setSelectedCodexModelIds((prev) => {
       if (prev.includes(modelId)) {
         return prev.filter((item) => item !== modelId);
       }
-
       const next = [...prev, modelId];
-      const order = new Map(catalogItems.map((item, index) => [item.id, index]));
+      const order = new Map(codexCatalogItems.map((item, index) => [item.id, index]));
       next.sort((left, right) => (order.get(left) ?? Number.MAX_SAFE_INTEGER) - (order.get(right) ?? Number.MAX_SAFE_INTEGER));
       return next;
     });
-  }, [catalogItems]);
+  }, [codexCatalogItems]);
 
   const handleApplyRecommendedCodexModels = useCallback(() => {
-    if (catalogItems.length === 0) {
+    if (codexCatalogItems.length === 0) {
       setSelectedCodexModelIds([...DEFAULT_CODEX_MODEL_SELECTIONS]);
       return;
     }
-    const available = new Set(catalogItems.map((item) => item.id));
+    const available = new Set(codexCatalogItems.map((item) => item.id));
     const recommended = DEFAULT_CODEX_MODEL_SELECTIONS.filter((modelId) => available.has(modelId));
     setSelectedCodexModelIds(recommended.length > 0 ? [...recommended] : [...DEFAULT_CODEX_MODEL_SELECTIONS]);
-  }, [catalogItems]);
+  }, [codexCatalogItems]);
 
-  const handleModelSave = useCallback(async () => {
+  const handleCodexModelSave = useCallback(async () => {
     if (selectedCodexModelIds.length === 0) {
-      setModelFeedback({ ok: false, msg: '최소 1개 이상의 Codex 모델을 선택해 주세요.' });
+      setCodexModelFeedback({ ok: false, msg: '최소 1개 이상의 Codex 모델을 선택해 주세요.' });
       return;
     }
-
-    setModelSaving(true);
-    setModelFeedback(null);
+    setCodexModelSaving(true);
+    setCodexModelFeedback(null);
     try {
       const response = await fetch('/api/settings/models', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          providers: {
-            codex: {
-              selectedModelIds: selectedCodexModelIds,
-            },
-          },
-        }),
+        body: JSON.stringify({ providers: { codex: { selectedModelIds: selectedCodexModelIds } } }),
       });
       const data = await response.json().catch(() => null);
       if (!response.ok || !data) {
@@ -274,16 +359,102 @@ export function SettingsTab() {
       }
       setModelSettings(data);
       syncCodexSelection(data);
-      setModelFeedback({ ok: true, msg: 'Codex 사용할 모델 목록이 저장되었습니다.' });
+      setCodexModelFeedback({ ok: true, msg: 'Codex 사용할 모델 목록이 저장되었습니다.' });
     } catch (error) {
-      setModelFeedback({ ok: false, msg: error instanceof Error ? error.message : 'Codex 모델 목록 저장에 실패했습니다.' });
+      setCodexModelFeedback({ ok: false, msg: error instanceof Error ? error.message : 'Codex 모델 목록 저장에 실패했습니다.' });
     } finally {
-      setModelSaving(false);
+      setCodexModelSaving(false);
     }
   }, [selectedCodexModelIds, syncCodexSelection]);
 
+  // Claude 모델 토글 / 권장 / 저장
+  const handleToggleClaudeModel = useCallback((modelId: string) => {
+    setSelectedClaudeModelIds((prev) => {
+      if (prev.includes(modelId)) {
+        return prev.filter((item) => item !== modelId);
+      }
+      const next = [...prev, modelId];
+      const order = new Map(claudeCatalogItems.map((item, index) => [item.id, index]));
+      next.sort((left, right) => (order.get(left) ?? Number.MAX_SAFE_INTEGER) - (order.get(right) ?? Number.MAX_SAFE_INTEGER));
+      return next;
+    });
+  }, [claudeCatalogItems]);
+
+  const handleApplyRecommendedClaudeModels = useCallback(() => {
+    if (claudeCatalogItems.length === 0) {
+      setSelectedClaudeModelIds([...DEFAULT_CLAUDE_MODEL_SELECTIONS]);
+      return;
+    }
+    const available = new Set(claudeCatalogItems.map((item) => item.id));
+    const recommended = DEFAULT_CLAUDE_MODEL_SELECTIONS.filter((modelId) => available.has(modelId));
+    setSelectedClaudeModelIds(recommended.length > 0 ? [...recommended] : [...DEFAULT_CLAUDE_MODEL_SELECTIONS]);
+  }, [claudeCatalogItems]);
+
+  const handleClaudeModelSave = useCallback(async () => {
+    if (selectedClaudeModelIds.length === 0) {
+      setClaudeModelFeedback({ ok: false, msg: '최소 1개 이상의 Claude 모델을 선택해 주세요.' });
+      return;
+    }
+    setClaudeModelSaving(true);
+    setClaudeModelFeedback(null);
+    try {
+      const response = await fetch('/api/settings/models', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ providers: { claude: { selectedModelIds: selectedClaudeModelIds } } }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok || !data) {
+        throw new Error('사용할 Claude 모델 목록을 저장하지 못했습니다.');
+      }
+      setModelSettings(data);
+      syncClaudeSelection(data);
+      setClaudeModelFeedback({ ok: true, msg: 'Claude 사용할 모델 목록이 저장되었습니다.' });
+    } catch (error) {
+      setClaudeModelFeedback({ ok: false, msg: error instanceof Error ? error.message : 'Claude 모델 목록 저장에 실패했습니다.' });
+    } finally {
+      setClaudeModelSaving(false);
+    }
+  }, [selectedClaudeModelIds, syncClaudeSelection]);
+
+  // 활성 provider에 따라 카드에 전달할 props 결정
+  const isCodex = activeProvider === 'codex';
+  const isClaude = activeProvider === 'claude';
+
+  const activeHasApiKey = isCodex
+    ? modelSettings.secrets.openAiApiKeyConfigured
+    : isClaude
+      ? modelSettings.secrets.claudeApiKeyConfigured
+      : false;
+
+  const activeKeyHasKey = isCodex
+    ? modelSettings.secrets.openAiApiKeyConfigured
+    : isClaude
+      ? modelSettings.secrets.claudeApiKeyConfigured
+      : false;
+
+  const activeKeySaving = isCodex ? codexKeySaving : isClaude ? claudeKeySaving : false;
+  const activeKeyDeleting = isCodex ? codexKeyDeleting : isClaude ? claudeKeyDeleting : false;
+  const activeKeyFeedback = isCodex ? codexKeyFeedback : isClaude ? claudeKeyFeedback : null;
+  const handleActiveKeySave = isCodex ? handleSaveCodexKey : isClaude ? handleSaveClaudeKey : async (_: string) => {};
+  const handleActiveKeyDelete = isCodex ? handleDeleteCodexKey : isClaude ? handleDeleteClaudeKey : async () => {};
+
+  const activeCatalogItems = isCodex ? codexCatalogItems : isClaude ? claudeCatalogItems : [];
+  const activeSelectedModelIds = isCodex ? selectedCodexModelIds : isClaude ? selectedClaudeModelIds : [];
+  const activeCatalogLoading = isCodex ? codexCatalogLoading : isClaude ? claudeCatalogLoading : false;
+  const activeModelSaving = isCodex ? codexModelSaving : isClaude ? claudeModelSaving : false;
+  const activeCatalogError = isCodex ? codexCatalogError : isClaude ? claudeCatalogError : null;
+  const activeModelFeedback = isCodex ? codexModelFeedback : isClaude ? claudeModelFeedback : null;
+  const handleActiveToggle = isCodex ? handleToggleCodexModel : isClaude ? handleToggleClaudeModel : (_: string) => {};
+  const handleActiveRefresh = isCodex ? loadCodexCatalog : isClaude ? loadClaudeCatalog : async () => {};
+  const handleActiveModelSave = isCodex ? handleCodexModelSave : isClaude ? handleClaudeModelSave : async () => {};
+  const handleActiveApplyRecommended = isCodex
+    ? handleApplyRecommendedCodexModels
+    : isClaude
+      ? handleApplyRecommendedClaudeModels
+      : () => {};
+
   const isFileLoaded = Boolean(sshPrivateKey && fileName);
-  const hasOpenAiApiKey = modelSettings.secrets.openAiApiKeyConfigured;
 
   return (
     <div className={`animate-in ${styles.settingsShell}`}>
@@ -294,7 +465,8 @@ export function SettingsTab() {
         </div>
         <h2 className={styles.heroTitle}>모델 카탈로그와 인프라 자격증명을 한 화면에서 관리</h2>
         <p className={styles.heroDescription}>
-          OpenAI 모델 선택은 동적 카탈로그 기반으로 관리하고, SSH 자격증명은 별도 보안 영역에서 유지합니다.
+          OpenAI(Codex)와 Anthropic(Claude) 모델 선택은 동적 카탈로그 기반으로 관리하고, SSH 자격증명은 별도 보안
+          영역에서 유지합니다.
         </p>
       </div>
 
@@ -303,29 +475,29 @@ export function SettingsTab() {
           providerOptions={PROVIDER_OPTIONS}
           activeProvider={activeProvider}
           onProviderChange={setActiveProvider}
-          hasKey={hasOpenAiApiKey}
-          saving={keySaving}
-          deleting={keyDeleting}
-          feedback={keyFeedback}
-          onSave={handleSaveOpenAiKey}
-          onDelete={handleDeleteOpenAiKey}
+          hasKey={activeKeyHasKey}
+          saving={activeKeySaving}
+          deleting={activeKeyDeleting}
+          feedback={activeKeyFeedback}
+          onSave={handleActiveKeySave}
+          onDelete={handleActiveKeyDelete}
         />
 
         <CodexModelCatalogCard
           providerOptions={PROVIDER_OPTIONS}
           activeProvider={activeProvider}
           onProviderChange={setActiveProvider}
-          hasApiKey={hasOpenAiApiKey}
-          items={catalogItems}
-          selectedModelIds={selectedCodexModelIds}
-          loading={catalogLoading}
-          saving={modelSaving}
-          error={catalogError}
-          feedback={modelFeedback}
-          onToggle={handleToggleCodexModel}
-          onRefresh={loadOpenAiCatalog}
-          onSave={handleModelSave}
-          onApplyRecommended={handleApplyRecommendedCodexModels}
+          hasApiKey={activeHasApiKey}
+          items={activeCatalogItems}
+          selectedModelIds={activeSelectedModelIds}
+          loading={activeCatalogLoading}
+          saving={activeModelSaving}
+          error={activeCatalogError}
+          feedback={activeModelFeedback}
+          onToggle={handleActiveToggle}
+          onRefresh={handleActiveRefresh}
+          onSave={handleActiveModelSave}
+          onApplyRecommended={handleActiveApplyRecommended}
         />
 
         <div className={styles.section}>

--- a/services/aris-web/app/api/settings/claude-key/route.ts
+++ b/services/aris-web/app/api/settings/claude-key/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireOperatorApiUser } from '@/lib/auth/guard';
+import { prisma } from '@/lib/db/prisma';
+import { encryptScopedSetting } from '@/lib/crypto/settings';
+
+const CLAUDE_KEY_SALT = 'aris-claude-settings-v1';
+
+const saveSchema = z.object({
+  apiKey: z.string().trim().min(20).max(300),
+});
+
+export async function GET(request: NextRequest) {
+  const auth = await requireOperatorApiUser(request);
+  if ('response' in auth) {
+    return auth.response;
+  }
+
+  const preference = await prisma.uiPreference.findUnique({
+    where: { userId: auth.user.id },
+    select: { claudeApiKeyEncrypted: true },
+  });
+
+  return NextResponse.json({
+    hasKey: Boolean(preference?.claudeApiKeyEncrypted),
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireOperatorApiUser(request);
+  if ('response' in auth) {
+    return auth.response;
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = saveSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: '입력값이 올바르지 않습니다.' }, { status: 400 });
+  }
+
+  await prisma.uiPreference.upsert({
+    where: { userId: auth.user.id },
+    update: {
+      claudeApiKeyEncrypted: encryptScopedSetting(parsed.data.apiKey, CLAUDE_KEY_SALT),
+    },
+    create: {
+      userId: auth.user.id,
+      claudeApiKeyEncrypted: encryptScopedSetting(parsed.data.apiKey, CLAUDE_KEY_SALT),
+    },
+  });
+
+  return NextResponse.json({ ok: true, hasKey: true });
+}
+
+export async function DELETE(request: NextRequest) {
+  const auth = await requireOperatorApiUser(request);
+  if ('response' in auth) {
+    return auth.response;
+  }
+
+  await prisma.uiPreference.upsert({
+    where: { userId: auth.user.id },
+    update: { claudeApiKeyEncrypted: null },
+    create: { userId: auth.user.id, claudeApiKeyEncrypted: null },
+  });
+
+  return NextResponse.json({ ok: true, hasKey: false });
+}

--- a/services/aris-web/app/api/settings/models/catalog/claude/route.ts
+++ b/services/aris-web/app/api/settings/models/catalog/claude/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOperatorApiUser } from '@/lib/auth/guard';
+import { prisma } from '@/lib/db/prisma';
+import { decryptScopedSetting } from '@/lib/crypto/settings';
+import {
+  deriveClaudeModelFamily,
+  deriveClaudeModelLabel,
+  deriveClaudeModelTags,
+  isClaudeModelId,
+  type ClaudeCatalogItem,
+} from '@/lib/settings/providerModels';
+
+const CLAUDE_KEY_SALT = 'aris-claude-settings-v1';
+
+type AnthropicModelApiItem = {
+  id?: unknown;
+  display_name?: unknown;
+  created_at?: unknown;
+  type?: unknown;
+};
+
+export async function GET(request: NextRequest) {
+  const auth = await requireOperatorApiUser(request);
+  if ('response' in auth) {
+    return auth.response;
+  }
+
+  const preference = await prisma.uiPreference.findUnique({
+    where: { userId: auth.user.id },
+    select: { claudeApiKeyEncrypted: true },
+  });
+
+  if (!preference?.claudeApiKeyEncrypted) {
+    return NextResponse.json({ error: 'CLAUDE_API_KEY_NOT_CONFIGURED' }, { status: 400 });
+  }
+
+  let apiKey = '';
+  try {
+    apiKey = decryptScopedSetting(preference.claudeApiKeyEncrypted, CLAUDE_KEY_SALT);
+  } catch (error) {
+    console.error('Failed to decrypt Claude API key:', error);
+    return NextResponse.json({ error: 'CLAUDE_API_KEY_DECRYPT_FAILED' }, { status: 500 });
+  }
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/models', {
+      method: 'GET',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      const message = typeof body?.error?.message === 'string'
+        ? body.error.message
+        : 'Claude 모델 목록을 불러오지 못했습니다.';
+      return NextResponse.json({ error: message }, { status: response.status });
+    }
+
+    const payload = await response.json().catch(() => ({ data: [] }));
+    const rawItems = Array.isArray(payload?.data) ? payload.data as AnthropicModelApiItem[] : [];
+
+    const items: ClaudeCatalogItem[] = rawItems
+      .map((item) => {
+        const id = typeof item.id === 'string' ? item.id.trim() : '';
+        const displayName = typeof item.display_name === 'string' ? item.display_name : undefined;
+        const createdAt = typeof item.created_at === 'string' ? item.created_at : null;
+        const created = createdAt ? Math.floor(new Date(createdAt).getTime() / 1000) : 0;
+
+        if (!isClaudeModelId(id)) {
+          return null;
+        }
+
+        return {
+          id,
+          family: deriveClaudeModelFamily(id),
+          label: deriveClaudeModelLabel(id, displayName),
+          created,
+          createdAt,
+          tags: deriveClaudeModelTags(id),
+        } satisfies ClaudeCatalogItem;
+      })
+      .filter((item): item is ClaudeCatalogItem => Boolean(item))
+      .sort((a, b) => {
+        if (b.created !== a.created) {
+          return b.created - a.created;
+        }
+        return a.id.localeCompare(b.id);
+      });
+
+    return NextResponse.json({ items, fetchedAt: new Date().toISOString() });
+  } catch (error) {
+    console.error('Failed to load Claude catalog:', error);
+    return NextResponse.json({ error: 'Claude 모델 목록 요청에 실패했습니다.' }, { status: 502 });
+  }
+}

--- a/services/aris-web/components/settings/CodexModelCatalogCard.tsx
+++ b/services/aris-web/components/settings/CodexModelCatalogCard.tsx
@@ -2,21 +2,29 @@
 
 import { useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { Bot, CheckCircle2, LoaderCircle, RefreshCw, Search, Sparkles, Stars } from 'lucide-react';
-import { DEFAULT_CODEX_MODEL_SELECTIONS, type OpenAiCatalogItem, type ProviderId } from '@/lib/settings/providerModels';
+import {
+  DEFAULT_CLAUDE_MODEL_SELECTIONS,
+  DEFAULT_CODEX_MODEL_SELECTIONS,
+  type ClaudeCatalogItem,
+  type OpenAiCatalogItem,
+  type ProviderId,
+} from '@/lib/settings/providerModels';
 import styles from './CodexModelCatalogCard.module.css';
 
 type Feedback = { ok: boolean; msg: string } | null;
+type CatalogItem = OpenAiCatalogItem | ClaudeCatalogItem;
 
 type ModelVersionGroup = {
   key: string;
   label: string;
-  items: OpenAiCatalogItem[];
+  items: CatalogItem[];
   latestCreated: number;
 };
 
-function deriveVersionGroup(item: OpenAiCatalogItem): { key: string; label: string } {
+function deriveVersionGroup(item: CatalogItem): { key: string; label: string } {
   const normalized = item.id.toLowerCase();
 
+  // OpenAI GPT models
   const dottedVersionMatch = normalized.match(/^gpt-(\d+\.\d+)/);
   if (dottedVersionMatch) {
     return {
@@ -45,13 +53,27 @@ function deriveVersionGroup(item: OpenAiCatalogItem): { key: string; label: stri
     return { key: 'chatgpt', label: 'ChatGPT' };
   }
 
+  // Claude models
+  if (normalized.includes('claude') && normalized.includes('opus')) {
+    return { key: 'claude-opus', label: 'Opus' };
+  }
+  if (normalized.includes('claude') && normalized.includes('sonnet')) {
+    return { key: 'claude-sonnet', label: 'Sonnet' };
+  }
+  if (normalized.includes('claude') && normalized.includes('haiku')) {
+    return { key: 'claude-haiku', label: 'Haiku' };
+  }
+  if (normalized.startsWith('claude')) {
+    return { key: 'claude', label: 'Claude' };
+  }
+
   return {
     key: item.family.toLowerCase().replace(/\s+/g, '-'),
     label: item.family,
   };
 }
 
-function buildVersionGroups(items: OpenAiCatalogItem[]): ModelVersionGroup[] {
+function buildVersionGroups(items: CatalogItem[]): ModelVersionGroup[] {
   const groups = new Map<string, ModelVersionGroup>();
 
   for (const item of items) {
@@ -98,7 +120,7 @@ export function CodexModelCatalogCard({
   activeProvider: ProviderId;
   onProviderChange: (provider: ProviderId) => void;
   hasApiKey: boolean;
-  items: OpenAiCatalogItem[];
+  items: CatalogItem[];
   selectedModelIds: string[];
   loading: boolean;
   saving: boolean;
@@ -112,6 +134,11 @@ export function CodexModelCatalogCard({
   const [query, setQuery] = useState('');
   const [selectedGroupKey, setSelectedGroupKey] = useState<string>('');
   const deferredQuery = useDeferredValue(query);
+
+  useEffect(() => {
+    setQuery('');
+    setSelectedGroupKey('');
+  }, [activeProvider]);
 
   const filteredItems = useMemo(() => {
     const normalizedQuery = deferredQuery.trim().toLowerCase();
@@ -145,12 +172,22 @@ export function CodexModelCatalogCard({
 
   const selectedCount = selectedModelIds.length;
   const isCodex = activeProvider === 'codex';
+  const isClaude = activeProvider === 'claude';
+  const isActiveProvider = isCodex || isClaude;
   const providerTitle = activeProvider === 'claude' ? 'Claude' : activeProvider === 'gemini' ? 'Gemini' : 'Codex';
   const themeClass = activeProvider === 'claude'
     ? styles.themeClaude
     : activeProvider === 'gemini'
       ? styles.themeGemini
       : styles.themeCodex;
+
+  const defaultSelectionsCount = isCodex
+    ? DEFAULT_CODEX_MODEL_SELECTIONS.length
+    : DEFAULT_CLAUDE_MODEL_SELECTIONS.length;
+
+  const noApiKeyMessage = isCodex
+    ? '키가 등록되면 `/v1/models` 기준으로 Codex용 텍스트 모델 카탈로그를 불러와 버전 그룹 기반 선택 UI로 표시합니다.'
+    : '키가 등록되면 Anthropic `/v1/models` 기준으로 Claude 모델 카탈로그를 불러와 표시합니다.';
 
   return (
     <section className={`${styles.card} ${themeClass}`}>
@@ -163,8 +200,8 @@ export function CodexModelCatalogCard({
             </div>
             <h3 className={styles.title}>사용할 모델 목록</h3>
             <p className={styles.description}>
-              {isCodex
-                ? 'OpenAI 계정에서 실제 조회한 텍스트 생성 모델만 표시합니다. 버전 그룹을 먼저 고른 뒤 실제 모델을 선택하는 2단계 브라우저로 구성했습니다.'
+              {isActiveProvider
+                ? `${providerTitle} 계정에서 실제 조회한 모델만 표시합니다. 버전 그룹을 먼저 고른 뒤 실제 모델을 선택하는 2단계 브라우저로 구성했습니다.`
                 : `${providerTitle}용 모델 카탈로그 UI는 이 위치에 연결됩니다. 현재는 provider 전환 구조와 플레이스홀더만 준비된 상태입니다.`}
             </p>
           </div>
@@ -187,7 +224,7 @@ export function CodexModelCatalogCard({
           </div>
         </div>
 
-        {isCodex ? (
+        {isActiveProvider ? (
           <>
             <div className={styles.toolbar}>
               <input
@@ -196,7 +233,7 @@ export function CodexModelCatalogCard({
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder="모델 이름, 버전, 태그로 검색"
-                aria-label="OpenAI 모델 검색"
+                aria-label={`${providerTitle} 모델 검색`}
               />
               <div className={styles.toolbarActions}>
                 <button
@@ -240,7 +277,7 @@ export function CodexModelCatalogCard({
               </span>
               <span className={styles.statPill}>
                 <Stars size={14} />
-                기본 권장 {DEFAULT_CODEX_MODEL_SELECTIONS.length}개
+                기본 권장 {defaultSelectionsCount}개
               </span>
               {feedback ? (
                 <span className={`${styles.feedback} ${feedback.ok ? styles.feedbackOk : styles.feedbackErr}`}>
@@ -253,7 +290,7 @@ export function CodexModelCatalogCard({
       </div>
 
       <div className={styles.listWrap}>
-        {!isCodex ? (
+        {!isActiveProvider ? (
           <div className={styles.emptyState}>
             <div className={styles.emptyStateTitle}>{providerTitle} 모델 선택 UI 준비됨</div>
             <p className={styles.emptyStateText}>
@@ -263,11 +300,8 @@ export function CodexModelCatalogCard({
           </div>
         ) : !hasApiKey ? (
           <div className={styles.emptyState}>
-            <div className={styles.emptyStateTitle}>먼저 OpenAI API 키를 등록하세요</div>
-            <p className={styles.emptyStateText}>
-              키가 등록되면 `/v1/models` 기준으로 Codex용 텍스트 모델 카탈로그를 불러와 버전 그룹 기반 선택 UI로
-              표시합니다.
-            </p>
+            <div className={styles.emptyStateTitle}>먼저 {providerTitle} API 키를 등록하세요</div>
+            <p className={styles.emptyStateText}>{noApiKeyMessage}</p>
           </div>
         ) : loading ? (
           <div className={styles.skeletonGrid}>

--- a/services/aris-web/components/settings/OpenAiApiKeyCard.tsx
+++ b/services/aris-web/components/settings/OpenAiApiKeyCard.tsx
@@ -7,6 +7,18 @@ import styles from './OpenAiApiKeyCard.module.css';
 
 type Feedback = { ok: boolean; msg: string } | null;
 
+const PROVIDER_KEY_LABELS: Record<string, string> = {
+  codex: 'OpenAI API Key',
+  claude: 'Anthropic API Key',
+  gemini: 'Google API Key',
+};
+
+const PROVIDER_KEY_PLACEHOLDERS: Record<string, string> = {
+  codex: 'sk-...',
+  claude: 'sk-ant-...',
+  gemini: 'AIza...',
+};
+
 export function OpenAiApiKeyCard({
   providerOptions,
   activeProvider,
@@ -31,18 +43,33 @@ export function OpenAiApiKeyCard({
   const [apiKey, setApiKey] = useState('');
 
   useEffect(() => {
+    setApiKey('');
+  }, [activeProvider]);
+
+  useEffect(() => {
     if (feedback?.ok) {
       setApiKey('');
     }
   }, [feedback]);
 
   const isCodex = activeProvider === 'codex';
+  const isClaude = activeProvider === 'claude';
+  const isActiveProvider = isCodex || isClaude;
   const providerTitle = activeProvider === 'claude' ? 'Claude' : activeProvider === 'gemini' ? 'Gemini' : 'Codex';
   const themeClass = activeProvider === 'claude'
     ? styles.themeClaude
     : activeProvider === 'gemini'
       ? styles.themeGemini
       : styles.themeCodex;
+
+  const keyLabel = PROVIDER_KEY_LABELS[activeProvider] ?? 'API Key';
+  const keyPlaceholder = PROVIDER_KEY_PLACEHOLDERS[activeProvider] ?? '';
+
+  const runtimeLabel = isCodex
+    ? 'Codex 실행 인자에 미주입'
+    : isClaude
+      ? 'Claude 실행 인자에 미주입'
+      : '런타임 분리';
 
   return (
     <section className={`${styles.card} ${themeClass}`}>
@@ -55,11 +82,11 @@ export function OpenAiApiKeyCard({
             </div>
             <h3 className={styles.title}>Model Provider API Keys</h3>
             <p className={styles.description}>
-              공급자별 API 키를 분리 저장합니다. 현재는 Codex용 OpenAI 카탈로그 조회만 연결되어 있고, 키는 런타임
+              공급자별 API 키를 분리 저장합니다. 키는 AES-256-GCM으로 암호화되며 런타임
               에이전트 실행 경로에 주입하지 않습니다.
             </p>
           </div>
-          {isCodex ? (
+          {isActiveProvider ? (
             <div className={`${styles.statusPill} ${hasKey ? styles.statusActive : styles.statusInactive}`}>
               {hasKey ? '등록됨' : '미등록'}
             </div>
@@ -86,7 +113,7 @@ export function OpenAiApiKeyCard({
           })}
         </div>
 
-        {isCodex ? (
+        {isActiveProvider ? (
           <>
             <div className={styles.securityGrid}>
               <div className={styles.securityItem}>
@@ -99,7 +126,7 @@ export function OpenAiApiKeyCard({
               </div>
               <div className={styles.securityItem}>
                 <span className={styles.securityLabel}>런타임 분리</span>
-                <span className={styles.securityValue}>Codex 실행 인자에 미주입</span>
+                <span className={styles.securityValue}>{runtimeLabel}</span>
               </div>
             </div>
 
@@ -111,7 +138,7 @@ export function OpenAiApiKeyCard({
                 </div>
               ) : null}
               <div>
-                <label className={styles.label}>OpenAI API Key</label>
+                <label className={styles.label}>{keyLabel}</label>
                 <div className={styles.inputRow}>
                   <input
                     className={styles.input}
@@ -119,7 +146,7 @@ export function OpenAiApiKeyCard({
                     autoComplete="off"
                     value={apiKey}
                     onChange={(event) => setApiKey(event.target.value)}
-                    placeholder={hasKey ? '새 키를 입력하면 교체됩니다' : 'sk-...'}
+                    placeholder={hasKey ? '새 키를 입력하면 교체됩니다' : keyPlaceholder}
                   />
                 </div>
               </div>
@@ -156,8 +183,8 @@ export function OpenAiApiKeyCard({
             <div className={styles.placeholderEyebrow}>{providerTitle} Placeholder</div>
             <div className={styles.placeholderTitle}>{providerTitle} API 키 설정은 다음 단계에서 연결됩니다</div>
             <p className={styles.placeholderText}>
-              공급자별 저장 구조는 동일하게 유지하되, 현재 배포에서는 Codex(OpenAI)만 실제 카탈로그 조회와 연결되어
-              있습니다. 이 영역은 이후 Claude, Gemini 키 관리 UI로 확장될 자리입니다.
+              공급자별 저장 구조는 동일하게 유지하되, 현재 배포에서는 Codex(OpenAI)와 Claude(Anthropic)만
+              실제 카탈로그 조회와 연결되어 있습니다.
             </p>
           </div>
         )}

--- a/services/aris-web/lib/settings/providerModels.ts
+++ b/services/aris-web/lib/settings/providerModels.ts
@@ -15,11 +15,21 @@ export type OpenAiCatalogItem = {
   tags: string[];
 };
 
+export type ClaudeCatalogItem = {
+  id: string;
+  family: string;
+  label: string;
+  created: number;
+  createdAt: string | null;
+  tags: string[];
+};
+
 export type ModelSettingsResponse = {
   providers: ProviderModelSelections;
   legacyCustomModels: Record<ProviderId, string>;
   secrets: {
     openAiApiKeyConfigured: boolean;
+    claudeApiKeyConfigured: boolean;
   };
 };
 
@@ -28,6 +38,12 @@ export const DEFAULT_CODEX_MODEL_SELECTIONS = [
   'gpt-5.3-codex',
   'gpt-5',
   'gpt-5-mini',
+] as const;
+
+export const DEFAULT_CLAUDE_MODEL_SELECTIONS = [
+  'claude-opus-4-6',
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5-20251001',
 ] as const;
 
 const PROVIDERS: ProviderId[] = ['codex', 'claude', 'gemini'];
@@ -186,6 +202,52 @@ export function deriveOpenAiModelTags(modelId: string): string[] {
   }
   if (normalized.includes('pro')) {
     tags.push('Pro');
+  }
+  return tags;
+}
+
+export function isClaudeModelId(modelId: string): boolean {
+  const normalized = modelId.trim().toLowerCase();
+  return normalized.startsWith('claude-');
+}
+
+export function deriveClaudeModelFamily(modelId: string): string {
+  const normalized = modelId.toLowerCase();
+  if (normalized.includes('opus')) {
+    return 'Claude Opus';
+  }
+  if (normalized.includes('sonnet')) {
+    return 'Claude Sonnet';
+  }
+  if (normalized.includes('haiku')) {
+    return 'Claude Haiku';
+  }
+  return 'Claude';
+}
+
+export function deriveClaudeModelLabel(modelId: string, displayName?: string): string {
+  if (displayName) {
+    return displayName;
+  }
+  return modelId
+    .replace(/^claude-/, 'Claude ')
+    .replace(/-/g, ' ');
+}
+
+export function deriveClaudeModelTags(modelId: string): string[] {
+  const tags: string[] = [];
+  const normalized = modelId.toLowerCase();
+  if (normalized.includes('opus')) {
+    tags.push('Opus');
+  }
+  if (normalized.includes('sonnet')) {
+    tags.push('Sonnet');
+  }
+  if (normalized.includes('haiku')) {
+    tags.push('Haiku');
+  }
+  if (/\d{8}/.test(normalized)) {
+    tags.push('Snapshot');
   }
   return tags;
 }

--- a/services/aris-web/lib/settings/providerPreferences.ts
+++ b/services/aris-web/lib/settings/providerPreferences.ts
@@ -47,6 +47,7 @@ export async function getUserModelSettings(userId: string): Promise<ModelSetting
       customAiModels: true,
       providerModelSelections: true,
       openAiApiKeyEncrypted: true,
+      claudeApiKeyEncrypted: true,
     },
   });
 
@@ -58,6 +59,7 @@ export async function getUserModelSettings(userId: string): Promise<ModelSetting
     legacyCustomModels,
     secrets: {
       openAiApiKeyConfigured: Boolean(preference?.openAiApiKeyEncrypted),
+      claudeApiKeyConfigured: Boolean(preference?.claudeApiKeyEncrypted),
     },
   };
 }

--- a/services/aris-web/prisma/migrations/20260313000000_add_claude_api_key/migration.sql
+++ b/services/aris-web/prisma/migrations/20260313000000_add_claude_api_key/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UiPreference" ADD COLUMN "claudeApiKeyEncrypted" TEXT;

--- a/services/aris-web/prisma/schema.prisma
+++ b/services/aris-web/prisma/schema.prisma
@@ -144,6 +144,7 @@ model UiPreference {
   customAiModels Json?
   providerModelSelections Json?
   openAiApiKeyEncrypted String?
+  claudeApiKeyEncrypted String?
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
   user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Summary

- **Claude API 키 등록/삭제**: Anthropic API 키를 AES-256-GCM으로 암호화하여 DB 저장 (`/api/settings/claude-key` 신규 라우트)
- **Claude 모델 카탈로그**: Anthropic `/v1/models` API를 호출하여 실제 사용 가능한 모델 목록을 조회 (`/api/settings/models/catalog/claude` 신규 라우트)
- **UI 연결**: 설정 탭의 Claude 탭이 Placeholder에서 실제 키 입력 폼 + 모델 선택 카탈로그로 전환됨
- **DB 마이그레이션**: `UiPreference` 테이블에 `claudeApiKeyEncrypted` 컬럼 추가

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `prisma/schema.prisma` | `claudeApiKeyEncrypted String?` 필드 추가 |
| `prisma/migrations/20260313000000_add_claude_api_key/` | 마이그레이션 SQL |
| `lib/settings/providerModels.ts` | `ClaudeCatalogItem` 타입, Claude 헬퍼 함수, `DEFAULT_CLAUDE_MODEL_SELECTIONS`, `secrets.claudeApiKeyConfigured` 추가 |
| `lib/settings/providerPreferences.ts` | `claudeApiKeyConfigured` 반환 |
| `app/api/settings/claude-key/route.ts` | 신규 - Claude 키 CRUD |
| `app/api/settings/models/catalog/claude/route.ts` | 신규 - Anthropic 모델 카탈로그 조회 |
| `components/settings/OpenAiApiKeyCard.tsx` | Claude 탭에 실제 폼 (Anthropic API 키 입력) |
| `components/settings/CodexModelCatalogCard.tsx` | Claude 모델 카탈로그 2단계 브라우저 지원 |
| `app/SettingsTab.tsx` | Claude 키/카탈로그 상태, 핸들러, 라우팅 전체 연결 |

## Test plan

- [ ] Claude 탭에서 `sk-ant-...` 형식의 Anthropic API 키 등록 가능 확인
- [ ] 키 등록 후 Claude 모델 카탈로그(Opus/Sonnet/Haiku 그룹)가 로드되는지 확인
- [ ] 모델 선택 후 저장하면 DB에 반영되는지 확인
- [ ] 키 삭제 시 카탈로그가 비워지는지 확인
- [ ] Codex 탭의 기존 동작이 영향받지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)