### PR TITLE
feat(gemini): stream all events via realtime path for instant display

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -4214,6 +4214,24 @@ export class HappyRuntimeStore {
             mode: selectedGeminiMode,
             signal: controller.signal,
             onAction: async (action, meta) => {
+              this.appendSessionRealtimeEvent(session.id, {
+                id: `gemini-action-pending:${action.callId ?? String(Date.now())}`,
+                sessionId: session.id,
+                type: 'tool',
+                title: action.title,
+                text: [action.command, action.path].filter(Boolean).join('\n'),
+                createdAt: new Date().toISOString(),
+                meta: {
+                  agent: 'gemini',
+                  chatId: scopedChatId,
+                  streamEvent: 'gemini_action_pending',
+                  sessionCallId: action.callId ?? '',
+                  actionType: action.actionType,
+                  command: action.command,
+                  path: action.path,
+                  threadId: meta.threadId,
+                },
+              });
               await geminiMessageQueue?.enqueueToolAction({
                 action,
                 execCwd: nonCodexCwd,
@@ -4269,6 +4287,25 @@ export class HappyRuntimeStore {
                 turnId: event.turnId,
                 itemId: event.itemId,
                 threadId: meta.threadId,
+              });
+              const isCommentaryText = event.phase === 'commentary';
+              this.appendSessionRealtimeEvent(session.id, {
+                id: `gemini-final-text:${meta.threadId ?? ''}:${event.turnId ?? ''}:${event.itemId ?? ''}:${event.phase ?? 'final'}`,
+                sessionId: session.id,
+                type: isCommentaryText ? 'tool' : 'message',
+                title: isCommentaryText ? 'Thinking' : 'Text Reply',
+                text: normalizedText,
+                createdAt: new Date().toISOString(),
+                meta: {
+                  agent: 'gemini',
+                  chatId: scopedChatId,
+                  streamEvent: isCommentaryText ? 'agent_commentary' : 'agent_message',
+                  messagePhase: event.phase ?? 'final',
+                  sessionTurnId: event.turnId ?? '',
+                  sessionItemId: event.itemId ?? '',
+                  threadId: meta.threadId,
+                  partial: false,
+                },
               });
               await geminiMessageQueue?.enqueueText({
                 output: normalizedText,

--- a/services/aris-web/app/api/runtime/sessions/[sessionId]/events/stream/route.ts
+++ b/services/aris-web/app/api/runtime/sessions/[sessionId]/events/stream/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { requireApiUser } from '@/lib/auth/guard';
-import { streamSessionEvents, HappyHttpError } from '@/lib/happy/client';
+import { streamSessionEvents, getSessionRealtimeEvents, HappyHttpError } from '@/lib/happy/client';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -33,6 +33,7 @@ export async function GET(
   let cursor = typeof after === 'string' && after.trim().length > 0 ? after.trim() : null;
   let initialLoadDone = cursor !== null;
   let latestSeqHint: number | undefined = undefined;
+  let realtimeCursor = 0;
 
   const encoder = new TextEncoder();
   let aborted = false;
@@ -63,6 +64,17 @@ export async function GET(
       void (async () => {
         while (!aborted) {
           try {
+            // realtime events 먼저 — DB polling보다 앞서 즉시 전달
+            try {
+              const rt = await getSessionRealtimeEvents({ sessionId, afterCursor: realtimeCursor, chatId });
+              realtimeCursor = rt.cursor;
+              for (const event of rt.events) {
+                writeEvent('event', { event });
+              }
+            } catch {
+              // realtime 실패 시 무시하고 DB polling 계속
+            }
+
             {
               const result = await streamSessionEvents(sessionId, {
                 after: initialLoadDone ? (cursor ?? undefined) : undefined,

--- a/services/aris-web/lib/hooks/useSessionEvents.ts
+++ b/services/aris-web/lib/hooks/useSessionEvents.ts
@@ -105,6 +105,7 @@ function isRealtimeOnlyEvent(event: UiEvent): boolean {
   return (
     streamEvent === 'agent_message_partial'
     || streamEvent === 'agent_commentary_partial'
+    || streamEvent === 'gemini_action_pending'
     || streamEvent === 'runtime_disconnected'
     || streamEvent === 'stream_error'
     || streamEvent === 'runtime_error'

--- a/services/aris-web/tests/sessionEventsStreamRoute.test.ts
+++ b/services/aris-web/tests/sessionEventsStreamRoute.test.ts
@@ -54,11 +54,13 @@ describe('session events stream route', () => {
   it('replays the initial event page when the stream starts without an after cursor', async () => {
     const initialEvent = buildEvent();
 
-    mocks.streamSessionEvents.mockResolvedValueOnce({
-      events: [initialEvent],
-      latestSeq: 42,
-    });
-    mocks.getSessionRealtimeEvents.mockRejectedValueOnce(new mocks.HappyHttpError(404, 'stream closed'));
+    // realtime events: 빈 결과 반환 (정상)
+    mocks.getSessionRealtimeEvents.mockResolvedValue({ events: [], cursor: 0 });
+
+    // DB events: 첫 번째 호출에서 이벤트 반환, 이후 404로 스트림 종료
+    mocks.streamSessionEvents
+      .mockResolvedValueOnce({ events: [initialEvent], latestSeq: 42 })
+      .mockRejectedValue(new mocks.HappyHttpError(404, 'session not found'));
 
     const response = await GET(
       new NextRequest('http://localhost/api/runtime/sessions/session-1/events/stream?chatId=chat-1'),
@@ -74,8 +76,42 @@ describe('session events stream route', () => {
       includeUnassigned: false,
       latestSeqHint: undefined,
     });
+    expect(mocks.getSessionRealtimeEvents).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      afterCursor: 0,
+      chatId: 'chat-1',
+    });
     expect(payload).toContain('event: event');
     expect(payload).toContain(`"id":"${initialEvent.id}"`);
-    expect(payload).toContain('"status":404');
+  });
+
+  it('delivers realtime events before DB events in each polling cycle', async () => {
+    const realtimeEvent = buildEvent({
+      id: 'rt-1',
+      meta: { streamEvent: 'gemini_action_pending', sessionCallId: 'call-1' },
+    });
+    const dbEvent = buildEvent({ id: 'db-1' });
+
+    mocks.getSessionRealtimeEvents
+      .mockResolvedValueOnce({ events: [realtimeEvent], cursor: 1 })
+      .mockResolvedValue({ events: [], cursor: 1 });
+
+    mocks.streamSessionEvents
+      .mockResolvedValueOnce({ events: [dbEvent], latestSeq: 10 })
+      .mockRejectedValue(new mocks.HappyHttpError(404, 'done'));
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/runtime/sessions/session-1/events/stream'),
+      { params: Promise.resolve({ sessionId: 'session-1' }) },
+    );
+
+    const payload = await response.text();
+
+    // realtime event가 DB event보다 먼저 payload에 등장해야 함
+    const rtPos = payload.indexOf('"id":"rt-1"');
+    const dbPos = payload.indexOf('"id":"db-1"');
+    expect(rtPos).toBeGreaterThanOrEqual(0);
+    expect(dbPos).toBeGreaterThanOrEqual(0);
+    expect(rtPos).toBeLessThan(dbPos);
   });
 });


### PR DESCRIPTION
## Summary

- **근본 원인 해결**: Gemini action card가 실행 완료 후 한꺼번에 늦게 표시되던 문제를 수정
- `onAction` 콜백에서 DB 저장 전에 `appendSessionRealtimeEvent(gemini_action_pending)`를 즉시 호출 → action card가 ACP 이벤트 수신 직후 채팅 화면에 표시됨
- `onText(partial=false)` 콜백에서도 동일하게 realtime에 먼저 추가 → commentary/text reply도 즉시 표시
- SSE route가 매 polling cycle마다 `getSessionRealtimeEvents()`를 먼저 호출 → realtime events가 DB events보다 먼저 클라이언트에 전달
- `isRealtimeOnlyEvent`에 `gemini_action_pending` 추가 → pending event ID가 DB polling cursor로 오용되지 않음
- DB 저장은 영속성(히스토리/재로드)을 위해 그대로 유지, realtime과 병렬 처리

## 데이터 흐름 (변경 후)

```
ACP 이벤트 도착
  ├─ MSG_CHUNK(partial) → appendGeminiRealtimePartial → SSE 즉시 (기존 유지)
  ├─ TOOL_START/END    → appendSessionRealtimeEvent(pending) → SSE 즉시 [신규]
  │                      + geminiMessageQueue → DB (영속성, 병렬)
  └─ MSG_CHUNK(final)  → appendSessionRealtimeEvent(final) → SSE 즉시 [신규]
                          + geminiMessageQueue → DB (영속성, 병렬)
```

## Test plan

- [x] `sessionEventsStreamRoute.test.ts` 2개 테스트 통과 (realtime 먼저 전달 검증 포함)
- [x] `tsc --noEmit` backend + web 타입 체크 통과
- [ ] Gemini 세션에서 파일 읽기 작업 실행 → action card가 즉시 표시되는지 확인
- [ ] 세션 새로고침 후 히스토리 정상 복원 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)