### PR TITLE
fix(gemini): remove redundant pending action write in onAction callback

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -4214,29 +4214,6 @@ export class HappyRuntimeStore {
             mode: selectedGeminiMode,
             signal: controller.signal,
             onAction: async (action, meta) => {
-              const callId = (action.callId ?? '').trim();
-              await this.appendAgentMessage(
-                session.id,
-                [
-                  action.command ? `$ ${action.command}` : '',
-                  action.path ? `path: ${action.path}` : '',
-                  action.output?.replace(/\n?0;\s*$/g, '').trim() ?? '',
-                ].filter(Boolean).join('\n').trim(),
-                {
-                  ...(scopedChatId ? { chatId: scopedChatId } : {}),
-                  requestedPath: session.metadata.path,
-                  actionType: action.actionType,
-                  normalizedActionKind: action.actionType,
-                  command: action.command,
-                  path: action.path,
-                  streamEvent: 'gemini_action_pending',
-                  agent: 'gemini',
-                  ...(selectedModel ? { model: selectedModel } : {}),
-                  ...(meta.threadId ? { threadId: meta.threadId } : {}),
-                  ...(callId ? { sessionCallId: callId } : {}),
-                },
-                { type: 'tool', title: action.title },
-              );
               await geminiMessageQueue?.enqueueToolAction({
                 action,
                 execCwd: nonCodexCwd,


### PR DESCRIPTION
## Summary

- `onAction` 콜백은 action이 **완료된 시점**에 호출되므로, pending 이벤트를 별도로 저장할 필요 없음
- 기존: `gemini_action_pending` → DB 저장 후 즉시 `agent_stream_action` → DB 저장 → collapse로 둘 다 제거되어 액션 카드가 아예 안 뜨는 문제
- 수정: `onAction`에서 `appendAgentMessage(gemini_action_pending)` 제거, `enqueueToolAction + flush()`만 유지 → `agent_stream_action`만 정상 저장

## Root Cause

```
// 이전 (문제)
onAction(완료 시점)
  → appendAgentMessage(gemini_action_pending)  // pending DB 저장
  → enqueueToolAction + flush()                // final DB 저장
  → 다음 폴링에서 둘 다 도착 → collapse → 둘 다 제거

// 수정 후
onAction(완료 시점)
  → enqueueToolAction + flush()  // final만 DB 저장 → 액션 카드 정상 표시
```

## Test plan

- [ ] Gemini 에이전트 실행 후 액션 카드(파일 읽기, 명령 실행 등) 실시간 표시 확인
- [ ] 여러 액션이 연속으로 실행될 때 순서대로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)