### PR TITLE
feat(codex): yolo 정책일 때 bubblewrap 샌드박스 해제

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -2649,6 +2649,7 @@ export class HappyRuntimeStore {
     }).model;
     const selectedReasoningEffort = normalizeModelReasoningEffort(modelReasoningEffort);
     const autoApproveAll = sessionApprovalPolicy === 'yolo';
+    const effectiveSandboxMode = autoApproveAll ? 'danger-full-access' : CODEX_SANDBOX_MODE;
     const mergedPath = `${process.env.PATH || ''}:${AGENT_EXTRA_PATHS}`;
     const args = [
       ...(selectedModel ? ['-c', `model=${JSON.stringify(selectedModel)}`] : []),
@@ -3293,7 +3294,7 @@ export class HappyRuntimeStore {
           threadId: resolvedThreadId,
           cwd: safeCwd,
           approvalPolicy: codexApprovalPolicy,
-          sandbox: CODEX_SANDBOX_MODE,
+          sandbox: effectiveSandboxMode,
           persistExtendedHistory: true,
         });
         const resumedThreadId = asString(asRecord(resumed.thread)?.id, '').trim();
@@ -3305,7 +3306,7 @@ export class HappyRuntimeStore {
         const started = await sendRequest('thread/start', {
           cwd: safeCwd,
           approvalPolicy: codexApprovalPolicy,
-          sandbox: CODEX_SANDBOX_MODE,
+          sandbox: effectiveSandboxMode,
           experimentalRawEvents: false,
           persistExtendedHistory: true,
         });
@@ -3486,6 +3487,7 @@ export class HappyRuntimeStore {
     }).model;
     const selectedReasoningEffort = normalizeModelReasoningEffort(modelReasoningEffort);
     const autoApproveAll = sessionApprovalPolicy === 'yolo';
+    const effectiveSandboxMode = autoApproveAll ? 'danger-full-access' : CODEX_SANDBOX_MODE;
     const mergedPath = `${process.env.PATH || ''}:${AGENT_EXTRA_PATHS}`;
     const execArgs = threadId
       ? ['exec', 'resume', threadId, '--json', prompt]
@@ -3494,7 +3496,7 @@ export class HappyRuntimeStore {
       '-a',
       codexApprovalPolicy,
       '-s',
-      CODEX_SANDBOX_MODE,
+      effectiveSandboxMode,
       ...(selectedModel ? ['-m', selectedModel] : []),
       ...(selectedReasoningEffort ? ['-c', `model_reasoning_effort=${JSON.stringify(selectedReasoningEffort)}`] : []),
       ...execArgs,


### PR DESCRIPTION
## 요약

- Codex CLI가 기본적으로 bubblewrap 샌드박스(`workspace-write`)를 사용하여 `sudo` 등이 차단되는 문제 수정
- 사용자가 승인 정책을 `yolo`로 설정한 경우에만 `danger-full-access`로 전환하여 샌드박스 해제

## 변경 내용

`runCodexAppServerWithEvents` 및 `runCodexExecCliWithEvents` 함수에서:
- `sessionApprovalPolicy === 'yolo'` 여부로 `effectiveSandboxMode` 결정
- yolo → `danger-full-access` (bubblewrap 비사용, sudo 가능)
- 그 외 → `CODEX_SANDBOX_MODE` 환경변수 값 유지 (기본: `workspace-write`)

## 테스트 계획

- [ ] yolo 정책 세션에서 Codex 에이전트가 `sudo` 명령 실행 가능한지 확인
- [ ] 일반 정책 세션에서 기존 샌드박스 동작 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)