### PR TITLE
fix(backend): 에이전트 응답 완료 후 '응답 생성 중' 상태가 지속되는 버그 수정

### DIFF
--- a/services/aris-backend/src/server.ts
+++ b/services/aris-backend/src/server.ts
@@ -141,6 +141,12 @@ function parseHappyBridgeMessages(body: unknown): HappyBridgeAppendMessage[] | n
     }
 
     const payloadMeta = asRecord(payload.meta) ?? undefined;
+    const payloadRole = typeof payload.role === 'string' && payload.role.trim().length > 0
+      ? payload.role.trim()
+      : undefined;
+    const mergedMeta = payloadRole
+      ? { role: payloadRole, ...payloadMeta }
+      : payloadMeta;
     const type = typeof payload.type === 'string' && payload.type.trim().length > 0
       ? payload.type.trim()
       : 'message';
@@ -161,7 +167,7 @@ function parseHappyBridgeMessages(body: unknown): HappyBridgeAppendMessage[] | n
         type,
         ...(title ? { title } : {}),
         text,
-        ...(payloadMeta ? { meta: payloadMeta } : {}),
+        ...(mergedMeta ? { meta: mergedMeta } : {}),
       },
     } satisfies HappyBridgeAppendMessage;
   });


### PR DESCRIPTION
## 문제

에이전트가 응답을 완료한 이후에도 UI에서 '응답 생성 중' 상태가 계속 유지되는 버그.

## 근본 원인

`appendAgentMessage`가 content JSON 최상위에 `role: 'agent'`를 포함시키지만,
`parseHappyBridgeMessages`는 `payload.meta`만 `input.meta`로 추출하고 최상위 `role`은 무시했습니다.

```
content JSON:
{
  "role": "agent",        ← 최상위 (무시됨)
  "meta": {
    "source": "cli-agent",
    "chatId": "...",
    ...                   ← 이것만 input.meta로 전달됨
  }
}
```

이로 인해 두 가지 경로 모두 오작동:

1. **세션 레벨 status**: `isAgentMessage = input.meta?.role === 'agent'` → 항상 `false`
   → 에이전트 메시지가 와도 session.status가 `'running'` → `'idle'`로 전환되지 않음

2. **chatId 기반 running 판단** (`resolveChatRunningState`): `deriveRunningStateFromMeta`에서
   `meta.role`을 찾지 못해 `null` 반환 → 마지막 유저 메시지(`role: 'user'`)까지 거슬러 올라가
   `isRunning: true` 반환

## 수정

`parseHappyBridgeMessages`에서 `payload.role`을 `mergedMeta`에 병합 (`server.ts`):

```typescript
const payloadRole = typeof payload.role === 'string' && payload.role.trim().length > 0
  ? payload.role.trim()
  : undefined;
const mergedMeta = payloadRole
  ? { role: payloadRole, ...payloadMeta }
  : payloadMeta;
```

## 테스트

- 백엔드 전체 테스트 통과 (176 tests)
- 타입 체크 통과

## 추가 조치

기존 stuck 세션 7개 (세션 레벨 5개 + chatId 레벨 2개)를 수동으로 abort 처리함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)