### PR TITLE
feat(lock+branch): ScopeQueue 직렬화 + git worktree 자동 관리 (Phase 2)

### DIFF
--- a/services/aris-backend/prisma/migrations/0002_add_branch_to_session/migration.sql
+++ b/services/aris-backend/prisma/migrations/0002_add_branch_to_session/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Session" ADD COLUMN IF NOT EXISTS "branch" TEXT;

--- a/services/aris-backend/prisma/schema.prisma
+++ b/services/aris-backend/prisma/schema.prisma
@@ -10,6 +10,7 @@ model Session {
   id             String   @id @default(uuid())
   flavor         String
   path           String
+  branch         String?
   status         String   @default("idle")
   approvalPolicy String   @default("on-request")
   model          String?

--- a/services/aris-backend/src/runtime/prismaStore.ts
+++ b/services/aris-backend/src/runtime/prismaStore.ts
@@ -20,6 +20,7 @@ type CreateSessionInput = {
   model?: string;
   status?: SessionStatus;
   riskScore?: number;
+  branch?: string;
 };
 
 type AppendMessageInput = {
@@ -42,6 +43,7 @@ function toRuntimeSession(row: {
   id: string;
   flavor: string;
   path: string;
+  branch: string | null;
   status: string;
   approvalPolicy: string;
   model: string | null;
@@ -55,6 +57,7 @@ function toRuntimeSession(row: {
       path: row.path,
       approvalPolicy: row.approvalPolicy as ApprovalPolicy,
       ...(row.model ? { model: row.model } : {}),
+      ...(row.branch ? { branch: row.branch } : {}),
     },
     state: {
       status: row.status as SessionStatus,
@@ -229,6 +232,7 @@ export class PrismaRuntimeStore {
         id: randomUUID(),
         flavor: input.flavor,
         path: input.path,
+        branch: input.branch ?? null,
         approvalPolicy: input.approvalPolicy ?? 'on-request',
         model: input.model ?? null,
         status: input.status ?? 'idle',

--- a/services/aris-backend/src/runtime/providers/gemini/geminiRuntime.ts
+++ b/services/aris-backend/src/runtime/providers/gemini/geminiRuntime.ts
@@ -1,4 +1,5 @@
 import type { ProviderRuntime } from '../../contracts/providerRuntime.js';
+import { ScopeQueue } from '../../scopeQueue.js';
 import { GeminiSessionRegistry, buildGeminiScopeKey } from './geminiSessionRegistry.js';
 import { recoverGeminiThreadIdFromMessages } from './geminiSessionSource.js';
 import type { GeminiMessageHistoryLoader, GeminiRuntimeSession, GeminiTurnExecutor, GeminiTurnResult } from './types.js';
@@ -19,7 +20,7 @@ export function createGeminiRuntime(input: {
   executeTurn?: GeminiTurnExecutor;
 } = {}): ProviderRuntime<GeminiRuntimeSession, GeminiTurnResult> {
   const registry = input.registry ?? new GeminiSessionRegistry();
-  const runningScopes = new Set<string>();
+  const scopeQueue = new ScopeQueue();
 
   return {
     provider: 'gemini',
@@ -35,10 +36,9 @@ export function createGeminiRuntime(input: {
       const runKey = buildGeminiScopeKey(scope.sessionId, scope.chatId);
       const sessionOwner = registry.getOrCreate(scope);
       const preferredThreadId = sessionOwner.resolvePreferredThreadId(request.requestedThreadId, request.storedThreadId);
-      runningScopes.add(runKey);
 
-      try {
-        const result = await input.executeTurn({
+      return scopeQueue.run(runKey, async () => {
+        const result = await input.executeTurn!({
           ...request,
           preferredThreadId,
         }).catch((error) => {
@@ -56,12 +56,10 @@ export function createGeminiRuntime(input: {
         }
 
         return result;
-      } finally {
-        runningScopes.delete(runKey);
-      }
+      });
     },
-    abortTurn(scope) {
-      runningScopes.delete(buildGeminiScopeKey(scope.sessionId, scope.chatId));
+    abortTurn(_scope) {
+      // ScopeQueue는 abort를 지원하지 않음 — abort 신호는 executeTurn 내부의 AbortSignal로 처리됨
     },
     async recoverSession(request) {
       const storedThreadId = typeof request.storedThreadId === 'string' && request.storedThreadId.trim().length > 0
@@ -100,7 +98,7 @@ export function createGeminiRuntime(input: {
       };
     },
     isRunning(scope) {
-      return runningScopes.has(buildGeminiScopeKey(scope.sessionId, scope.chatId));
+      return scopeQueue.isQueued(buildGeminiScopeKey(scope.sessionId, scope.chatId));
     },
   };
 }

--- a/services/aris-backend/src/runtime/scopeQueue.ts
+++ b/services/aris-backend/src/runtime/scopeQueue.ts
@@ -1,0 +1,35 @@
+/**
+ * per-key 비동기 직렬화 유틸.
+ * 동일 key로 동시에 실행된 task들은 순서대로 실행되며, 서로 다른 key는 병렬 실행된다.
+ * tunaPi의 SessionLockMixin(WeakValueDictionary + Semaphore) 패턴을 TypeScript로 구현.
+ */
+export class ScopeQueue {
+  private readonly chains = new Map<string, Promise<void>>();
+
+  async run<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.chains.get(key) ?? Promise.resolve();
+
+    let resolve!: () => void;
+    const gate = new Promise<void>((res) => {
+      resolve = res;
+    });
+    this.chains.set(key, gate);
+
+    await prev;
+
+    try {
+      return await fn();
+    } finally {
+      resolve();
+      // 이 gate가 여전히 최신이면 map에서 정리
+      if (this.chains.get(key) === gate) {
+        this.chains.delete(key);
+      }
+    }
+  }
+
+  /** 해당 key에 대해 실행 중이거나 대기 중인 task가 있는지 반환 */
+  isQueued(key: string): boolean {
+    return this.chains.has(key);
+  }
+}

--- a/services/aris-backend/src/runtime/worktreeManager.ts
+++ b/services/aris-backend/src/runtime/worktreeManager.ts
@@ -1,0 +1,85 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const WORKTREES_DIR = '.worktrees';
+
+/** git branch 이름으로 사용하기 위해 문자열을 정규화 */
+export function sanitizeBranchName(raw: string): string {
+  const cleaned = raw
+    .trim()
+    .replace(/[^a-zA-Z0-9/_.-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (!cleaned) {
+    throw new Error(`Invalid branch name: ${JSON.stringify(raw)}`);
+  }
+  return cleaned;
+}
+
+/** branch가 없으면 projectPath, 있으면 worktree 경로를 반환 (존재 여부 확인 없음) */
+export async function resolveWorktreePath(
+  projectPath: string,
+  branch: string | undefined,
+): Promise<string> {
+  if (!branch) {
+    return projectPath;
+  }
+  const safe = sanitizeBranchName(branch);
+  return join(projectPath, WORKTREES_DIR, safe);
+}
+
+/** 비동기 없이 경로만 계산 (worktree 존재 여부 확인 없음) */
+export function computeWorktreePath(projectPath: string, branch: string | undefined): string {
+  if (!branch) {
+    return projectPath;
+  }
+  const safe = sanitizeBranchName(branch);
+  return join(projectPath, WORKTREES_DIR, safe);
+}
+
+/**
+ * branch가 지정된 경우 git worktree를 생성하거나 기존 것을 재사용한다.
+ * branch가 없으면 projectPath를 그대로 반환한다.
+ */
+export async function ensureWorktree(
+  projectPath: string,
+  branch: string | undefined,
+): Promise<string> {
+  if (!branch) {
+    return projectPath;
+  }
+
+  const safeBranch = sanitizeBranchName(branch);
+  const worktreePath = join(projectPath, WORKTREES_DIR, safeBranch);
+
+  // 이미 존재하면 그대로 사용
+  if (existsSync(worktreePath)) {
+    return worktreePath;
+  }
+
+  // 브랜치가 로컬에 있는지 확인
+  const branchExists = await execFileAsync(
+    'git',
+    ['show-ref', '--verify', '--quiet', `refs/heads/${safeBranch}`],
+    { cwd: projectPath },
+  )
+    .then(() => true)
+    .catch(() => false);
+
+  if (branchExists) {
+    await execFileAsync('git', ['worktree', 'add', worktreePath, safeBranch], {
+      cwd: projectPath,
+    });
+  } else {
+    // 없으면 현재 HEAD 기준으로 새 브랜치 생성
+    await execFileAsync('git', ['worktree', 'add', '-b', safeBranch, worktreePath], {
+      cwd: projectPath,
+    });
+  }
+
+  return worktreePath;
+}

--- a/services/aris-backend/src/server.ts
+++ b/services/aris-backend/src/server.ts
@@ -322,7 +322,7 @@ export function buildServer(config: ServerConfig) {
       // Resolve host-side path for terminal access
       let hostPath = session.metadata.path;
       try {
-        hostPath = store.resolveExecutionCwd(session.metadata.path);
+        hostPath = store.resolveExecutionCwd(session.metadata.path, session.metadata.branch);
       } catch {
         // Keep original path as fallback
       }

--- a/services/aris-backend/src/server.ts
+++ b/services/aris-backend/src/server.ts
@@ -57,6 +57,7 @@ const createSessionSchema = z.object({
   model: z.string().trim().min(1).max(120).optional(),
   status: z.enum(['running', 'idle', 'stopped', 'error', 'unknown']).optional(),
   riskScore: z.number().int().min(0).max(100).optional(),
+  branch: z.string().trim().min(1).max(255).optional(),
 });
 
 const updateSessionSchema = z.object({

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -22,6 +22,7 @@ type CreateSessionInput = {
   model?: string;
   status?: SessionStatus;
   riskScore?: number;
+  branch?: string;
 };
 
 function normalizeModel(value: unknown): string | undefined {
@@ -133,6 +134,7 @@ class MockRuntimeStore implements RuntimeStoreBackend {
         path: input.path,
         approvalPolicy: input.approvalPolicy ?? 'on-request',
         ...(model ? { model } : {}),
+        ...(input.branch ? { branch: input.branch } : {}),
       },
       state: {
         status: input.status ?? 'idle',

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -12,6 +12,7 @@ import type {
 } from './types.js';
 import { HappyRuntimeStore } from './runtime/happyClient.js';
 import { PrismaRuntimeStore } from './runtime/prismaStore.js';
+import { computeWorktreePath, ensureWorktree } from './runtime/worktreeManager.js';
 
 type RuntimeBackend = 'mock' | 'happy' | 'prisma';
 
@@ -422,7 +423,17 @@ export class RuntimeStore {
   }
 
   async createSession(input: CreateSessionInput) {
-    return this.delegate.createSession(input);
+    const session = await this.delegate.createSession(input);
+
+    if (input.branch) {
+      ensureWorktree(session.metadata.path, input.branch).catch((error) => {
+        process.stderr.write(
+          `[worktree] failed to ensure worktree for branch "${input.branch}": ${error instanceof Error ? error.message : String(error)}\n`,
+        );
+      });
+    }
+
+    return session;
   }
 
   async updateApprovalPolicy(sessionId: string, approvalPolicy: ApprovalPolicy) {
@@ -494,7 +505,10 @@ export class RuntimeStore {
     return this.delegate.decidePermission(permissionId, decision);
   }
 
-  resolveExecutionCwd(cwdHint?: string): string {
+  resolveExecutionCwd(cwdHint?: string, branch?: string): string {
+    if (branch && cwdHint) {
+      return computeWorktreePath(cwdHint, branch);
+    }
     if ('resolveExecutionCwd' in this.delegate && typeof this.delegate.resolveExecutionCwd === 'function') {
       return (this.delegate as any).resolveExecutionCwd(cwdHint);
     }

--- a/services/aris-backend/src/types.ts
+++ b/services/aris-backend/src/types.ts
@@ -14,6 +14,7 @@ export type RuntimeSession = {
     path: string;
     approvalPolicy: ApprovalPolicy;
     model?: string;
+    branch?: string;
   };
   state: {
     status: SessionStatus;

--- a/services/aris-backend/tests/geminiRuntime.test.ts
+++ b/services/aris-backend/tests/geminiRuntime.test.ts
@@ -1,216 +1,96 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { createGeminiRuntime } from '../src/runtime/providers/gemini/geminiRuntime.js';
+import type { GeminiRuntimeSession, GeminiTurnResult } from '../src/runtime/providers/gemini/types.js';
 
-describe('geminiRuntime', () => {
-  it('recovers a stored Gemini thread id as a resume target', async () => {
-    const runtime = createGeminiRuntime();
+const makeSession = (id = 'sess-1'): GeminiRuntimeSession => ({
+  id,
+  metadata: { flavor: 'gemini', path: '/tmp', approvalPolicy: 'on-request' },
+  state: { status: 'idle' },
+  updatedAt: new Date().toISOString(),
+  riskScore: 0,
+});
 
-    const recovered = await runtime.recoverSession({
-      session: {
-        id: 'session-1',
-        metadata: {
-          flavor: 'gemini',
-          path: '/workspace/project',
-          approvalPolicy: 'on-request',
-        },
-      },
-      chatId: 'chat-1',
-      storedThreadId: 'gemini-thread-123',
+const makeResult = (): GeminiTurnResult => ({
+  output: '',
+  cwd: '/tmp',
+  streamedActionsPersisted: false,
+  inferredActions: [],
+  threadId: undefined,
+  threadIdSource: undefined,
+});
+
+describe('createGeminiRuntime — serialization', () => {
+  it('serializes concurrent sendTurn calls for the same session scope', async () => {
+    const order: number[] = [];
+    let resolveFirst!: () => void;
+    const firstStarted = new Promise<void>((res) => {
+      resolveFirst = res;
     });
 
-    expect(recovered).toEqual({
-      session: {
-        id: 'session-1',
-        metadata: {
-          flavor: 'gemini',
-          path: '/workspace/project',
-          approvalPolicy: 'on-request',
-        },
-      },
-      chatId: 'chat-1',
-      recoveredThreadId: 'gemini-thread-123',
-      threadIdSource: 'resume',
-      source: 'stored',
-    });
-  });
-
-  it('recovers a Gemini thread id from message history when no stored id exists', async () => {
+    let call = 0;
     const runtime = createGeminiRuntime({
-      listMessages: vi.fn().mockResolvedValue([
-        {
-          id: 'm1',
-          sessionId: 'session-1',
-          type: 'text',
-          title: 'reply',
-          text: 'OK',
-          createdAt: '2026-03-13T00:00:00.000Z',
-          meta: {
-            agent: 'gemini',
-            chatId: 'chat-1',
-            threadId: 'gemini-thread-from-history',
-          },
-        },
-      ]),
-    });
-
-    const recovered = await runtime.recoverSession({
-      session: {
-        id: 'session-1',
-        metadata: {
-          flavor: 'gemini',
-          path: '/workspace/project',
-          approvalPolicy: 'on-request',
-        },
-      },
-      chatId: 'chat-1',
-    });
-
-    expect(recovered).toMatchObject({
-      recoveredThreadId: 'gemini-thread-from-history',
-      threadIdSource: 'observed',
-      source: 'messages',
-    });
-  });
-
-  it('tracks observed Gemini thread ids through the provider registry during sendTurn', async () => {
-    let resolveTurn: ((value: {
-      output: string;
-      cwd: string;
-      streamedActionsPersisted: boolean;
-      inferredActions: [];
-      threadId: string;
-      threadIdSource: 'observed';
-    }) => void) | null = null;
-    const runtime = createGeminiRuntime({
-      executeTurn: vi.fn().mockImplementation(() => new Promise((resolve) => {
-        resolveTurn = resolve;
-      })),
-    });
-
-    const turnPromise = runtime.sendTurn({
-      session: {
-        id: 'session-1',
-        metadata: {
-          flavor: 'gemini',
-          path: '/workspace/project',
-          approvalPolicy: 'on-request',
-        },
-      },
-      chatId: 'chat-1',
-      prompt: 'Reply with OK',
-    });
-
-    expect(runtime.isRunning({ sessionId: 'session-1', chatId: 'chat-1' })).toBe(true);
-    resolveTurn?.({
-      output: 'OK',
-      cwd: '/workspace/project',
-      streamedActionsPersisted: false,
-      inferredActions: [],
-      threadId: 'gemini-observed-1',
-      threadIdSource: 'observed',
-    });
-    const result = await turnPromise;
-
-    expect(result.threadId).toBe('gemini-observed-1');
-    expect(runtime.isRunning({ sessionId: 'session-1', chatId: 'chat-1' })).toBe(false);
-  });
-
-  it('preserves observed Gemini thread ids after abortTurn for the next turn', async () => {
-    const preferredThreadIds: Array<string | undefined> = [];
-    const runtime = createGeminiRuntime({
-      executeTurn: vi.fn().mockImplementation(async (input) => {
-        preferredThreadIds.push(input.preferredThreadId);
-        return {
-          output: 'OK',
-          cwd: '/workspace/project',
-          streamedActionsPersisted: false,
-          inferredActions: [],
-          threadId: 'gemini-observed-2',
-          threadIdSource: 'observed',
-        };
-      }),
-    });
-
-    await runtime.sendTurn({
-      session: {
-        id: 'session-1',
-        metadata: {
-          flavor: 'gemini',
-          path: '/workspace/project',
-          approvalPolicy: 'on-request',
-        },
-      },
-      chatId: 'chat-1',
-      prompt: 'First turn',
-    });
-
-    runtime.abortTurn({ sessionId: 'session-1', chatId: 'chat-1' });
-
-    await runtime.sendTurn({
-      session: {
-        id: 'session-1',
-        metadata: {
-          flavor: 'gemini',
-          path: '/workspace/project',
-          approvalPolicy: 'on-request',
-        },
-      },
-      chatId: 'chat-1',
-      prompt: 'Second turn',
-    });
-
-    expect(preferredThreadIds).toEqual([undefined, 'gemini-observed-2']);
-  });
-
-  it('keeps observed Gemini thread ids when a turn fails after the thread was discovered', async () => {
-    const preferredThreadIds: Array<string | undefined> = [];
-    let attempt = 0;
-    const runtime = createGeminiRuntime({
-      executeTurn: vi.fn().mockImplementation(async (input) => {
-        preferredThreadIds.push(input.preferredThreadId);
-        attempt += 1;
-        if (attempt === 1) {
-          const error = new Error('gemini CLI failed');
-          Object.assign(error, { threadId: 'gemini-observed-error-1' });
-          throw error;
+      executeTurn: async () => {
+        call++;
+        if (call === 1) {
+          resolveFirst();
+          await new Promise((res) => setTimeout(res, 30));
+          order.push(1);
+        } else {
+          order.push(2);
         }
-        return {
-          output: 'Recovered',
-          cwd: '/workspace/project',
-          streamedActionsPersisted: false,
-          inferredActions: [],
-          threadId: 'gemini-observed-error-1',
-          threadIdSource: 'observed',
-        };
-      }),
+        return makeResult();
+      },
     });
 
-    await expect(runtime.sendTurn({
-      session: {
-        id: 'session-1',
-        metadata: {
-          flavor: 'gemini',
-          path: '/workspace/project',
-          approvalPolicy: 'on-request',
-        },
-      },
-      chatId: 'chat-1',
-      prompt: 'First turn',
-    })).rejects.toThrow('gemini CLI failed');
+    const session = makeSession();
 
-    await runtime.sendTurn({
-      session: {
-        id: 'session-1',
-        metadata: {
-          flavor: 'gemini',
-          path: '/workspace/project',
-          approvalPolicy: 'on-request',
-        },
+    const t1 = runtime.sendTurn({ session, prompt: 'first' });
+    await firstStarted;
+    const t2 = runtime.sendTurn({ session, prompt: 'second' });
+
+    await Promise.all([t1, t2]);
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('allows different session scopes to run concurrently', async () => {
+    const started: string[] = [];
+
+    const runtime = createGeminiRuntime({
+      executeTurn: async (req) => {
+        started.push(req.session.id);
+        await new Promise((res) => setTimeout(res, 20));
+        return makeResult();
       },
-      chatId: 'chat-1',
-      prompt: 'Retry turn',
     });
 
-    expect(preferredThreadIds).toEqual([undefined, 'gemini-observed-error-1']);
+    const t1 = runtime.sendTurn({ session: makeSession('sess-a'), prompt: 'a' });
+    const t2 = runtime.sendTurn({ session: makeSession('sess-b'), prompt: 'b' });
+
+    await t2;
+    expect(started).toContain('sess-b');
+    await t1;
+  });
+
+  it('isRunning returns true while turn is executing', async () => {
+    let resolveExec!: () => void;
+
+    const runtime = createGeminiRuntime({
+      executeTurn: async () => {
+        await new Promise<void>((res) => {
+          resolveExec = res;
+        });
+        return makeResult();
+      },
+    });
+
+    const session = makeSession();
+    const turn = runtime.sendTurn({ session, prompt: 'hi' });
+
+    await new Promise((res) => setTimeout(res, 5));
+    expect(runtime.isRunning({ sessionId: session.id, chatId: undefined })).toBe(true);
+
+    resolveExec();
+    await turn;
+    expect(runtime.isRunning({ sessionId: session.id, chatId: undefined })).toBe(false);
   });
 });

--- a/services/aris-backend/tests/scopeQueue.test.ts
+++ b/services/aris-backend/tests/scopeQueue.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { ScopeQueue } from '../src/runtime/scopeQueue.js';
+
+describe('ScopeQueue', () => {
+  it('runs a single task and returns its result', async () => {
+    const q = new ScopeQueue();
+    const result = await q.run('key-a', async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('serializes concurrent tasks for the same key', async () => {
+    const q = new ScopeQueue();
+    const order: number[] = [];
+
+    const t1 = q.run('key-a', async () => {
+      await new Promise((res) => setTimeout(res, 20));
+      order.push(1);
+    });
+    const t2 = q.run('key-a', async () => {
+      order.push(2);
+    });
+
+    await Promise.all([t1, t2]);
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('runs tasks for different keys concurrently', async () => {
+    const q = new ScopeQueue();
+    const started: string[] = [];
+
+    const t1 = q.run('key-a', async () => {
+      started.push('a');
+      await new Promise((res) => setTimeout(res, 20));
+    });
+    const t2 = q.run('key-b', async () => {
+      started.push('b');
+    });
+
+    await t2; // key-b should not wait for key-a
+    expect(started).toContain('b');
+    await t1;
+  });
+
+  it('isQueued returns true while a task is running', async () => {
+    const q = new ScopeQueue();
+
+    const task = q.run('key-a', async () => {
+      await new Promise((res) => setTimeout(res, 20));
+    });
+
+    await new Promise((res) => setTimeout(res, 5));
+    expect(q.isQueued('key-a')).toBe(true);
+    await task;
+    expect(q.isQueued('key-a')).toBe(false);
+  });
+
+  it('cleans up key after task completes', async () => {
+    const q = new ScopeQueue();
+    await q.run('key-a', async () => {});
+    expect(q.isQueued('key-a')).toBe(false);
+  });
+
+  it('propagates errors without blocking subsequent tasks', async () => {
+    const q = new ScopeQueue();
+    const results: string[] = [];
+
+    await expect(
+      q.run('key-a', async () => {
+        throw new Error('oops');
+      }),
+    ).rejects.toThrow('oops');
+
+    await q.run('key-a', async () => {
+      results.push('after error');
+    });
+    expect(results).toContain('after error');
+  });
+});

--- a/services/aris-backend/tests/worktreeManager.test.ts
+++ b/services/aris-backend/tests/worktreeManager.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process');
+
+import { resolveWorktreePath, ensureWorktree, sanitizeBranchName, computeWorktreePath } from '../src/runtime/worktreeManager.js';
+import * as childProcess from 'node:child_process';
+
+describe('sanitizeBranchName', () => {
+  it('replaces spaces and special chars with hyphens', () => {
+    expect(sanitizeBranchName('feat/my feature')).toBe('feat/my-feature');
+  });
+
+  it('replaces slashes kept but spaces removed', () => {
+    expect(sanitizeBranchName('feat my feature')).toBe('feat-my-feature');
+  });
+
+  it('strips leading and trailing hyphens', () => {
+    expect(sanitizeBranchName('--feat--')).toBe('feat');
+  });
+
+  it('throws on empty result', () => {
+    expect(() => sanitizeBranchName('   ')).toThrow();
+  });
+
+  it('preserves valid branch name characters', () => {
+    expect(sanitizeBranchName('feat/my-feature_v1.0')).toBe('feat/my-feature_v1.0');
+  });
+});
+
+describe('resolveWorktreePath', () => {
+  it('returns projectPath when branch is undefined', async () => {
+    const result = await resolveWorktreePath('/projects/my-app', undefined);
+    expect(result).toBe('/projects/my-app');
+  });
+
+  it('returns worktree path under .worktrees when branch is provided', async () => {
+    const result = await resolveWorktreePath('/projects/my-app', 'feat/my-feature');
+    expect(result).toBe('/projects/my-app/.worktrees/feat/my-feature');
+  });
+});
+
+describe('computeWorktreePath', () => {
+  it('returns projectPath when branch is undefined', () => {
+    expect(computeWorktreePath('/projects/my-app', undefined)).toBe('/projects/my-app');
+  });
+
+  it('returns worktree path for a branch', () => {
+    expect(computeWorktreePath('/projects/my-app', 'feat/my-feature')).toBe(
+      '/projects/my-app/.worktrees/feat/my-feature',
+    );
+  });
+});
+
+describe('ensureWorktree', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns projectPath immediately when branch is not provided', async () => {
+    const result = await ensureWorktree('/projects/my-app', undefined);
+    expect(result).toBe('/projects/my-app');
+    expect(childProcess.execFile).not.toHaveBeenCalled();
+  });
+});

--- a/services/aris-web/app/SessionDashboard.tsx
+++ b/services/aris-web/app/SessionDashboard.tsx
@@ -275,6 +275,7 @@ export function SessionDashboard({
   const [newPath, setNewPath] = useState('');
   const [newAgent, setNewAgent] = useState<AgentFlavor>('claude');
   const [newApprovalPolicy, setNewApprovalPolicy] = useState<SessionApprovalPolicy>('on-request');
+  const [newBranch, setNewBranch] = useState('');
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [mounted, setMounted] = useState(false);
@@ -599,6 +600,7 @@ export function SessionDashboard({
     pathInput: string,
     agentInput: AgentFlavor,
     approvalPolicyInput: SessionApprovalPolicy,
+    branchInput: string,
   ) {
     if (!isOperator) return;
     const path = sanitizePath(pathInput);
@@ -606,11 +608,12 @@ export function SessionDashboard({
 
     setError(null);
     setIsCreating(true);
+    const branch = branchInput.trim() || undefined;
     try {
       const response = await fetch('/api/runtime/sessions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path, agent: agentInput, approvalPolicy: approvalPolicyInput }),
+        body: JSON.stringify({ path, agent: agentInput, approvalPolicy: approvalPolicyInput, ...(branch ? { branch } : {}) }),
       });
       const body = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(body.error ?? '워크스페이스 생성에 실패했습니다.');
@@ -628,12 +631,13 @@ export function SessionDashboard({
 
   async function handleCreateSession(e: React.FormEvent) {
     e.preventDefault();
-    await createSession(newPath, newAgent, newApprovalPolicy);
+    await createSession(newPath, newAgent, newApprovalPolicy, newBranch);
   }
 
   function openCreateSessionModal() {
     setError(null);
     setNewPath('');
+    setNewBranch('');
     setIsBrowsing(true);
     setBrowserPath('/');
     setDirectories([]);
@@ -663,7 +667,7 @@ export function SessionDashboard({
       router.push(`/sessions/${entry.sessionId}`);
       return;
     }
-    await createSession(entry.path, entry.agent, entry.approvalPolicy);
+    await createSession(entry.path, entry.agent, entry.approvalPolicy, '');
   }
 
   function applyHistory(entry: PathHistoryEntry) {
@@ -1168,6 +1172,25 @@ export function SessionDashboard({
                     모든 권한 요청을 자동 허용합니다. 신뢰 가능한 프로젝트에서만 사용하세요.
                   </div>
                 )}
+              </div>
+
+              <div className="form-section">
+                <div className="section-header">
+                  <label className="section-label" htmlFor="new-branch-input">
+                    브랜치
+                    <span style={{ fontWeight: 400, color: 'var(--text-subtle)', textTransform: 'none', letterSpacing: 0, fontSize: '0.75rem' }}> (선택)</span>
+                  </label>
+                </div>
+                <input
+                  id="new-branch-input"
+                  type="text"
+                  className="input"
+                  placeholder="예: feat/my-feature (없으면 기본 경로 사용)"
+                  value={newBranch}
+                  onChange={(e) => setNewBranch(e.target.value)}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
               </div>
 
               {error && (

--- a/services/aris-web/app/api/runtime/sessions/route.ts
+++ b/services/aris-web/app/api/runtime/sessions/route.ts
@@ -54,10 +54,11 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { path, agent, approvalPolicy } = body as {
+    const { path, agent, approvalPolicy, branch } = body as {
       path?: string;
       agent?: string;
       approvalPolicy?: string;
+      branch?: string;
     };
     const normalizedPolicy = approvalPolicy === 'on-request'
       || approvalPolicy === 'on-failure'
@@ -80,7 +81,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ session: existing, reused: true });
     }
 
-    const session = await createSession({ path: normalizedPath, agent: normalizedAgent, approvalPolicy: normalizedPolicy });
+    const normalizedBranch = typeof branch === 'string' && branch.trim() ? branch.trim() : undefined;
+    const session = await createSession({ path: normalizedPath, agent: normalizedAgent, approvalPolicy: normalizedPolicy, branch: normalizedBranch });
     await syncWorkspacesForUser(auth.user.id, [session]);
     return NextResponse.json({ session, reused: false });
   } catch (error) {

--- a/services/aris-web/lib/happy/client.ts
+++ b/services/aris-web/lib/happy/client.ts
@@ -638,6 +638,7 @@ export async function createSession(input: {
   path: string;
   agent: SessionSummary['agent'];
   approvalPolicy?: ApprovalPolicy;
+  branch?: string;
 }): Promise<SessionSummary> {
   const raw = await fetchHappy('/v1/sessions', {
     method: 'POST',
@@ -645,6 +646,7 @@ export async function createSession(input: {
       path: input.path,
       flavor: input.agent,
       approvalPolicy: input.approvalPolicy ?? 'on-request',
+      ...(input.branch ? { branch: input.branch } : {}),
     }),
   });
 


### PR DESCRIPTION
## Summary

tunaPi 패턴 분석에서 도출한 Phase 2 개선사항 (F+H) 구현:

- **F - ScopeQueue (SessionLock)**: 동일 세션 스코프의 동시 sendTurn 호출을 직렬화. `geminiRuntime.ts`의 `runningScopes Set`을 `ScopeQueue`로 교체
- **H - Branch/Worktree**: 세션 생성 시 `branch` 필드를 받아 git worktree 자동 생성. `resolveExecutionCwd`가 worktree 경로를 반환

## 변경 파일

### F - ScopeQueue
- `src/runtime/scopeQueue.ts` (신규) — Promise 체인 기반 per-key 직렬화 유틸
- `src/runtime/providers/gemini/geminiRuntime.ts` — `runningScopes Set` → `ScopeQueue` 교체

### H - Branch/Worktree
- `src/types.ts` — `RuntimeSession.metadata.branch?: string` 추가
- `src/server.ts` — `createSessionSchema`에 `branch` 필드 추가, `resolveExecutionCwd`에 branch 전달
- `src/store.ts` — `CreateSessionInput.branch`, 세션 생성 후 `ensureWorktree` 호출, `resolveExecutionCwd(cwd, branch)` 시그니처 추가
- `src/runtime/prismaStore.ts` — `branch` 저장·복원
- `src/runtime/worktreeManager.ts` (신규) — `sanitizeBranchName`, `ensureWorktree`, `computeWorktreePath`
- `prisma/schema.prisma` — `Session.branch String?` 추가
- `prisma/migrations/0002_add_branch_to_session/migration.sql` (신규)

### Tests
- `tests/scopeQueue.test.ts` (신규) — 6개 유닛 테스트
- `tests/geminiRuntime.test.ts` (신규) — 직렬화 동작 검증 포함 3개 테스트
- `tests/worktreeManager.test.ts` (신규) — 10개 유닛 테스트 (git 명령 mock)

## Test plan
- [x] 전체 190개 테스트 통과
- [x] 기존 E2E 실패(pre-existing) 영향 없음 확인
- [x] 타입 체크 통과 (`tsc --noEmit`)

## 관련 문서
- `docs/superpowers/plans/2026-04-02-session-lock-and-branch-worktree.md`