### PR TITLE
fix(agent): close stdin for claude cli to prevent 3s timeout warning

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -1971,7 +1971,9 @@ export class HappyRuntimeStore {
           maxBuffer: 8 * 1024 * 1024,
           env: { ...spawnEnv, PATH: mergedPath },
           signal,
-        })
+          stdio: ['ignore', 'pipe', 'pipe'],
+          encoding: 'utf8',
+        } as any) as unknown as Promise<{ stdout: string; stderr: string }>
     );
     const runCommandStreaming = async (
       args: string[],


### PR DESCRIPTION
Fixes the warning 'Warning: no stdin data received in 3s' caused by execFileAsync not closing stdin when running the claude CLI without streaming