### PR TITLE
채팅 전환 시 오버레이 로딩 표시

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -1141,6 +1141,53 @@
   overflow: visible;
 }
 
+.chatTransitionOverlay {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.22) 0%, rgba(241, 245, 249, 0.16) 100%);
+  backdrop-filter: blur(2px);
+}
+
+:global(html[data-theme='dark']) .chatTransitionOverlay {
+  background: linear-gradient(180deg, rgba(2, 6, 23, 0.32) 0%, rgba(15, 23, 42, 0.22) 100%);
+}
+
+.chatTransitionCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.85rem;
+  min-width: min(280px, 84vw);
+  padding: 1.1rem 1.35rem 1.25rem;
+  border-radius: 1.5rem;
+  border: 1px solid var(--chat-popover-border);
+  background: var(--chat-popover-bg);
+  box-shadow: var(--chat-popover-shadow);
+}
+
+.chatTransitionLogo {
+  width: 72px;
+  height: 72px;
+  border-radius: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+}
+
+.chatTransitionMessage {
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--chat-text-primary);
+  text-align: center;
+}
+
 .centerHeader {
   display: flex;
   align-items: center;

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -75,7 +75,6 @@ import { CustomizationSidebar } from './CustomizationSidebar';
 import { PermissionRequestMessage } from './PermissionRequestMessage';
 import { buildPermissionTimelineItems } from './chatTimeline';
 import { resolveChatReadMarkerId } from './chatSidebar';
-import { SessionLoading } from './SessionLoading';
 import styles from './ChatInterface.module.css';
 import dynamic from 'next/dynamic';
 import {
@@ -5457,13 +5456,13 @@ export function ChatInterface({
             </div>
           </header>
 
-          {!showChatTransitionLoading && runtimeNotice && (
+          {runtimeNotice && (
             <div className={styles.noticeWrap}>
               <BackendNotice message={`백엔드 연결 상태: ${runtimeNotice}`} />
             </div>
           )}
 
-          {!showChatTransitionLoading && showDisconnectRetry && (
+          {showDisconnectRetry && (
             <div className={styles.disconnectNoticeBar} role="status" aria-live="polite">
               <span>에이전트 연결이 중단되었습니다.</span>
               <button
@@ -5479,7 +5478,7 @@ export function ChatInterface({
             </div>
           )}
 
-          {!showChatTransitionLoading && effectivePendingPermissions.length > 0 && (
+          {effectivePendingPermissions.length > 0 && (
             <div className={styles.permissionNoticeBar} role="status" aria-live="polite">
               <span>
                 승인 요청 {effectivePendingPermissions.length}건이 대기 중입니다.
@@ -5491,10 +5490,7 @@ export function ChatInterface({
             </div>
           )}
 
-          {showChatTransitionLoading ? (
-            <SessionLoading variant="panel" />
-          ) : (
-            <>
+          <>
           <div className={`${styles.stream} ${isMobileLayout ? styles.streamMobileScroll : ''}`} ref={scrollRef} onScroll={handleStreamScroll}>
             {isNewChatPlaceholder ? (
               <div className={styles.agentSelectorContainer}>
@@ -5906,8 +5902,18 @@ export function ChatInterface({
               </div>
             </form>
           </footer>
-            </>
-          )}
+
+            {showChatTransitionLoading && (
+              <div className={styles.chatTransitionOverlay} role="status" aria-live="polite" aria-busy="true">
+                <div className={styles.chatTransitionCard}>
+                  <div className={`${styles.chatTransitionLogo} ${getAgentAvatarToneClass(agentMeta.tone)}`}>
+                    <agentMeta.Icon size={34} />
+                  </div>
+                  <div className={styles.chatTransitionMessage}>에이전트 채팅 로딩중…</div>
+                </div>
+              </div>
+            )}
+          </>
         </section>
       </main>
 


### PR DESCRIPTION
## 요약
- 채팅 전환 중 기존 UI는 유지하고, 가운데에 에이전트 로고와 로딩 문구를 덮어씌우도록 바꿨습니다.
- 채팅 UI와 상태 배너는 그대로 보이도록 했습니다.
- 전환 로딩 분기 로직에 대한 테스트를 유지했습니다.

## 검증
- npm test -- tests/chatSelection.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false