### PR TITLE
perf(messages): add after_id cursor to replace backward seq scan

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -4612,15 +4612,34 @@ export class HappyRuntimeStore {
 
   async listMessages(
     sessionId: string,
-    options: { afterSeq?: number; limit?: number } = {},
+    options: { afterSeq?: number; afterId?: string; limit?: number } = {},
   ): Promise<RuntimeMessage[]> {
     const session = await this.getSession(sessionId);
     if (!session) {
       throw new Error('SESSION_NOT_FOUND');
     }
 
-    const hasPaginatedRequest = options.afterSeq !== undefined || options.limit !== undefined;
+    const hasPaginatedRequest = options.afterSeq !== undefined || options.afterId !== undefined || options.limit !== undefined;
     if (hasPaginatedRequest) {
+      // afterId path: single DB-level query — no backward scan needed
+      if (typeof options.afterId === 'string' && options.afterId) {
+        const normalizedLimit = Number.isFinite(options.limit)
+          ? Math.max(1, Math.min(HAPPY_MESSAGES_PAGE_MAX_LIMIT, Math.floor(Number(options.limit))))
+          : HAPPY_MESSAGES_BATCH_LIMIT;
+        const query = new URLSearchParams({
+          after_id: options.afterId,
+          limit: String(normalizedLimit),
+        });
+        const response = await this.request<HappyMessageResponse>(
+          `/v3/sessions/${encodeURIComponent(sessionId)}/messages?${query.toString()}`,
+        );
+        const batch = Array.isArray(response.messages) ? response.messages : [];
+        return batch
+          .filter((message) => typeof message.id === 'string')
+          .map((message) => toRuntimeMessage(sessionId, message))
+          .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+      }
+
       const normalizedAfterSeq = Number.isFinite(options.afterSeq)
         ? Math.max(0, Math.floor(Number(options.afterSeq)))
         : 0;

--- a/services/aris-backend/src/server.ts
+++ b/services/aris-backend/src/server.ts
@@ -345,7 +345,7 @@ export function buildServer(config: ServerConfig) {
   app.get('/v3/sessions/:sessionId/messages', async (request, reply) => {
     try {
       const { sessionId } = request.params as { sessionId: string };
-      const { after_seq, limit } = request.query as { after_seq?: string; limit?: string };
+      const { after_seq, after_id, limit } = request.query as { after_seq?: string; after_id?: string; limit?: string };
       const session = await store.getSession(sessionId);
       if (!session) {
         return reply.code(404).send({ error: 'Session not found' });
@@ -356,13 +356,14 @@ export function buildServer(config: ServerConfig) {
       const afterSeq = Number.isFinite(parsedAfterSeq) && parsedAfterSeq >= 0
         ? parsedAfterSeq
         : undefined;
+      const afterId = typeof after_id === 'string' && after_id ? after_id : undefined;
       const pageLimit = Number.isFinite(parsedLimit) && parsedLimit > 0
         ? Math.min(1000, parsedLimit)
         : undefined;
 
       const readLimit = pageLimit ? pageLimit + 1 : undefined;
       const rawMessages = await store.listMessages(sessionId, {
-        ...(afterSeq !== undefined ? { afterSeq } : {}),
+        ...(afterId !== undefined ? { afterId } : afterSeq !== undefined ? { afterSeq } : {}),
         ...(readLimit !== undefined ? { limit: readLimit } : {}),
       });
       const hasMore = pageLimit ? rawMessages.length > pageLimit : undefined;

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -55,7 +55,7 @@ interface RuntimeStoreBackend {
   getSession(sessionId: string): Promise<RuntimeSession | null>;
   getGeminiSessionCapabilities?(sessionId: string): Promise<GeminiSessionCapabilities>;
   createSession(input: CreateSessionInput): Promise<RuntimeSession>;
-  listMessages(sessionId: string, options?: { afterSeq?: number; limit?: number }): Promise<RuntimeMessage[]>;
+  listMessages(sessionId: string, options?: { afterSeq?: number; afterId?: string; limit?: number }): Promise<RuntimeMessage[]>;
   listRealtimeEvents?(sessionId: string, options?: { afterCursor?: number; limit?: number; chatId?: string }): Promise<{ events: RuntimeMessage[]; cursor: number }>;
   appendMessage(sessionId: string, input: AppendMessageInput): Promise<RuntimeMessage>;
   applySessionAction(sessionId: string, action: SessionAction, chatId?: string): Promise<{ accepted: boolean; message: string; at: string }>;
@@ -132,7 +132,7 @@ class MockRuntimeStore implements RuntimeStoreBackend {
     return session;
   }
 
-  async listMessages(sessionId: string, options: { afterSeq?: number; limit?: number } = {}): Promise<RuntimeMessage[]> {
+  async listMessages(sessionId: string, options: { afterSeq?: number; afterId?: string; limit?: number } = {}): Promise<RuntimeMessage[]> {
     const base = this.messages.get(sessionId) ?? [];
     const sorted = [...base].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
     const withSeq = sorted.map((message, index) => ({
@@ -142,6 +142,17 @@ class MockRuntimeStore implements RuntimeStoreBackend {
         seq: index + 1,
       },
     }));
+
+    // afterId: find the index of that message and slice everything after it
+    if (typeof options.afterId === 'string' && options.afterId) {
+      const idx = withSeq.findIndex((m) => m.id === options.afterId);
+      const afterIdFiltered = idx >= 0 ? withSeq.slice(idx + 1) : withSeq;
+      const normalizedLimit = Number.isFinite(options.limit)
+        ? Math.max(1, Math.floor(Number(options.limit)))
+        : null;
+      return normalizedLimit === null ? afterIdFiltered : afterIdFiltered.slice(0, normalizedLimit);
+    }
+
     const normalizedAfterSeq = Number.isFinite(options.afterSeq)
       ? Math.max(0, Math.floor(Number(options.afterSeq)))
       : 0;
@@ -362,7 +373,7 @@ export class RuntimeStore {
     return this.delegate.createSession(input);
   }
 
-  async listMessages(sessionId: string, options?: { afterSeq?: number; limit?: number }) {
+  async listMessages(sessionId: string, options?: { afterSeq?: number; afterId?: string; limit?: number }) {
     return this.delegate.listMessages(sessionId, options);
   }
 

--- a/services/aris-web/lib/happy/client.ts
+++ b/services/aris-web/lib/happy/client.ts
@@ -306,14 +306,20 @@ async function fetchHappy(path: string, init?: RequestInit): Promise<unknown> {
 async function fetchSessionMessagesPage(
   sessionId: string,
   options: {
-    afterSeq: number;
+    afterSeq?: number;
+    afterId?: string;
     limit: number;
   },
 ): Promise<{ messages: unknown[]; hasMore: boolean; lastSeq: number }> {
-  const query = new URLSearchParams({
-    after_seq: String(Math.max(0, Math.floor(options.afterSeq))),
+  const params: Record<string, string> = {
     limit: String(clampHappyMessagesWindow(options.limit)),
-  });
+  };
+  if (typeof options.afterId === 'string' && options.afterId) {
+    params.after_id = options.afterId;
+  } else {
+    params.after_seq = String(Math.max(0, Math.floor(options.afterSeq ?? 0)));
+  }
+  const query = new URLSearchParams(params);
   const raw = await fetchHappy(`/v3/sessions/${encodeURIComponent(sessionId)}/messages?${query.toString()}`);
   const batch = extractArrayPayload(raw, 'messages');
   const response = asObject(raw);
@@ -436,6 +442,18 @@ async function listMessagesForAfterCursor(
   const recentWindow = clampHappyMessagesWindow(
     Math.min(1000, Math.max(RECENT_WINDOW_MIN, pageLimit * 10)),
   );
+
+  // Fast path: use after_id for a single DB-level query when the cursor is a UUID
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(options.after);
+  if (isUuid) {
+    const page = await fetchSessionMessagesPage(sessionId, {
+      afterId: options.after,
+      limit: recentWindow,
+    });
+    return page.messages.length > 0 ? page.messages : [];
+  }
+
+  // Fallback: seq-based backward scan (legacy cursors)
   const maxScans = 6;
   let cursor = latestSeq;
   let collected: unknown[] = [];


### PR DESCRIPTION
## Summary

- `GET /v3/sessions/:id/messages`에 `after_id` 쿼리 파라미터 추가
- SSE 폴링에서 UUID 커서일 때 **최대 6번**의 역방향 `after_seq` 페이지 스캔을 **단일 DB 쿼리**로 대체
- 백엔드 3곳(인터페이스, MockRuntimeStore, HappyRuntimeStore) + 프론트엔드 1곳 변경

## 동작 원리

| 이전 | 이후 |
|------|------|
| `listMessagesForAfterCursor`가 `after_seq`를 줄여가며 최대 6회 HTTP 호출 | cursor가 UUID면 `?after_id=<uuid>&limit=N` 1회 호출 |
| 응답마다 `lastSeq` 추적 필요 | seq 계산 불필요 |

레거시(seq 기반) 커서는 fallback 경로로 기존 동작 유지.

## Test plan

- [ ] CI 타입 체크 통과 확인
- [ ] 기존 `sessionEventsStreamRoute.test.ts` 등 테스트 통과 확인
- [ ] 실제 세션에서 SSE 폴링 시 백엔드 로그로 단일 쿼리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)