### PR TITLE
모바일 새 채팅 생성 직후 이전 내용 노출 버그 수정

### DIFF
--- a/services/aris-web/lib/hooks/useSessionEvents.ts
+++ b/services/aris-web/lib/hooks/useSessionEvents.ts
@@ -113,6 +113,14 @@ export function collapseRealtimeGeminiPartialEvents(events: UiEvent[]): UiEvent[
   });
 }
 
+export function getScopedSessionEvents(
+  events: UiEvent[],
+  eventsForChatId: string | null,
+  activeChatId: string | null,
+): UiEvent[] {
+  return eventsForChatId === activeChatId ? events : [];
+}
+
 function areEventsEqual(prev: UiEvent[], next: UiEvent[]): boolean {
   if (prev.length !== next.length) {
     return false;
@@ -212,6 +220,13 @@ export function useSessionEvents(
   useEffect(() => {
     hasMoreBeforeRef.current = hasMoreBefore;
   }, [hasMoreBefore]);
+
+  const scopedEvents = useMemo(
+    () => getScopedSessionEvents(events, eventsForChatId, chatId),
+    [chatId, events, eventsForChatId],
+  );
+  const scopedHasMoreBefore = eventsForChatId === chatId ? hasMoreBefore : false;
+  const scopedIsLoadingOlder = eventsForChatId === chatId ? isLoadingOlder : false;
 
   const refreshEvents = useCallback(async (force = false) => {
     if (!enabled && !force) {
@@ -652,8 +667,17 @@ export function useSessionEvents(
   }, [enabled, sessionId, chatId, includeUnassigned, refreshEvents]);
 
   const addEvent = (event: UiEvent) => {
+    setEventsForChatId(chatId);
     setEvents((prev) => mergeEvents([...prev, event]));
   };
 
-  return { events, eventsForChatId, addEvent, syncError, loadOlder, hasMoreBefore, isLoadingOlder };
+  return {
+    events: scopedEvents,
+    eventsForChatId,
+    addEvent,
+    syncError,
+    loadOlder,
+    hasMoreBefore: scopedHasMoreBefore,
+    isLoadingOlder: scopedIsLoadingOlder,
+  };
 }

--- a/services/aris-web/tests/sessionEventsScope.test.ts
+++ b/services/aris-web/tests/sessionEventsScope.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { UiEvent } from '@/lib/happy/types';
+import { getScopedSessionEvents } from '@/lib/hooks/useSessionEvents';
+
+function buildEvent(overrides: Partial<UiEvent> = {}): UiEvent {
+  return {
+    id: overrides.id ?? 'event-1',
+    timestamp: overrides.timestamp ?? '2026-03-19T09:00:00.000Z',
+    kind: overrides.kind ?? 'text_reply',
+    title: overrides.title ?? 'Text Reply',
+    body: overrides.body ?? 'hello',
+    ...(overrides.meta ? { meta: overrides.meta } : {}),
+  };
+}
+
+describe('getScopedSessionEvents', () => {
+  it('returns an empty list when the current events belong to a different chat', () => {
+    const staleEvents = [buildEvent({
+      id: 'event-stale-1',
+      body: '이전 채팅 내용',
+      meta: { chatId: 'chat-old' },
+    })];
+
+    expect(getScopedSessionEvents(staleEvents, 'chat-old', 'chat-new')).toEqual([]);
+  });
+
+  it('returns the original events when the active chat matches', () => {
+    const currentEvents = [buildEvent({
+      id: 'event-current-1',
+      body: '현재 채팅 내용',
+      meta: { chatId: 'chat-new' },
+    })];
+
+    expect(getScopedSessionEvents(currentEvents, 'chat-new', 'chat-new')).toEqual(currentEvents);
+  });
+});


### PR DESCRIPTION
## 변경 내용
- active chat과 다른 chat scope의 이벤트는 즉시 빈 배열로 가려서 stale 렌더를 차단
- optimistic event 추가 시 현재 chat scope를 함께 갱신
- 이벤트 스코프 회귀 테스트 추가

## 검증
- ./node_modules/.bin/vitest run tests/chatSelection.test.ts tests/sessionEventsScope.test.ts
- ./node_modules/.bin/tsc --noEmit