### PR TITLE
모바일 새 채팅 초기화 버그 수정

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -74,6 +74,7 @@ import { CustomizationSidebar } from './CustomizationSidebar';
 import { PermissionRequestMessage } from './PermissionRequestMessage';
 import styles from './ChatInterface.module.css';
 import dynamic from 'next/dynamic';
+import { resolveActiveChat, resolveNextSelectedChatId } from './chatSelection';
 
 // SSR을 비활성화해 react-syntax-highlighter의 window 참조 오류 방지
 const SyntaxHighlighter = dynamic(
@@ -2159,33 +2160,33 @@ export function ChatInterface({
 
   const [chats, setChats] = useState<SessionChat[]>(() => sortSessionChats(initialChats));
   const [selectedChatId, setSelectedChatId] = useState<string | null>(activeChatId);
+  const [isNewChatPlaceholder, setIsNewChatPlaceholder] = useState(false);
   const activeChat = useMemo(
-    () => (selectedChatId ? chats.find((chat) => chat.id === selectedChatId) : null) ?? chats[0] ?? null,
-    [chats, selectedChatId],
+    () => resolveActiveChat(chats, selectedChatId, isNewChatPlaceholder),
+    [chats, isNewChatPlaceholder, selectedChatId],
   );
   const activeChatIdResolved = activeChat?.id ?? null;
   useEffect(() => {
-    if (selectedChatId && chats.some((chat) => chat.id === selectedChatId)) {
+    const nextSelectedChatId = resolveNextSelectedChatId({
+      chats,
+      selectedChatId,
+      requestedChatId: readChatIdFromLocation(),
+      isNewChatPlaceholder,
+    });
+    if (nextSelectedChatId === selectedChatId) {
       return;
     }
-    const requestedChatId = readChatIdFromLocation();
-    if (requestedChatId && chats.some((chat) => chat.id === requestedChatId)) {
-      setSelectedChatId(requestedChatId);
-      return;
-    }
-    const fallbackChatId = chats[0]?.id ?? null;
-    if (fallbackChatId !== selectedChatId) {
-      setSelectedChatId(fallbackChatId);
-    }
-  }, [chats, selectedChatId]);
+    setSelectedChatId(nextSelectedChatId);
+  }, [chats, isNewChatPlaceholder, selectedChatId]);
   useEffect(() => {
     const syncFromHistory = () => {
-      const requestedChatId = readChatIdFromLocation();
-      if (requestedChatId && chats.some((chat) => chat.id === requestedChatId)) {
-        setSelectedChatId(requestedChatId);
-        return;
-      }
-      setSelectedChatId(chats[0]?.id ?? null);
+      setIsNewChatPlaceholder(false);
+      setSelectedChatId(resolveNextSelectedChatId({
+        chats,
+        selectedChatId: null,
+        requestedChatId: readChatIdFromLocation(),
+        isNewChatPlaceholder: false,
+      }));
     };
     window.addEventListener('popstate', syncFromHistory);
     return () => {
@@ -2193,11 +2194,11 @@ export function ChatInterface({
     };
   }, [chats]);
   useEffect(() => {
-    if (!activeChatIdResolved) {
+    if (isNewChatPlaceholder || !activeChatIdResolved) {
       return;
     }
     writeChatIdToHistory(buildChatUrl(sessionId, activeChatIdResolved), 'replace');
-  }, [activeChatIdResolved, sessionId]);
+  }, [activeChatIdResolved, isNewChatPlaceholder, sessionId]);
   const includeUnassignedEvents = Boolean(activeChat?.isDefault);
   const { isLeader: isSessionSyncLeader } = useSessionSyncLeader(sessionId);
   const [chatRuntimeUiByChat, setChatRuntimeUiByChat] = useState<Record<string, ChatRuntimeUiState>>({});
@@ -2318,7 +2319,6 @@ export function ChatInterface({
     updateActiveChatRuntimeUi({ submitError: value });
   }, [updateActiveChatRuntimeUi]);
   const [isMobileLayout, setIsMobileLayout] = useState(false);
-  const [isNewChatPlaceholder, setIsNewChatPlaceholder] = useState(false);
   const [expandedResultIds, setExpandedResultIds] = useState<Record<string, boolean>>({});
   const [expandedActionRunIds, setExpandedActionRunIds] = useState<Record<string, boolean>>({});
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);

--- a/services/aris-web/app/sessions/[sessionId]/chatSelection.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chatSelection.ts
@@ -1,0 +1,37 @@
+import type { SessionChat } from '@/lib/happy/types';
+
+type ChatSelectionInput = {
+  chats: SessionChat[];
+  selectedChatId: string | null;
+  requestedChatId: string | null;
+  isNewChatPlaceholder: boolean;
+};
+
+export function resolveActiveChat(
+  chats: SessionChat[],
+  selectedChatId: string | null,
+  isNewChatPlaceholder: boolean,
+): SessionChat | null {
+  if (isNewChatPlaceholder) {
+    return null;
+  }
+  return (selectedChatId ? chats.find((chat) => chat.id === selectedChatId) : null) ?? chats[0] ?? null;
+}
+
+export function resolveNextSelectedChatId({
+  chats,
+  selectedChatId,
+  requestedChatId,
+  isNewChatPlaceholder,
+}: ChatSelectionInput): string | null {
+  if (isNewChatPlaceholder) {
+    return null;
+  }
+  if (selectedChatId && chats.some((chat) => chat.id === selectedChatId)) {
+    return selectedChatId;
+  }
+  if (requestedChatId && chats.some((chat) => chat.id === requestedChatId)) {
+    return requestedChatId;
+  }
+  return chats[0]?.id ?? null;
+}

--- a/services/aris-web/tests/chatSelection.test.ts
+++ b/services/aris-web/tests/chatSelection.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionChat } from '@/lib/happy/types';
+import { resolveActiveChat, resolveNextSelectedChatId } from '@/app/sessions/[sessionId]/chatSelection';
+
+function makeChat(id: string, overrides: Partial<SessionChat> = {}): SessionChat {
+  return {
+    id,
+    sessionId: 'session-1',
+    title: `채팅 ${id}`,
+    agent: 'codex',
+    model: 'gpt-5.4',
+    geminiMode: null,
+    modelReasoningEffort: null,
+    threadId: null,
+    isPinned: false,
+    createdAt: '2026-03-19T00:00:00.000Z',
+    updatedAt: '2026-03-19T00:00:00.000Z',
+    lastActivityAt: '2026-03-19T00:00:00.000Z',
+    isDefault: false,
+    ...overrides,
+  };
+}
+
+describe('chatSelection', () => {
+  it('returns no active chat while new chat placeholder is visible', () => {
+    const chats = [makeChat('chat-1'), makeChat('chat-2')];
+
+    expect(resolveActiveChat(chats, null, true)).toBeNull();
+    expect(resolveNextSelectedChatId({
+      chats,
+      selectedChatId: 'chat-1',
+      requestedChatId: 'chat-2',
+      isNewChatPlaceholder: true,
+    })).toBeNull();
+  });
+
+  it('keeps an existing selected chat when placeholder is not visible', () => {
+    const chats = [makeChat('chat-1'), makeChat('chat-2')];
+
+    expect(resolveActiveChat(chats, 'chat-2', false)?.id).toBe('chat-2');
+    expect(resolveNextSelectedChatId({
+      chats,
+      selectedChatId: 'chat-2',
+      requestedChatId: 'chat-1',
+      isNewChatPlaceholder: false,
+    })).toBe('chat-2');
+  });
+
+  it('falls back to the requested chat or first chat when needed', () => {
+    const chats = [makeChat('chat-1'), makeChat('chat-2')];
+
+    expect(resolveNextSelectedChatId({
+      chats,
+      selectedChatId: null,
+      requestedChatId: 'chat-2',
+      isNewChatPlaceholder: false,
+    })).toBe('chat-2');
+
+    expect(resolveNextSelectedChatId({
+      chats,
+      selectedChatId: null,
+      requestedChatId: 'missing',
+      isNewChatPlaceholder: false,
+    })).toBe('chat-1');
+  });
+});


### PR DESCRIPTION
## 변경 내용
- 새 채팅 placeholder 상태에서는 기존 채팅이 active chat로 다시 선택되지 않도록 수정
- 히스토리 동기화 시 placeholder를 해제하고 정상 chat 선택 로직을 재사용하도록 정리
- 선택 로직 회귀 테스트 추가

## 검증
- ./node_modules/.bin/vitest run tests/chatSelection.test.ts
- ./node_modules/.bin/tsc --noEmit