### PR TITLE
fix(chat): 새 채팅 생성 시 이전 채팅이 표시되는 버그 수정

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -4415,7 +4415,6 @@ export function ChatInterface({
     }
     setIsCreatingChat(true);
     setChatMutationError(null);
-    setIsNewChatPlaceholder(false);
     const defaultModelId = resolveDefaultModelId(agent, providerSelections, legacyCustomModels);
     const defaultGeminiModeId = agent === 'gemini'
       ? resolveDefaultGeminiModeId(approvalPolicy, providerSelections?.gemini?.defaultModeId)


### PR DESCRIPTION
## 버그 원인

`handleCreateChat` 함수에서 `setIsNewChatPlaceholder(false)`를 API 호출 **전에** 조기 실행하는 문제.

**버그 재현 경로:**
1. 새 채팅 버튼 클릭 → `setIsNewChatPlaceholder(true)`, `setSelectedChatId(null)`
2. 에이전트 선택 → `handleCreateChat()` 호출
3. **`setIsNewChatPlaceholder(false)` 조기 실행** ← 문제
4. API 응답 대기 중: `isNewChatPlaceholder=false`, `selectedChatId=null`
5. `resolveActiveChat(chats, null, false)` → 첫 번째 채팅(이전 채팅) 활성화됨
6. API 응답 후 `goToChat(newChatId)` 호출로 올바른 채팅으로 이동

## 수정 내용

`goToChat()` 내부에서 이미 `setIsNewChatPlaceholder(false)`를 처리하므로, `handleCreateChat`의 중복 조기 호출 1줄 제거.

## 테스트 방법

- [ ] 새 채팅 버튼 클릭
- [ ] 에이전트 선택 후 이전 채팅이 잠깐 표시되지 않는지 확인
- [ ] 새 채팅이 올바르게 생성·표시되는지 확인