### PR TITLE
fix(chat): avoid stale approval hint after decision

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -72,6 +72,7 @@ import type { AgentFlavor, ApprovalPolicy, PermissionRequest, SessionChat, UiEve
 import { ClaudeIcon, GeminiIcon, CodexIcon, GitLogoIcon, DockerLogoIcon } from '@/components/ui/AgentIcons';
 import { CustomizationSidebar } from './CustomizationSidebar';
 import { PermissionRequestMessage } from './PermissionRequestMessage';
+import { buildPermissionTimelineItems } from './chatTimeline';
 import styles from './ChatInterface.module.css';
 import dynamic from 'next/dynamic';
 import { resolveActiveChat, resolveNextSelectedChatId } from './chatSelection';
@@ -2536,7 +2537,12 @@ export function ChatInterface({
     () => mergedDisplayPermissions.filter((permission) => permission.state === 'pending'),
     [mergedDisplayPermissions],
   );
-  const deferredDisplayPermissions = useDeferredValue(mergedDisplayPermissions);
+  // Permission decisions must surface immediately; deferring this list can
+  // briefly re-render stale pending state and show the wrong hint.
+  const permissionTimelineItems = useMemo(
+    () => buildPermissionTimelineItems(mergedDisplayPermissions),
+    [mergedDisplayPermissions],
+  );
   const streamItems = useMemo(
     () => buildStreamRenderItems(deferredVisibleEvents, expandedActionRunIds),
     [deferredVisibleEvents, expandedActionRunIds],
@@ -2544,7 +2550,6 @@ export function ChatInterface({
   const timelineItems = useMemo<TimelineRenderItem[]>(() => {
     const merged: TimelineRenderItem[] = [];
     let order = 0;
-    const fallbackBase = Number.MAX_SAFE_INTEGER / 8;
 
     for (const item of streamItems) {
       const timestamp = item.type === 'event' ? item.event.timestamp : item.timestamp;
@@ -2552,19 +2557,16 @@ export function ChatInterface({
       merged.push({
         type: 'stream',
         item,
-        sortKey: Number.isFinite(parsed) ? parsed : fallbackBase + order,
+        sortKey: Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER / 8 + order,
         order,
       });
       order += 1;
     }
 
     if (showPermissionQueue) {
-      for (const permission of deferredDisplayPermissions) {
-        const parsed = Date.parse(permission.requestedAt);
+      for (const permission of permissionTimelineItems) {
         merged.push({
-          type: 'permission',
-          permission,
-          sortKey: Number.isFinite(parsed) ? parsed : fallbackBase + order,
+          ...permission,
           order,
         });
         order += 1;
@@ -2577,7 +2579,7 @@ export function ChatInterface({
       }
       return a.order - b.order;
     });
-  }, [deferredDisplayPermissions, showPermissionQueue, streamItems]);
+  }, [permissionTimelineItems, showPermissionQueue, streamItems]);
   const firstPendingPermissionId = effectivePendingPermissions[0]?.id ?? null;
   const runPhase: ChatRunPhase = resolveRunPhaseState({
     isAborting,

--- a/services/aris-web/app/sessions/[sessionId]/chatTimeline.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chatTimeline.ts
@@ -1,0 +1,22 @@
+import type { RenderablePermissionRequest } from '@/lib/happy/permissions';
+
+const TIMELINE_FALLBACK_BASE = Number.MAX_SAFE_INTEGER / 8;
+
+export type PermissionTimelineItem = {
+  type: 'permission';
+  permission: RenderablePermissionRequest;
+  sortKey: number;
+  order: number;
+};
+
+export function buildPermissionTimelineItems(permissions: RenderablePermissionRequest[]): PermissionTimelineItem[] {
+  return permissions.map((permission, order) => {
+    const parsed = Date.parse(permission.requestedAt);
+    return {
+      type: 'permission',
+      permission,
+      sortKey: Number.isFinite(parsed) ? parsed : TIMELINE_FALLBACK_BASE + order,
+      order,
+    };
+  });
+}

--- a/services/aris-web/tests/chatTimeline.test.ts
+++ b/services/aris-web/tests/chatTimeline.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { RenderablePermissionRequest } from '@/lib/happy/permissions';
+import { buildPermissionTimelineItems } from '@/app/sessions/[sessionId]/chatTimeline';
+
+function buildPermission(overrides: Partial<RenderablePermissionRequest> = {}): RenderablePermissionRequest {
+  return {
+    id: overrides.id ?? 'perm-1',
+    sessionId: overrides.sessionId ?? 'session-1',
+    ...(overrides.chatId ? { chatId: overrides.chatId } : {}),
+    agent: overrides.agent ?? 'gemini',
+    command: overrides.command ?? 'Run pwd',
+    reason: overrides.reason ?? 'Need shell access',
+    risk: overrides.risk ?? 'medium',
+    requestedAt: overrides.requestedAt ?? '2026-03-15T00:00:00.000Z',
+    state: overrides.state ?? 'approved',
+    availability: overrides.availability ?? 'persisted',
+  };
+}
+
+describe('buildPermissionTimelineItems', () => {
+  it('keeps approved permissions in the timeline without reclassifying them as pending', () => {
+    const items = buildPermissionTimelineItems([
+      buildPermission({ state: 'approved' }),
+    ]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      type: 'permission',
+      permission: {
+        id: 'perm-1',
+        state: 'approved',
+        availability: 'persisted',
+      },
+    });
+  });
+});


### PR DESCRIPTION
승인 직후 권한 요청 카드가 stale pending 스냅샷을 잠깐 렌더하던 문제를 수정했습니다.\n\n- 권한 타임라인은 즉시 렌더하도록 변경\n- 회귀 테스트 추가\n- 전체 스위트에서 확인된 별도 sessionEvents 실패는 issue #144로 분리