### PR TITLE
feat(session): 워크스페이스 내 ApprovalPolicy 런타임 변경 기능 추가

### DIFF
--- a/services/aris-backend/src/runtime/prismaStore.ts
+++ b/services/aris-backend/src/runtime/prismaStore.ts
@@ -238,6 +238,16 @@ export class PrismaRuntimeStore {
     return toRuntimeSession(row);
   }
 
+  async updateApprovalPolicy(sessionId: string, approvalPolicy: ApprovalPolicy): Promise<RuntimeSession> {
+    const existing = await this.db.session.findUnique({ where: { id: sessionId } });
+    if (!existing) throw new Error('SESSION_NOT_FOUND');
+    const row = await this.db.session.update({
+      where: { id: sessionId },
+      data: { approvalPolicy, updatedAt: new Date() },
+    });
+    return toRuntimeSession(row);
+  }
+
   async listMessages(
     sessionId: string,
     options: { afterSeq?: number; afterId?: string; limit?: number } = {},

--- a/services/aris-backend/src/server.ts
+++ b/services/aris-backend/src/server.ts
@@ -59,6 +59,10 @@ const createSessionSchema = z.object({
   riskScore: z.number().int().min(0).max(100).optional(),
 });
 
+const updateSessionSchema = z.object({
+  approvalPolicy: z.enum(['on-request', 'on-failure', 'never', 'yolo']),
+});
+
 const appendMessageSchema = z.object({
   type: z.string().min(1),
   title: z.string().min(1).optional(),
@@ -345,6 +349,28 @@ export function buildServer(config: ServerConfig) {
       return reply.code(201).send({ session });
     } catch (error) {
       const message = toErrorMessage(error, 'Failed to create session');
+      return reply.code(502).send({ error: message });
+    }
+  });
+
+  app.patch('/v1/sessions/:sessionId', async (request, reply) => {
+    const parsed = updateSessionSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'Invalid request body' });
+    }
+
+    const { sessionId } = request.params as { sessionId: string };
+    try {
+      const session = await store.updateApprovalPolicy(sessionId, parsed.data.approvalPolicy);
+      return { session };
+    } catch (error) {
+      if (error instanceof Error && error.message === 'SESSION_NOT_FOUND') {
+        return reply.code(404).send({ error: 'Session not found' });
+      }
+      if (error instanceof Error && error.message === 'UPDATE_APPROVAL_POLICY_NOT_SUPPORTED') {
+        return reply.code(501).send({ error: 'Not supported in current backend' });
+      }
+      const message = toErrorMessage(error, 'Failed to update session');
       return reply.code(502).send({ error: message });
     }
   });

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -56,6 +56,7 @@ interface RuntimeStoreBackend {
   getSession(sessionId: string): Promise<RuntimeSession | null>;
   getGeminiSessionCapabilities?(sessionId: string): Promise<GeminiSessionCapabilities>;
   createSession(input: CreateSessionInput): Promise<RuntimeSession>;
+  updateApprovalPolicy?(sessionId: string, approvalPolicy: ApprovalPolicy): Promise<RuntimeSession>;
   listMessages(sessionId: string, options?: { afterSeq?: number; afterId?: string; limit?: number }): Promise<RuntimeMessage[]>;
   listRealtimeEvents?(sessionId: string, options?: { afterCursor?: number; limit?: number; chatId?: string }): Promise<{ events: RuntimeMessage[]; cursor: number }>;
   appendMessage(sessionId: string, input: AppendMessageInput): Promise<RuntimeMessage>;
@@ -142,6 +143,16 @@ class MockRuntimeStore implements RuntimeStoreBackend {
 
     this.sessions.set(session.id, session);
     this.messages.set(session.id, []);
+    return session;
+  }
+
+  async updateApprovalPolicy(sessionId: string, approvalPolicy: ApprovalPolicy): Promise<RuntimeSession> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error('SESSION_NOT_FOUND');
+    }
+    session.metadata.approvalPolicy = approvalPolicy;
+    session.updatedAt = new Date().toISOString();
     return session;
   }
 
@@ -410,6 +421,13 @@ export class RuntimeStore {
 
   async createSession(input: CreateSessionInput) {
     return this.delegate.createSession(input);
+  }
+
+  async updateApprovalPolicy(sessionId: string, approvalPolicy: ApprovalPolicy) {
+    if (typeof this.delegate.updateApprovalPolicy === 'function') {
+      return this.delegate.updateApprovalPolicy(sessionId, approvalPolicy);
+    }
+    throw new Error('UPDATE_APPROVAL_POLICY_NOT_SUPPORTED');
   }
 
   async listMessages(sessionId: string, options?: { afterSeq?: number; afterId?: string; limit?: number }) {

--- a/services/aris-web/app/api/runtime/sessions/[sessionId]/route.ts
+++ b/services/aris-web/app/api/runtime/sessions/[sessionId]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireApiUser } from '@/lib/auth/guard';
+import { updateSessionApprovalPolicy } from '@/lib/happy/client';
+import type { ApprovalPolicy } from '@/lib/happy/types';
+
+/**
+ * PATCH /api/runtime/sessions/[sessionId]
+ * 세션의 approvalPolicy를 변경합니다. operator 권한이 필요합니다.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const auth = await requireApiUser(request);
+  if ('response' in auth) {
+    return auth.response;
+  }
+
+  if (auth.user.role !== 'operator') {
+    return NextResponse.json({ error: 'Operator role required' }, { status: 403 });
+  }
+
+  const { sessionId } = await params;
+
+  try {
+    const body = await request.json();
+    const { approvalPolicy } = body as { approvalPolicy?: string };
+
+    const validPolicies: ApprovalPolicy[] = ['on-request', 'on-failure', 'never', 'yolo'];
+    if (!approvalPolicy || !validPolicies.includes(approvalPolicy as ApprovalPolicy)) {
+      return NextResponse.json(
+        { error: 'approvalPolicy must be one of: on-request, on-failure, never, yolo' },
+        { status: 400 },
+      );
+    }
+
+    const session = await updateSessionApprovalPolicy(sessionId, approvalPolicy as ApprovalPolicy);
+    return NextResponse.json({ session });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to update session';
+    if (message === 'SESSION_NOT_FOUND') {
+      return NextResponse.json({ error: '세션을 찾을 수 없습니다.' }, { status: 404 });
+    }
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -1312,6 +1312,38 @@
   cursor: not-allowed;
 }
 
+.contextMenuPolicyRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.35rem;
+  border-bottom: 1px solid var(--chat-panel-border);
+}
+
+.contextMenuPolicyLabel {
+  font-size: 0.67rem;
+  font-weight: 700;
+  color: var(--chat-text-muted);
+  white-space: nowrap;
+}
+
+.contextMenuPolicySelect {
+  flex: 1;
+  border: 1px solid var(--chat-control-border);
+  border-radius: 6px;
+  background: var(--chat-surface-subtle);
+  color: var(--chat-text-primary);
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.2rem 0.35rem;
+  cursor: pointer;
+}
+
+.contextMenuPolicySelect:disabled {
+  opacity: 0.58;
+  cursor: not-allowed;
+}
+
 .noticeWrap {
   padding: 0.7rem 0.85rem 0;
 }

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -2129,7 +2129,7 @@ export function ChatInterface({
   alias,
   agentFlavor,
   sessionModel,
-  approvalPolicy,
+  approvalPolicy: initialApprovalPolicy,
 }: {
   sessionId: string;
   initialEvents: UiEvent[];
@@ -2145,6 +2145,8 @@ export function ChatInterface({
   sessionModel?: string | null;
   approvalPolicy?: ApprovalPolicy;
 }) {
+  const [approvalPolicy, setApprovalPolicy] = useState<ApprovalPolicy | undefined>(initialApprovalPolicy);
+  const [isPolicyChanging, setIsPolicyChanging] = useState(false);
   const [modelSettings, setModelSettings] = useState<ModelSettingsResponse | null>(null);
   
   useEffect(() => {
@@ -5196,9 +5198,46 @@ export function ChatInterface({
                 {isContextMenuOpen && (
                   <div className={styles.contextMenuPanel} role="menu">
                     <div className={styles.contextMenuMeta}>
-                      <span>Policy: {approvalPolicyLabel(approvalPolicy)}</span>
                       <span>Pending: {effectivePendingPermissions.length}</span>
                     </div>
+                    {isOperator && (
+                      <div className={styles.contextMenuPolicyRow}>
+                        <label htmlFor="approval-policy-select" className={styles.contextMenuPolicyLabel}>
+                          Policy
+                        </label>
+                        <select
+                          id="approval-policy-select"
+                          className={styles.contextMenuPolicySelect}
+                          value={approvalPolicy ?? 'on-request'}
+                          disabled={isPolicyChanging}
+                          onChange={(e) => {
+                            const next = e.target.value as ApprovalPolicy;
+                            setIsPolicyChanging(true);
+                            fetch(`/api/runtime/sessions/${encodeURIComponent(sessionId)}`, {
+                              method: 'PATCH',
+                              headers: { 'Content-Type': 'application/json' },
+                              body: JSON.stringify({ approvalPolicy: next }),
+                            })
+                              .then((res) => {
+                                if (!res.ok) throw new Error('Failed to update policy');
+                                setApprovalPolicy(next);
+                              })
+                              .catch(() => {})
+                              .finally(() => setIsPolicyChanging(false));
+                          }}
+                        >
+                          <option value="on-request">ON REQUEST</option>
+                          <option value="on-failure">ON FAILURE</option>
+                          <option value="never">NEVER</option>
+                          <option value="yolo">YOLO</option>
+                        </select>
+                      </div>
+                    )}
+                    {!isOperator && (
+                      <div className={styles.contextMenuMeta}>
+                        <span>Policy: {approvalPolicyLabel(approvalPolicy)}</span>
+                      </div>
+                    )}
                     <button
                       type="button"
                       className={styles.contextMenuItem}

--- a/services/aris-web/lib/happy/client.ts
+++ b/services/aris-web/lib/happy/client.ts
@@ -657,6 +657,24 @@ export async function createSession(input: {
   return normalizeSessions([session])[0];
 }
 
+export async function updateSessionApprovalPolicy(
+  sessionId: string,
+  approvalPolicy: ApprovalPolicy,
+): Promise<SessionSummary> {
+  const raw = await fetchHappy(`/v1/sessions/${encodeURIComponent(sessionId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ approvalPolicy }),
+  });
+
+  const obj = asObject(raw);
+  const session = obj?.session;
+  if (!session) {
+    throw new Error('백엔드 응답이 올바르지 않습니다.');
+  }
+
+  return normalizeSessions([session])[0];
+}
+
 export async function getSessionEvents(
   sessionId: string,
   options: string | GetSessionEventsOptions = {},


### PR DESCRIPTION
## 요약

- 세션 생성 이후에도 컨텍스트 메뉴에서 `ApprovalPolicy`를 드롭다운으로 즉시 변경 가능
- `operator` 권한을 가진 사용자만 변경할 수 있으며, 일반 사용자에게는 읽기 전용 표시
- 변경 즉시 백엔드 DB에 반영되고 UI 상태도 동기화됨

## 변경 내용

**aris-backend**
- `MockRuntimeStore`, `PrismaRuntimeStore`, `RuntimeStore`에 `updateApprovalPolicy` 메서드 추가
- `PATCH /v1/sessions/:sessionId` 엔드포인트 추가 (Zod 유효성 검사 포함)

**aris-web**
- `lib/happy/client.ts`에 `updateSessionApprovalPolicy` 함수 추가
- `app/api/runtime/sessions/[sessionId]/route.ts` (PATCH) 신규 생성
- `ChatInterface.tsx` 컨텍스트 메뉴에 Policy 드롭다운 추가 (operator 전용)
- `ChatInterface.module.css`에 드롭다운 스타일 추가

## 테스트 플랜

- [ ] 세션 상세 페이지에서 컨텍스트 메뉴(⋮) 클릭
- [ ] operator 계정: Policy 드롭다운이 표시되고 선택 시 변경됨
- [ ] viewer 계정: 드롭다운 없이 "Policy: ..." 텍스트만 표시됨
- [ ] 페이지 새로고침 후 변경된 policy가 유지되는지 확인
- [ ] yolo 선택 시 Gemini 모드도 자동으로 yolo 가능 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)