### PR TITLE
fix(gemini): persist action cards immediately as each action completes

### DIFF
--- a/services/aris-backend/src/runtime/providers/gemini/geminiAcpClient.ts
+++ b/services/aris-backend/src/runtime/providers/gemini/geminiAcpClient.ts
@@ -913,7 +913,7 @@ export async function runGeminiAcpTurn(input: GeminiAcpClientOptions): Promise<G
     return finalizedMessage;
   };
 
-  const handleUpdate = (payload: Record<string, unknown>) => {
+  const handleUpdate = async (payload: Record<string, unknown>) => {
     const params = asRecord(payload.params) ?? {};
     const update = asRecord(params.update) ?? {};
     const updateType = asString(update.sessionUpdate, '').trim();
@@ -991,7 +991,7 @@ export async function runGeminiAcpTurn(input: GeminiAcpClientOptions): Promise<G
           stopReason,
         }));
         if (input.onAction) {
-          emitChain = emitChain.then(() => input.onAction?.(action, { threadId: sessionId }));
+          await input.onAction(action, { threadId: sessionId });
           streamedActionCount += 1;
         } else {
           inferredActions.push(action);
@@ -1039,7 +1039,7 @@ export async function runGeminiAcpTurn(input: GeminiAcpClientOptions): Promise<G
     const hasId = Object.prototype.hasOwnProperty.call(payload, 'id');
 
     if (method === 'session/update') {
-      handleUpdate(payload);
+      emitChain = emitChain.then(() => handleUpdate(payload)).catch(() => undefined);
       return;
     }
 


### PR DESCRIPTION
## Summary

- Gemini 액션 카드가 실행 완료 후 한꺼번에 몰아서 표시되는 문제 수정
- 원인: `handleUpdate()`가 sync 함수여서 `onAction`이 `emitChain`에 쌓이다가 ACP 세션 완료 후 한꺼번에 실행됨
- 수정: `handleUpdate()`를 `async`로 변경, `onAction`을 직접 `await`해서 각 액션 완료 즉시 DB 저장

## Root Cause

```typescript
// 기존: 모든 onAction이 emitChain에 쌓임 → ACP 완료 후 한꺼번에 실행
emitChain = emitChain.then(() => input.onAction(action));
handleUpdate(payload);  // fire-and-forget

// 수정: 각 액션을 즉시 await → 실행 순서대로 DB 저장
await input.onAction(action);  // handleUpdate 내부
emitChain = emitChain.then(() => handleUpdate(payload));  // 순서 보장
```

## Test plan

- [ ] Gemini 에이전트 실행 중 파일 읽기/쓰기 액션이 실시간으로 표시되는지 확인
- [ ] 여러 액션이 순서대로 표시되는지 확인 (마지막에 몰아서 나오지 않는지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)