### PR TITLE
feat(stream): JSONL 파싱 오류 가시화 + TurnProgressTracker (Phase 1)

### DIFF
--- a/services/aris-backend/src/runtime/contracts/providerRuntime.ts
+++ b/services/aris-backend/src/runtime/contracts/providerRuntime.ts
@@ -35,6 +35,7 @@ export type ProviderActionEvent = {
   additions: number;
   deletions: number;
   hasDiffSignal: boolean;
+  meta?: Record<string, unknown>;
 };
 
 export type ProviderTextEvent = {

--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -17,6 +17,7 @@ import {
 import { ClaudeMessageQueue } from './providers/claude/claudeMessageQueue.js';
 import { extractClaudePermissionRequest } from './providers/claude/claudePermissionBridge.js';
 import { looksLikeClaudeActionTranscript, parseClaudeStreamLine, parseClaudeStreamOutput } from './providers/claude/claudeProtocolMapper.js';
+import { TurnProgressTracker } from './providers/claude/turnProgressTracker.js';
 import { ClaudeSessionRegistry } from './providers/claude/claudeSessionRegistry.js';
 import { ClaudeSessionLogTracker, extractClaudeSessionHintIds } from './providers/claude/claudeSessionScanner.js';
 import { buildClaudeSessionId } from './providers/claude/claudeSessionSource.js';
@@ -1986,7 +1987,10 @@ export class HappyRuntimeStore {
       actions: ParsedAgentActionEvent[];
       streamedActionsPersisted: boolean;
       threadId?: string;
-    }> => new Promise((resolve, reject) => {
+    }> => {
+      const tracker = new TurnProgressTracker();
+      tracker.setModel(agent);
+      return new Promise((resolve, reject) => {
       let child: ReturnType<typeof spawn>;
       try {
         child = command.requiresPty
@@ -2022,7 +2026,11 @@ export class HappyRuntimeStore {
       let providerErrorDetail = '';
       let emitChain: Promise<void> = Promise.resolve();
       const geminiStreamAdapter = agent === 'gemini' && GEMINI_STREAM_BACKEND_V2
-        ? new GeminiStreamAdapter()
+        ? new GeminiStreamAdapter({
+          onParseWarning: (rawLine) => {
+            process.stderr.write(`[gemini] JSONL parse failed: ${rawLine.slice(0, 200)}\n`);
+          },
+        })
         : null;
       let settled = false;
       let timedOut = false;
@@ -2094,7 +2102,11 @@ export class HappyRuntimeStore {
           }
         }
         if (agent === 'claude') {
-          const parsedLine = parseClaudeStreamLine(normalized);
+          const parsedLine = parseClaudeStreamLine(normalized, {
+            onParseWarning: (rawLine) => {
+              process.stderr.write(`[claude] JSONL parse failed: ${rawLine.slice(0, 200)}\n`);
+            },
+          });
           if (parsedLine.sessionId) {
             resolvedSessionId = parsedLine.sessionId;
           }
@@ -2104,8 +2116,14 @@ export class HappyRuntimeStore {
           if (parsedLine.action && parsedLine.actionKey && !actionByKey.has(parsedLine.actionKey)) {
             actionByKey.set(parsedLine.actionKey, parsedLine.action);
             if (onAction) {
+              tracker.nextStep();
+              const progressMeta = tracker.toMeta();
+              const actionWithMeta: ParsedAgentActionEvent = {
+                ...parsedLine.action,
+                meta: { ...parsedLine.action.meta, ...progressMeta },
+              };
               emitChain = emitChain.then(async () => {
-                await onAction(parsedLine.action!);
+                await onAction(actionWithMeta);
                 streamedActionsPersisted = true;
               });
             }
@@ -2149,8 +2167,14 @@ export class HappyRuntimeStore {
               if (!actionByKey.has(actionKey)) {
                 actionByKey.set(actionKey, event.action);
                 if (onAction) {
+                  tracker.nextStep();
+                  const progressMeta = tracker.toMeta();
+                  const actionWithMeta: ParsedAgentActionEvent = {
+                    ...event.action,
+                    meta: { ...event.action.meta, ...progressMeta },
+                  };
                   emitChain = emitChain.then(async () => {
-                    await onAction(event.action);
+                    await onAction(actionWithMeta);
                     streamedActionsPersisted = true;
                   });
                 }
@@ -2291,7 +2315,8 @@ export class HappyRuntimeStore {
             settleReject(error);
           });
       });
-    });
+      });
+    };
 
     let result: { stdout: string; stderr: string; threadId?: string } | null = null;
     let lastError: unknown = null;

--- a/services/aris-backend/src/runtime/providers/claude/claudeProtocolFields.ts
+++ b/services/aris-backend/src/runtime/providers/claude/claudeProtocolFields.ts
@@ -12,10 +12,14 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-export function parseClaudeJsonLine(line: string): Record<string, unknown> | null {
+export function parseClaudeJsonLine(
+  line: string,
+  onParseWarning?: (rawLine: string) => void,
+): Record<string, unknown> | null {
   try {
     return asRecord(JSON.parse(line));
   } catch {
+    onParseWarning?.(line);
     return null;
   }
 }

--- a/services/aris-backend/src/runtime/providers/claude/claudeProtocolMapper.ts
+++ b/services/aris-backend/src/runtime/providers/claude/claudeProtocolMapper.ts
@@ -150,8 +150,12 @@ function buildToolName(action: ClaudeActionEvent, payloadSubtype: string): strin
   return action.actionType;
 }
 
-export function parseClaudeStreamLine(line: string): ClaudeMappedLine {
-  const payload = parseClaudeJsonLine(line);
+type ParseClaudeStreamLineOptions = {
+  onParseWarning?: (rawLine: string) => void;
+};
+
+export function parseClaudeStreamLine(line: string, options?: ParseClaudeStreamLineOptions): ClaudeMappedLine {
+  const payload = parseClaudeJsonLine(line, options?.onParseWarning);
   if (!payload) {
     return { envelopes: [] };
   }

--- a/services/aris-backend/src/runtime/providers/claude/turnProgressTracker.ts
+++ b/services/aris-backend/src/runtime/providers/claude/turnProgressTracker.ts
@@ -1,0 +1,34 @@
+const MODEL_SHORTEN_RE = /^(claude|gemini|codex|opencode)-(.+)$/i;
+
+function shortenModel(raw: string): string {
+  const m = MODEL_SHORTEN_RE.exec(raw.trim());
+  if (!m) return raw.trim();
+  return `${m[1]!.toLowerCase()}/${m[2]}`;
+}
+
+export type ProgressMeta = {
+  step: number;
+  elapsedMs: number;
+  modelLabel?: string;
+};
+
+export class TurnProgressTracker {
+  private readonly startedAt = Date.now();
+  private stepCount = 0;
+  private model?: string;
+
+  nextStep(): void { this.stepCount += 1; }
+
+  setModel(raw: string): void {
+    if (this.model || !raw.trim()) return;
+    this.model = shortenModel(raw.trim());
+  }
+
+  toMeta(): ProgressMeta {
+    return {
+      step: this.stepCount,
+      elapsedMs: Date.now() - this.startedAt,
+      ...(this.model ? { modelLabel: this.model } : {}),
+    };
+  }
+}

--- a/services/aris-backend/src/runtime/providers/gemini/geminiProtocolFields.ts
+++ b/services/aris-backend/src/runtime/providers/gemini/geminiProtocolFields.ts
@@ -16,10 +16,14 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-export function parseGeminiJsonLine(line: string): Record<string, unknown> | null {
+export function parseGeminiJsonLine(
+  line: string,
+  onParseWarning?: (rawLine: string) => void,
+): Record<string, unknown> | null {
   try {
     return asRecord(JSON.parse(line));
   } catch {
+    onParseWarning?.(line);
     return null;
   }
 }

--- a/services/aris-backend/src/runtime/providers/gemini/geminiStreamAdapter.ts
+++ b/services/aris-backend/src/runtime/providers/gemini/geminiStreamAdapter.ts
@@ -278,6 +278,10 @@ type GeminiStreamSummary = {
   errorText?: string;
 };
 
+type GeminiStreamAdapterOptions = {
+  onParseWarning?: (rawLine: string) => void;
+};
+
 export class GeminiStreamAdapter {
   private readonly assembler = new GeminiIdentityAssembler();
   private readonly emittedKeys = new Set<string>();
@@ -286,14 +290,19 @@ export class GeminiStreamAdapter {
   private readonly pendingToolCalls = new Map<string, GeminiPendingToolCall>();
   private readonly completedTexts: GeminiCanonicalTextCompletedEvent[] = [];
   private readonly events: GeminiCanonicalEvent[] = [];
+  private readonly onParseWarning?: (rawLine: string) => void;
   private latestThreadId?: string;
   private sequence = 0;
   private errorText?: string;
   private pendingTextBlock: GeminiPendingTextBlock | null = null;
   private syntheticItemSequence = 0;
 
+  constructor(options?: GeminiStreamAdapterOptions) {
+    this.onParseWarning = options?.onParseWarning;
+  }
+
   processLine(line: string): GeminiCanonicalEvent[] {
-    const payload = parseGeminiJsonLine(line);
+    const payload = parseGeminiJsonLine(line, this.onParseWarning);
     if (!payload) {
       return [];
     }
@@ -914,8 +923,8 @@ export class GeminiStreamAdapter {
   }
 }
 
-export function parseGeminiStreamToCanonicalEvents(stdout: string): GeminiCanonicalEvent[] {
-  const adapter = new GeminiStreamAdapter();
+export function parseGeminiStreamToCanonicalEvents(stdout: string, options?: GeminiStreamAdapterOptions): GeminiCanonicalEvent[] {
+  const adapter = new GeminiStreamAdapter(options);
   for (const line of stdout.replace(/\r\n/g, '\n').split('\n').map((entry) => entry.trim()).filter(Boolean)) {
     adapter.processLine(line);
   }

--- a/services/aris-backend/tests/turnProgressTracker.test.ts
+++ b/services/aris-backend/tests/turnProgressTracker.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { TurnProgressTracker } from '../src/runtime/providers/claude/turnProgressTracker.js';
+
+describe('TurnProgressTracker', () => {
+  it('starts with step 0 and zero elapsed approximation', () => {
+    const tracker = new TurnProgressTracker();
+    const meta = tracker.toMeta();
+    expect(meta.step).toBe(0);
+    expect(meta.elapsedMs).toBeGreaterThanOrEqual(0);
+    expect(meta.modelLabel).toBeUndefined();
+  });
+
+  it('increments step on each nextStep call', () => {
+    const tracker = new TurnProgressTracker();
+    tracker.nextStep();
+    tracker.nextStep();
+    tracker.nextStep();
+    expect(tracker.toMeta().step).toBe(3);
+  });
+
+  it('shortens claude model names', () => {
+    const tracker = new TurnProgressTracker();
+    tracker.setModel('claude-opus-4-6');
+    expect(tracker.toMeta().modelLabel).toBe('claude/opus-4-6');
+  });
+
+  it('shortens gemini model names', () => {
+    const tracker = new TurnProgressTracker();
+    tracker.setModel('gemini-2.0-flash');
+    expect(tracker.toMeta().modelLabel).toBe('gemini/2.0-flash');
+  });
+
+  it('keeps unknown model names as-is', () => {
+    const tracker = new TurnProgressTracker();
+    tracker.setModel('gpt-4o');
+    expect(tracker.toMeta().modelLabel).toBe('gpt-4o');
+  });
+
+  it('only records the first setModel call', () => {
+    const tracker = new TurnProgressTracker();
+    tracker.setModel('claude-opus-4-6');
+    tracker.setModel('gemini-2.0-flash');
+    expect(tracker.toMeta().modelLabel).toBe('claude/opus-4-6');
+  });
+
+  it('ignores empty string in setModel', () => {
+    const tracker = new TurnProgressTracker();
+    tracker.setModel('');
+    expect(tracker.toMeta().modelLabel).toBeUndefined();
+  });
+
+  it('elapsedMs grows over time', async () => {
+    const tracker = new TurnProgressTracker();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(tracker.toMeta().elapsedMs).toBeGreaterThan(0);
+  });
+});

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -964,6 +964,32 @@ function getLatestVisibleEvent(events: UiEvent[]): UiEvent | null {
   return null;
 }
 
+function extractProgressMeta(events: UiEvent[]): { step?: number; elapsedMs?: number; modelLabel?: string } | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (!event?.meta) continue;
+    const step = typeof event.meta.step === 'number' ? event.meta.step : undefined;
+    const elapsedMs = typeof event.meta.elapsedMs === 'number' ? event.meta.elapsedMs : undefined;
+    const modelLabel = typeof event.meta.modelLabel === 'string' ? event.meta.modelLabel : undefined;
+    if (step !== undefined || modelLabel !== undefined) {
+      return { step, elapsedMs, modelLabel };
+    }
+  }
+  return null;
+}
+
+function buildProgressLabel(
+  base: string,
+  progress: { step?: number; elapsedMs?: number; modelLabel?: string } | null,
+): string {
+  if (!progress) return base;
+  const parts: string[] = ['working'];
+  if (progress.modelLabel) parts.push(progress.modelLabel);
+  if (progress.elapsedMs !== undefined) parts.push(`${Math.floor(progress.elapsedMs / 1000)}s`);
+  if (progress.step !== undefined && progress.step > 0) parts.push(`step ${progress.step}`);
+  return parts.length > 1 ? parts.join(' · ') : base;
+}
+
 function hasChatErrorSignal(event: UiEvent | null | undefined): boolean {
   if (!event) {
     return false;
@@ -2570,8 +2596,9 @@ export function ChatInterface({
     : runtimeNotice
       ? 'degraded'
       : 'connected';
+  const progressMeta = isRunActive ? extractProgressMeta(events) : null;
   const connectionLabel = connectionState === 'running'
-    ? (runPhaseLabel ?? '실행 중')
+    ? buildProgressLabel(runPhaseLabel ?? '실행 중', progressMeta)
     : connectionState === 'connected'
       ? '정상 연결'
       : '응답 지연 또는 연결 확인 필요';


### PR DESCRIPTION
## Summary

tunaPi 패턴 분석에서 도출한 Phase 1 개선사항 (D+E) 구현:

- **D - JSONL 오류 가시화**: Claude/Gemini JSONL 파싱 실패 시 `onParseWarning` 콜백으로 노출 (기존엔 silent drop)
- **E - TurnProgressTracker**: 턴당 step 수·경과 시간·모델명을 추적하고 프론트엔드 progress label로 표시

## 변경 파일

### Backend
- `claudeProtocolFields.ts` — `parseClaudeJsonLine(line, onParseWarning?)`
- `claudeProtocolMapper.ts` — `ParseClaudeStreamLineOptions` 타입, 옵션 전파
- `geminiProtocolFields.ts` — `parseGeminiJsonLine(line, onParseWarning?)`
- `geminiStreamAdapter.ts` — `GeminiStreamAdapterOptions`, 옵션 전파
- `turnProgressTracker.ts` (신규) — `TurnProgressTracker` 클래스
- `providerRuntime.ts` — `ProviderActionEvent`에 `meta?` 필드 추가
- `happyClient.ts` — TurnProgressTracker 연결, onParseWarning → stderr

### Frontend
- `ChatInterface.tsx` — `extractProgressMeta`, `buildProgressLabel` 추가
  → 실행 중 상태: `working · claude/opus-4-6 · 23s · step 4`

### Tests
- `turnProgressTracker.test.ts` (신규) — 유닛 테스트

## Test plan
- [x] 유닛 테스트 183개 통과
- [x] TurnProgressTracker 테스트 신규 추가
- [x] 기존 E2E 실패(pre-existing) 영향 없음 확인

## 관련 문서
- `docs/superpowers/plans/2026-04-02-jsonl-error-visibility-and-progress-tracker.md`
- `docs/03-platform/tunapi-feature-candidates.md`