### PR TITLE
fix(logger): include agent name in log file name

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -1827,6 +1827,7 @@ export class HappyRuntimeStore {
     const channel = input.agent === 'codex' && CODEX_RUNTIME_MODE !== 'exec' ? 'app_server' : 'exec_cli';
     this.happyEventLogger.logParsed({
       sessionId: input.sessionId,
+      agent: input.agent,
       ...(input.chatId ? { chatId: input.chatId } : {}),
       ...(input.model ? { model: input.model } : {}),
       turnStatus: 'run_stale_cleanup',
@@ -2644,6 +2645,7 @@ export class HappyRuntimeStore {
     });
     this.happyEventLogger.logParsed({
       sessionId: session.id,
+      agent: 'codex',
       ...(chatId ? { chatId } : {}),
       model: selectedModel,
       turnStatus: 'run_started',
@@ -2703,6 +2705,7 @@ export class HappyRuntimeStore {
     ) => {
       this.happyEventLogger.logParsed({
         sessionId: session.id,
+        agent: 'codex',
         ...(chatId ? { chatId } : {}),
         model: selectedModel,
         channel: 'app_server',
@@ -3103,6 +3106,7 @@ export class HappyRuntimeStore {
         const errorMessage = asString(asRecord(turn?.error)?.message, '').trim() || undefined;
         this.happyEventLogger.logParsed({
           sessionId: session.id,
+          agent: 'codex',
           ...(chatId ? { chatId } : {}),
           model: selectedModel,
           turnStatus: status,
@@ -3129,6 +3133,7 @@ export class HappyRuntimeStore {
       const rawLine = line.trim();
       this.happyEventLogger.logRaw({
         sessionId: session.id,
+        agent: 'codex',
         ...(chatId ? { chatId } : {}),
         model: selectedModel,
         channel: 'app_server',
@@ -3138,6 +3143,7 @@ export class HappyRuntimeStore {
       if (!payload) {
         this.happyEventLogger.logParsed({
           sessionId: session.id,
+          agent: 'codex',
           ...(chatId ? { chatId } : {}),
           model: selectedModel,
           channel: 'app_server',
@@ -3148,6 +3154,7 @@ export class HappyRuntimeStore {
       }
       this.happyEventLogger.logParsed({
         sessionId: session.id,
+        agent: 'codex',
         ...(chatId ? { chatId } : {}),
         model: selectedModel,
         channel: 'app_server',
@@ -3307,6 +3314,7 @@ export class HappyRuntimeStore {
       activeTurnId = asString(asRecord(turnStarted.turn)?.id, '').trim();
       this.happyEventLogger.logParsed({
         sessionId: session.id,
+        agent: 'codex',
         ...(chatId ? { chatId } : {}),
         model: selectedModel,
         turnStatus: 'turn_started',
@@ -3405,6 +3413,7 @@ export class HappyRuntimeStore {
         }
         this.happyEventLogger.logParsed({
           sessionId: session.id,
+          agent: 'codex',
           ...(chatId ? { chatId } : {}),
           model: selectedModel,
           turnStatus: 'turn_incomplete',
@@ -3420,6 +3429,7 @@ export class HappyRuntimeStore {
       }
       this.happyEventLogger.logParsed({
         sessionId: session.id,
+        agent: 'codex',
         ...(chatId ? { chatId } : {}),
         model: selectedModel,
         turnStatus: runStatus,
@@ -3477,6 +3487,7 @@ export class HappyRuntimeStore {
     });
     this.happyEventLogger.logParsed({
       sessionId: session.id,
+      agent: 'codex',
       ...(chatId ? { chatId } : {}),
       model: selectedModel,
       turnStatus: 'run_started',
@@ -3507,6 +3518,7 @@ export class HappyRuntimeStore {
     ) => {
       this.happyEventLogger.logParsed({
         sessionId: session.id,
+        agent: 'codex',
         ...(chatId ? { chatId } : {}),
         model: selectedModel,
         channel: 'exec_cli',
@@ -3569,6 +3581,7 @@ export class HappyRuntimeStore {
       const rawLine = line.trim();
       this.happyEventLogger.logRaw({
         sessionId: session.id,
+        agent: 'codex',
         ...(chatId ? { chatId } : {}),
         model: selectedModel,
         channel: 'exec_cli',
@@ -3578,6 +3591,7 @@ export class HappyRuntimeStore {
       if (!payload) {
         this.happyEventLogger.logParsed({
           sessionId: session.id,
+          agent: 'codex',
           ...(chatId ? { chatId } : {}),
           model: selectedModel,
           channel: 'exec_cli',
@@ -3588,6 +3602,7 @@ export class HappyRuntimeStore {
       }
       this.happyEventLogger.logParsed({
         sessionId: session.id,
+        agent: 'codex',
         ...(chatId ? { chatId } : {}),
         model: selectedModel,
         channel: 'exec_cli',
@@ -3744,6 +3759,7 @@ export class HappyRuntimeStore {
     if (signal?.aborted) {
       this.happyEventLogger.logParsed({
         sessionId: session.id,
+        agent: 'codex',
         ...(chatId ? { chatId } : {}),
         model: selectedModel,
         turnStatus: 'aborted',
@@ -3766,6 +3782,7 @@ export class HappyRuntimeStore {
       const detail = stripAnsi(stderr).slice(0, 800) || `exit code ${result.code}`;
       this.happyEventLogger.logParsed({
         sessionId: session.id,
+        agent: 'codex',
         ...(chatId ? { chatId } : {}),
         model: selectedModel,
         turnStatus: 'failed',
@@ -3782,6 +3799,7 @@ export class HappyRuntimeStore {
 
     this.happyEventLogger.logParsed({
       sessionId: session.id,
+      agent: 'codex',
       ...(chatId ? { chatId } : {}),
       model: selectedModel,
       turnStatus: 'completed',
@@ -3892,6 +3910,7 @@ export class HappyRuntimeStore {
     if (modelSelection.source !== 'requested') {
       this.happyEventLogger.logParsed({
         sessionId: session.id,
+        agent: flavor,
         ...(scopedChatId ? { chatId: scopedChatId } : {}),
         model: selectedModel,
         ...(selectedGeminiMode ? { geminiMode: selectedGeminiMode } : {}),

--- a/services/aris-backend/src/runtime/happyEventLogger.ts
+++ b/services/aris-backend/src/runtime/happyEventLogger.ts
@@ -19,6 +19,7 @@ type LogStage = 'incoming_raw' | 'incoming_payload' | 'parsed_append' | 'run_sta
 
 export type HappyRawLogRecord = {
   sessionId: string;
+  agent?: string;
   chatId?: string;
   threadId?: string;
   model?: string;
@@ -29,6 +30,7 @@ export type HappyRawLogRecord = {
 
 export type HappyParsedLogRecord = {
   sessionId: string;
+  agent?: string;
   chatId?: string;
   threadId?: string;
   model?: string;
@@ -101,6 +103,7 @@ export class HappyEventLogger {
 
   private getConversationKey(record: unknown): string {
     const parsedRecord = record as {
+      agent?: unknown;
       chatId?: unknown;
       threadId?: unknown;
       payload?: unknown;
@@ -109,6 +112,12 @@ export class HappyEventLogger {
     const sessionId = this.normalizeLogId(
       typeof parsedRecord.sessionId === 'string'
         ? parsedRecord.sessionId
+        : undefined,
+    );
+
+    const agent = this.normalizeLogId(
+      typeof parsedRecord.agent === 'string'
+        ? parsedRecord.agent
         : undefined,
     );
 
@@ -123,10 +132,11 @@ export class HappyEventLogger {
         : this.extractThreadIdFromPayload(parsedRecord.payload),
     );
 
+    const safeAgent = agent || 'unknown';
     const safeChatId = chatId || 'no-chat';
     const safeThreadId = threadId || sessionId || 'no-thread';
 
-    return `${safeChatId}-${safeThreadId}`;
+    return `chat-${safeAgent}-${safeChatId}-${safeThreadId}`;
   }
 
   private extractThreadIdFromPayload(payload: unknown): string | undefined {


### PR DESCRIPTION
## Summary

- 로그 파일명이 `chat-{chatId}-{threadId}-parsed.ndjson`이어서 어떤 에이전트인지 알 수 없었던 문제 수정
- 변경 후: `chat-{agent}-{chatId}-{threadId}-parsed.ndjson`
- `HappyRawLogRecord`, `HappyParsedLogRecord`에 `agent?: string` 필드 추가
- 모든 `logParsed`/`logRaw` 호출부에 agent 값 전달:
  - `handleStaleRunCleanup`: `input.agent`
  - `runCodexAppServerWithEvents` / `runCodexExecCliWithEvents`: `'codex'`
  - `sendTurn` (model_normalized): `flavor` 변수

## Test plan

- [x] `tsc --noEmit` 타입 체크 통과
- [ ] 배포 후 `/home/ubuntu/project/ARIS/logs/2026/03/*/chat-gemini-*` 파일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)