### PR TITLE
채팅 목록 메뉴에 읽음 처리 추가

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -74,7 +74,7 @@ import { ClaudeIcon, GeminiIcon, CodexIcon, GitLogoIcon, DockerLogoIcon } from '
 import { CustomizationSidebar } from './CustomizationSidebar';
 import { PermissionRequestMessage } from './PermissionRequestMessage';
 import { buildPermissionTimelineItems } from './chatTimeline';
-import { resolveNextChatReadMarker } from './chatSidebar';
+import { resolveChatReadMarkerId } from './chatSidebar';
 import styles from './ChatInterface.module.css';
 import dynamic from 'next/dynamic';
 import { resolveActiveChat, resolveNextSelectedChatId } from './chatSelection';
@@ -2714,6 +2714,25 @@ export function ChatInterface({
     });
   }, []);
 
+  const handleMarkChatAsRead = useCallback((chat: SessionChat) => {
+    const nextReadMarker = resolveChatReadMarkerId({
+      latestEventId: chatSidebarSnapshots[chat.id]?.latestEventId,
+      fallbackLatestEventId: chat.latestEventId,
+    });
+    if (!nextReadMarker) {
+      return;
+    }
+
+    setChatReadMarkers((prev) => (
+      prev[chat.id] === nextReadMarker
+        ? prev
+      : {
+          ...prev,
+          [chat.id]: nextReadMarker,
+        }
+    ));
+  }, [chatSidebarSnapshots]);
+
   const scheduleApprovalFeedbackReset = useCallback((chatId: string) => {
     const currentTimer = approvalFeedbackTimersRef.current[chatId];
     if (currentTimer) {
@@ -3179,11 +3198,9 @@ export function ChatInterface({
       return;
     }
     const latestEvent = getLatestVisibleEvent(visibleEvents);
-    const nextReadMarker = resolveNextChatReadMarker({
-      activeChatId: activeChatIdResolved,
-      eventsForChatId,
-      latestEventId: latestEvent?.id ?? null,
-      hasScrollToBottomButton: showScrollToBottom,
+    const nextReadMarker = resolveChatReadMarkerId({
+      latestEventId: latestEvent?.id,
+      fallbackLatestEventId: chatSidebarSnapshots[activeChatIdResolved]?.latestEventId,
     });
     if (!nextReadMarker) {
       return;
@@ -3196,7 +3213,7 @@ export function ChatInterface({
           [activeChatIdResolved]: nextReadMarker,
         }
     ));
-  }, [activeChatIdResolved, eventsForChatId, showScrollToBottom, visibleEvents]);
+  }, [activeChatIdResolved, chatSidebarSnapshots, eventsForChatId, visibleEvents]);
 
   useEffect(() => {
     if (!activeChatIdResolved) {
@@ -5132,6 +5149,22 @@ export function ChatInterface({
                                         zIndex: 9999,
                                       }}
                                     >
+                                      <button
+                                        type="button"
+                                        className={styles.chatListMenuItem}
+                                        onClick={() => {
+                                          handleMarkChatAsRead(chat);
+                                          setChatActionMenuId(null);
+                                          setChatActionMenuRect(null);
+                                        }}
+                                        disabled={!resolveChatReadMarkerId({
+                                          latestEventId: chatSidebarSnapshots[chat.id]?.latestEventId,
+                                          fallbackLatestEventId: chat.latestEventId,
+                                        })}
+                                      >
+                                        <CheckCircle2 size={14} />
+                                        읽음 처리
+                                      </button>
                                       <button
                                         type="button"
                                         className={styles.chatListMenuItem}

--- a/services/aris-web/app/sessions/[sessionId]/chatSidebar.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chatSidebar.ts
@@ -1,15 +1,14 @@
-type ResolveNextChatReadMarkerInput = {
-  activeChatId: string | null;
-  eventsForChatId: string | null;
-  latestEventId: string | null | undefined;
-  hasScrollToBottomButton?: boolean;
+type ResolveChatReadMarkerIdInput = {
+  latestEventId?: string | null;
+  fallbackLatestEventId?: string | null;
 };
 
-export function resolveNextChatReadMarker(input: ResolveNextChatReadMarkerInput): string | null {
-  if (!input.activeChatId || input.eventsForChatId !== input.activeChatId) {
-    return null;
+export function resolveChatReadMarkerId(input: ResolveChatReadMarkerIdInput): string | null {
+  const primary = typeof input.latestEventId === 'string' ? input.latestEventId.trim() : '';
+  if (primary) {
+    return primary;
   }
 
-  const latestEventId = typeof input.latestEventId === 'string' ? input.latestEventId.trim() : '';
-  return latestEventId || null;
+  const fallback = typeof input.fallbackLatestEventId === 'string' ? input.fallbackLatestEventId.trim() : '';
+  return fallback || null;
 }

--- a/services/aris-web/tests/chatSidebarReadMarker.test.ts
+++ b/services/aris-web/tests/chatSidebarReadMarker.test.ts
@@ -1,15 +1,22 @@
 import { describe, expect, it } from 'vitest';
-import { resolveNextChatReadMarker } from '@/app/sessions/[sessionId]/chatSidebar';
+import { resolveChatReadMarkerId } from '@/app/sessions/[sessionId]/chatSidebar';
 
-describe('resolveNextChatReadMarker', () => {
-  it('marks the active chat as read even when the scroll-to-bottom button is visible', () => {
+describe('resolveChatReadMarkerId', () => {
+  it('uses the latest event id when available', () => {
     expect(
-      resolveNextChatReadMarker({
-        activeChatId: 'chat-1',
-        eventsForChatId: 'chat-1',
+      resolveChatReadMarkerId({
         latestEventId: 'evt-2',
-        hasScrollToBottomButton: true,
+        fallbackLatestEventId: 'evt-1',
       }),
     ).toBe('evt-2');
+  });
+
+  it('falls back to the cached latest event id when needed', () => {
+    expect(
+      resolveChatReadMarkerId({
+        latestEventId: null,
+        fallbackLatestEventId: 'evt-1',
+      }),
+    ).toBe('evt-1');
   });
 });


### PR DESCRIPTION
## 요약\n- 채팅 목록 우측 메뉴에 를 추가했습니다.\n- 최신 이벤트 ID 또는 캐시된 최신 이벤트 ID를 읽음 마커로 저장하도록 처리했습니다.\n- 회귀 테스트를 추가했습니다.\n\n## 검증\n- npm test -- tests/chatSidebarReadMarker.test.ts tests/chatSidebarRoute.test.ts tests/chatSelection.test.ts\n- npm run lint\n- npx tsc --noEmit --pretty false