### PR TITLE
채팅 전환 오버레이 로딩 디자인 개선

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -1146,38 +1146,43 @@
   inset: 0;
   z-index: 20;
   display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: #fff;
+}
+
+.chatTransitionOrb {
+  position: relative;
+  width: 96px;
+  height: 96px;
+  display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1.25rem;
-  background: linear-gradient(180deg, rgba(248, 250, 252, 0.22) 0%, rgba(241, 245, 249, 0.16) 100%);
-  backdrop-filter: blur(2px);
 }
 
-:global(html[data-theme='dark']) .chatTransitionOverlay {
-  background: linear-gradient(180deg, rgba(2, 6, 23, 0.32) 0%, rgba(15, 23, 42, 0.22) 100%);
-}
-
-.chatTransitionCard {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.85rem;
-  min-width: min(280px, 84vw);
-  padding: 1.1rem 1.35rem 1.25rem;
-  border-radius: 1.5rem;
-  border: 1px solid var(--chat-popover-border);
-  background: var(--chat-popover-bg);
-  box-shadow: var(--chat-popover-shadow);
+.chatTransitionSpinner {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 4px solid rgba(148, 163, 184, 0.22);
+  border-top-color: var(--chat-transition-accent, var(--chat-accent));
+  animation: chatTransitionSpin 1s linear infinite;
 }
 
 .chatTransitionLogo {
   width: 72px;
   height: 72px;
-  border-radius: 1.5rem;
+  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  background: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  color: var(--chat-transition-accent, var(--chat-accent));
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
 }
 
 .chatTransitionMessage {
@@ -1186,6 +1191,15 @@
   letter-spacing: -0.01em;
   color: var(--chat-text-primary);
   text-align: center;
+}
+
+@keyframes chatTransitionSpin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .centerHeader {

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -5904,13 +5904,20 @@ export function ChatInterface({
           </footer>
 
             {showChatTransitionLoading && (
-              <div className={styles.chatTransitionOverlay} role="status" aria-live="polite" aria-busy="true">
-                <div className={styles.chatTransitionCard}>
-                  <div className={`${styles.chatTransitionLogo} ${getAgentAvatarToneClass(agentMeta.tone)}`}>
+              <div
+                className={styles.chatTransitionOverlay}
+                role="status"
+                aria-live="polite"
+                aria-busy="true"
+                style={{ '--chat-transition-accent': `var(--agent-${activeAgentFlavor}-accent)` } as React.CSSProperties}
+              >
+                <div className={styles.chatTransitionOrb}>
+                  <span className={styles.chatTransitionSpinner} aria-hidden="true" />
+                  <div className={styles.chatTransitionLogo}>
                     <agentMeta.Icon size={34} />
                   </div>
-                  <div className={styles.chatTransitionMessage}>에이전트 채팅 로딩중…</div>
                 </div>
+                <div className={styles.chatTransitionMessage}>에이전트 채팅 로딩중…</div>
               </div>
             )}
           </>


### PR DESCRIPTION
## 변경 사항\n- 채팅 전환 중 기존 채팅 UI는 유지하고, 중앙에 에이전트 로고와 스피너를 표시\n- 배경 블러를 제거하고 흰 배경 오버레이로 변경\n- 새 채팅 예시 질문이 로딩 중 노출되지 않도록 유지\n\n## 확인\n-  통과\n-  통과