### PR TITLE
Prisma 런타임에서 로컬 executor로 에이전트 실행 연결

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -4935,6 +4935,41 @@ export class HappyRuntimeStore {
     return created;
   }
 
+  async triggerPersistedUserMessage(sessionId: string, input: HappyRuntimeAppendInput): Promise<void> {
+    if (input.meta?.role === 'agent') {
+      return;
+    }
+
+    const session = await this.getSession(sessionId);
+    if (!session) {
+      throw new Error('SESSION_NOT_FOUND');
+    }
+
+    const chatId = typeof input.meta?.chatId === 'string' && input.meta.chatId.trim().length > 0
+      ? input.meta.chatId.trim()
+      : undefined;
+    const threadId = typeof input.meta?.threadId === 'string' && input.meta.threadId.trim().length > 0
+      ? input.meta.threadId.trim()
+      : undefined;
+    const requestedAgent = normalizeAgent(input.meta?.agent);
+    const requestedModel = normalizeModel(input.meta?.model);
+    const requestedGeminiMode = normalizeGeminiMode(input.meta?.geminiMode);
+    const customModel = normalizeModel(input.meta?.customModel);
+    const modelReasoningEffort = normalizeModelReasoningEffort(
+      input.meta?.modelReasoningEffort ?? input.meta?.model_reasoning_effort,
+    );
+
+    void this.generateAndPersistAgentReply(session, input.text, {
+      chatId,
+      threadId,
+      ...(requestedAgent !== 'unknown' ? { agent: requestedAgent } : {}),
+      ...(requestedModel ? { model: requestedModel } : {}),
+      ...(requestedGeminiMode ? { geminiMode: requestedGeminiMode } : {}),
+      ...(customModel ? { customModel } : {}),
+      ...(modelReasoningEffort ? { modelReasoningEffort } : {}),
+    });
+  }
+
   async applySessionAction(sessionId: string, action: SessionAction, chatId?: string): Promise<{ accepted: boolean; message: string; at: string }> {
     const session = await this.getSession(sessionId);
     if (!session) {

--- a/services/aris-backend/src/server.ts
+++ b/services/aris-backend/src/server.ts
@@ -10,6 +10,8 @@ type RequestBucket = {
 };
 
 type ServerConfig = {
+  HOST: string;
+  PORT: number;
   RUNTIME_API_TOKEN: string;
   RUNTIME_BACKEND?: 'mock' | 'happy' | 'prisma';
   DATABASE_URL?: string;
@@ -104,6 +106,8 @@ export function buildServer(config: ServerConfig) {
     config.HAPPY_SERVER_TOKEN,
     config.HOST_PROJECTS_ROOT,
     config.DATABASE_URL,
+    `http://127.0.0.1:${config.PORT}`,
+    config.RUNTIME_API_TOKEN,
   );
   const rateLimitBuckets = new Map<string, RequestBucket>();
 

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -66,6 +66,18 @@ interface RuntimeStoreBackend {
   decidePermission(permissionId: string, decision: PermissionDecision): Promise<PermissionRequest>;
 }
 
+type RuntimeExecutor = Pick<
+  HappyRuntimeStore,
+  | 'triggerPersistedUserMessage'
+  | 'listRealtimeEvents'
+  | 'applySessionAction'
+  | 'isSessionRunning'
+  | 'listPermissions'
+  | 'createPermission'
+  | 'decidePermission'
+  | 'getGeminiSessionCapabilities'
+>;
+
 class MockRuntimeStore implements RuntimeStoreBackend {
   private readonly sessions = new Map<string, RuntimeSession>();
   private readonly messages = new Map<string, RuntimeMessage[]>();
@@ -331,6 +343,7 @@ class MockRuntimeStore implements RuntimeStoreBackend {
 
 export class RuntimeStore {
   private readonly delegate: RuntimeStoreBackend;
+  private readonly runtimeExecutor: RuntimeExecutor | null;
 
   constructor(
     defaultProjectPath: string,
@@ -339,12 +352,23 @@ export class RuntimeStore {
     happyServerToken?: string,
     hostProjectsRoot?: string,
     databaseUrl?: string,
+    runtimeApiUrl?: string,
+    runtimeApiToken?: string,
   ) {
     if (runtimeBackend === 'prisma') {
       if (!databaseUrl) {
         throw new Error('DATABASE_URL is required when RUNTIME_BACKEND=prisma');
       }
       this.delegate = new PrismaRuntimeStore(databaseUrl);
+      const internalRuntimeUrl = typeof runtimeApiUrl === 'string' && runtimeApiUrl.trim().length > 0
+        ? runtimeApiUrl.trim()
+        : 'http://127.0.0.1:4080';
+      this.runtimeExecutor = new HappyRuntimeStore({
+        serverUrl: internalRuntimeUrl,
+        token: runtimeApiToken ?? '',
+        workspaceRoot: defaultProjectPath,
+        hostProjectsRoot: hostProjectsRoot ?? '',
+      });
       return;
     }
 
@@ -358,10 +382,12 @@ export class RuntimeStore {
         workspaceRoot: defaultProjectPath,
         hostProjectsRoot: hostProjectsRoot ?? '',
       });
+      this.runtimeExecutor = null;
       return;
     }
 
     this.delegate = new MockRuntimeStore(defaultProjectPath);
+    this.runtimeExecutor = null;
   }
 
   async listSessions() {
@@ -373,6 +399,9 @@ export class RuntimeStore {
   }
 
   async getGeminiSessionCapabilities(sessionId: string) {
+    if (this.runtimeExecutor) {
+      return this.runtimeExecutor.getGeminiSessionCapabilities(sessionId);
+    }
     if ('getGeminiSessionCapabilities' in this.delegate && typeof this.delegate.getGeminiSessionCapabilities === 'function') {
       return this.delegate.getGeminiSessionCapabilities(sessionId);
     }
@@ -388,10 +417,17 @@ export class RuntimeStore {
   }
 
   async appendMessage(sessionId: string, input: AppendMessageInput) {
-    return this.delegate.appendMessage(sessionId, input);
+    const created = await this.delegate.appendMessage(sessionId, input);
+    if (this.runtimeExecutor && input.meta?.role !== 'agent') {
+      await this.runtimeExecutor.triggerPersistedUserMessage(sessionId, input);
+    }
+    return created;
   }
 
   async listRealtimeEvents(sessionId: string, options?: { afterCursor?: number; limit?: number; chatId?: string }) {
+    if (this.runtimeExecutor) {
+      return this.runtimeExecutor.listRealtimeEvents(sessionId, options);
+    }
     if ('listRealtimeEvents' in this.delegate && typeof this.delegate.listRealtimeEvents === 'function') {
       return this.delegate.listRealtimeEvents(sessionId, options);
     }
@@ -399,22 +435,42 @@ export class RuntimeStore {
   }
 
   async applySessionAction(sessionId: string, action: SessionAction, chatId?: string) {
+    if (this.runtimeExecutor) {
+      if (action === 'kill') {
+        await this.runtimeExecutor.applySessionAction(sessionId, 'abort');
+        return this.delegate.applySessionAction(sessionId, action, chatId);
+      }
+      await this.runtimeExecutor.applySessionAction(sessionId, action, chatId);
+      return this.delegate.applySessionAction(sessionId, action, chatId);
+    }
     return this.delegate.applySessionAction(sessionId, action, chatId);
   }
 
   async isSessionRunning(sessionId: string, chatId?: string) {
+    if (this.runtimeExecutor) {
+      return this.runtimeExecutor.isSessionRunning(sessionId, chatId);
+    }
     return this.delegate.isSessionRunning(sessionId, chatId);
   }
 
   async listPermissions(state?: PermissionRequest['state']) {
+    if (this.runtimeExecutor) {
+      return this.runtimeExecutor.listPermissions(state);
+    }
     return this.delegate.listPermissions(state);
   }
 
   async createPermission(input: CreatePermissionInput) {
+    if (this.runtimeExecutor) {
+      return this.runtimeExecutor.createPermission(input);
+    }
     return this.delegate.createPermission(input);
   }
 
   async decidePermission(permissionId: string, decision: PermissionDecision) {
+    if (this.runtimeExecutor) {
+      return this.runtimeExecutor.decidePermission(permissionId, decision);
+    }
     return this.delegate.decidePermission(permissionId, decision);
   }
 


### PR DESCRIPTION
## 변경 내용
- prisma persistence 위에 local happy executor를 붙여 user prompt 이후 실제 agent turn을 시작하도록 연결
- prisma 모드에서도 runtime, realtime-events, permissions, gemini capabilities가 executor 상태를 사용하도록 정리
- self-runtime URL과 runtime token을 backend 내부 executor에 주입

## 검증
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vitest run tests/prismaRuntimeStore.test.ts tests/runtimeContracts.test.ts