### PR TITLE
채팅 목록 완료 상태가 읽음 이후 해제되도록 수정

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -74,6 +74,7 @@ import { ClaudeIcon, GeminiIcon, CodexIcon, GitLogoIcon, DockerLogoIcon } from '
 import { CustomizationSidebar } from './CustomizationSidebar';
 import { PermissionRequestMessage } from './PermissionRequestMessage';
 import { buildPermissionTimelineItems } from './chatTimeline';
+import { resolveNextChatReadMarker } from './chatSidebar';
 import styles from './ChatInterface.module.css';
 import dynamic from 'next/dynamic';
 import { resolveActiveChat, resolveNextSelectedChatId } from './chatSelection';
@@ -3178,15 +3179,21 @@ export function ChatInterface({
       return;
     }
     const latestEvent = getLatestVisibleEvent(visibleEvents);
-    if (!latestEvent || showScrollToBottom) {
+    const nextReadMarker = resolveNextChatReadMarker({
+      activeChatId: activeChatIdResolved,
+      eventsForChatId,
+      latestEventId: latestEvent?.id ?? null,
+      hasScrollToBottomButton: showScrollToBottom,
+    });
+    if (!nextReadMarker) {
       return;
     }
     setChatReadMarkers((prev) => (
-      prev[activeChatIdResolved] === latestEvent.id
+      prev[activeChatIdResolved] === nextReadMarker
         ? prev
       : {
           ...prev,
-          [activeChatIdResolved]: latestEvent.id,
+          [activeChatIdResolved]: nextReadMarker,
         }
     ));
   }, [activeChatIdResolved, eventsForChatId, showScrollToBottom, visibleEvents]);

--- a/services/aris-web/app/sessions/[sessionId]/chatSidebar.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chatSidebar.ts
@@ -1,0 +1,15 @@
+type ResolveNextChatReadMarkerInput = {
+  activeChatId: string | null;
+  eventsForChatId: string | null;
+  latestEventId: string | null | undefined;
+  hasScrollToBottomButton?: boolean;
+};
+
+export function resolveNextChatReadMarker(input: ResolveNextChatReadMarkerInput): string | null {
+  if (!input.activeChatId || input.eventsForChatId !== input.activeChatId) {
+    return null;
+  }
+
+  const latestEventId = typeof input.latestEventId === 'string' ? input.latestEventId.trim() : '';
+  return latestEventId || null;
+}

--- a/services/aris-web/tests/chatSidebarReadMarker.test.ts
+++ b/services/aris-web/tests/chatSidebarReadMarker.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { resolveNextChatReadMarker } from '@/app/sessions/[sessionId]/chatSidebar';
+
+describe('resolveNextChatReadMarker', () => {
+  it('marks the active chat as read even when the scroll-to-bottom button is visible', () => {
+    expect(
+      resolveNextChatReadMarker({
+        activeChatId: 'chat-1',
+        eventsForChatId: 'chat-1',
+        latestEventId: 'evt-2',
+        hasScrollToBottomButton: true,
+      }),
+    ).toBe('evt-2');
+  });
+});


### PR DESCRIPTION
## 요약\n- 활성 채팅의 읽음 마커 갱신을 스크롤 버튼 상태와 분리했습니다.\n- 완료 상태가 읽음 이후에도 남는 문제를 막기 위한 회귀 테스트를 추가했습니다.\n\n## 검증\n- npm test -- tests/chatSidebarReadMarker.test.ts tests/chatSidebarRoute.test.ts tests/chatSelection.test.ts\n- npm run lint\n- npx tsc --noEmit --pretty false