### PR TITLE
refactor(chat): 사이드바 스냅샷을 이벤트 스트림 기반으로 전환

### DIFF
--- a/services/aris-backend/src/runtime/prismaStore.ts
+++ b/services/aris-backend/src/runtime/prismaStore.ts
@@ -150,6 +150,98 @@ export function resolveChatRunningState<
   return false;
 }
 
+// ── Chat snapshot derivation from event stream ──
+
+type MessageRow = {
+  id: string;
+  text: string;
+  meta: unknown;
+  createdAt: Date;
+};
+
+const TERMINAL_RUN_STATUSES = new Set([
+  'completed', 'failed', 'aborted', 'timed_out', 'turn_incomplete', 'run_stale_cleanup',
+]);
+
+function readMetaString(meta: unknown, key: string): string {
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return '';
+  const value = (meta as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function isRunLifecycleMessage(meta: unknown): boolean {
+  return readMetaString(meta, 'streamEvent') === 'run_status';
+}
+
+function deriveErrorSignalFromMeta(meta: unknown): boolean {
+  const streamEvent = readMetaString(meta, 'streamEvent');
+  if (streamEvent === 'runtime_disconnected' || streamEvent === 'stream_error' || streamEvent === 'runtime_error') {
+    return true;
+  }
+  if (streamEvent === 'run_status') {
+    const runStatus = readMetaString(meta, 'runStatus')
+      || readMetaString(meta, 'sessionTurnStatus');
+    return TERMINAL_RUN_STATUSES.has(runStatus) && runStatus !== 'completed';
+  }
+  return false;
+}
+
+export type ChatSnapshot = {
+  chatId: string;
+  preview: string;
+  hasEvents: boolean;
+  hasErrorSignal: boolean;
+  latestEventId: string | null;
+  latestEventAt: string | null;
+  latestEventIsUser: boolean;
+  isRunning: boolean;
+};
+
+function deriveSnapshotFromRows(rows: MessageRow[], chatId: string): ChatSnapshot {
+  const chatRows = filterRealtimeRowsByChat(rows, chatId);
+  const isRunning = resolveChatRunningState(rows, chatId);
+
+  // Find latest non-lifecycle event for preview/snapshot fields
+  let latestVisible: MessageRow | null = null;
+  for (let i = chatRows.length - 1; i >= 0; i -= 1) {
+    if (!isRunLifecycleMessage(chatRows[i].meta)) {
+      latestVisible = chatRows[i];
+      break;
+    }
+  }
+
+  // Error signal from the absolute latest event (including lifecycle)
+  const latestEvent = chatRows.length > 0 ? chatRows[chatRows.length - 1] : null;
+  const hasErrorSignal = latestEvent ? deriveErrorSignalFromMeta(latestEvent.meta) : false;
+
+  if (!latestVisible) {
+    return {
+      chatId,
+      preview: '',
+      hasEvents: false,
+      hasErrorSignal,
+      latestEventId: null,
+      latestEventAt: null,
+      latestEventIsUser: false,
+      isRunning,
+    };
+  }
+
+  const role = readMetaString(latestVisible.meta, 'role');
+  const preview = (latestVisible.text || '').slice(0, 240).split('\n')[0] || '';
+
+  return {
+    chatId,
+    preview,
+    hasEvents: true,
+    hasErrorSignal,
+    latestEventId: latestVisible.id,
+    latestEventAt: latestVisible.createdAt.toISOString(),
+    latestEventIsUser: role === 'user',
+    isRunning,
+  };
+}
+
 function toPermissionRequest(row: {
   id: string;
   sessionId: string;
@@ -451,6 +543,26 @@ export class PrismaRuntimeStore {
       },
     });
     return toPermissionRequest(row);
+  }
+
+  async getChatSnapshots(sessionId: string, chatIds: string[]): Promise<ChatSnapshot[]> {
+    const normalizedChatIds = chatIds
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0);
+    if (normalizedChatIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.db.sessionMessage.findMany({
+      where: { sessionId },
+      orderBy: { seq: 'asc' },
+      take: 200,
+      select: { id: true, text: true, meta: true, createdAt: true },
+    });
+
+    return normalizedChatIds.map((chatId) =>
+      deriveSnapshotFromRows(rows as MessageRow[], chatId),
+    );
   }
 
   resolveExecutionCwd(cwdHint?: string): string {

--- a/services/aris-backend/src/server.ts
+++ b/services/aris-backend/src/server.ts
@@ -442,6 +442,27 @@ export function buildServer(config: ServerConfig) {
     }
   });
 
+  app.get('/v1/sessions/:sessionId/chats/snapshots', async (request, reply) => {
+    const { sessionId } = request.params as { sessionId: string };
+    const { chatId } = request.query as { chatId?: string | string[] };
+    const chatIds = (Array.isArray(chatId) ? chatId : (chatId ?? '').split(','))
+      .map((id) => id.trim())
+      .filter(Boolean);
+    if (chatIds.length === 0) {
+      return { snapshots: [] };
+    }
+    try {
+      const snapshots = await store.getChatSnapshots(sessionId, chatIds);
+      return { snapshots };
+    } catch (error) {
+      if (error instanceof Error && error.message === 'SESSION_NOT_FOUND') {
+        return reply.code(404).send({ error: 'Session not found' });
+      }
+      const message = toErrorMessage(error, 'Failed to load chat snapshots');
+      return reply.code(502).send({ error: message });
+    }
+  });
+
   app.get('/v1/sessions/:sessionId/providers/gemini/capabilities', async (request, reply) => {
     const { sessionId } = request.params as { sessionId: string };
     try {

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -11,7 +11,7 @@ import type {
   SessionStatus,
 } from './types.js';
 import { HappyRuntimeStore } from './runtime/happyClient.js';
-import { PrismaRuntimeStore } from './runtime/prismaStore.js';
+import { PrismaRuntimeStore, type ChatSnapshot } from './runtime/prismaStore.js';
 import { computeWorktreePath, ensureWorktree } from './runtime/worktreeManager.js';
 
 type RuntimeBackend = 'mock' | 'happy' | 'prisma';
@@ -64,6 +64,7 @@ interface RuntimeStoreBackend {
   appendMessage(sessionId: string, input: AppendMessageInput): Promise<RuntimeMessage>;
   applySessionAction(sessionId: string, action: SessionAction, chatId?: string): Promise<{ accepted: boolean; message: string; at: string }>;
   isSessionRunning(sessionId: string, chatId?: string): Promise<boolean>;
+  getChatSnapshots?(sessionId: string, chatIds: string[]): Promise<ChatSnapshot[]>;
   listPermissions(state?: PermissionRequest['state']): Promise<PermissionRequest[]>;
   createPermission(input: CreatePermissionInput): Promise<PermissionRequest>;
   decidePermission(permissionId: string, decision: PermissionDecision): Promise<PermissionRequest>;
@@ -482,6 +483,13 @@ export class RuntimeStore {
       return this.runtimeExecutor.isSessionRunning(sessionId, chatId);
     }
     return this.delegate.isSessionRunning(sessionId, chatId);
+  }
+
+  async getChatSnapshots(sessionId: string, chatIds: string[]): Promise<ChatSnapshot[]> {
+    if (this.delegate.getChatSnapshots) {
+      return this.delegate.getChatSnapshots(sessionId, chatIds);
+    }
+    return [];
   }
 
   async listPermissions(state?: PermissionRequest['state']) {

--- a/services/aris-web/app/api/runtime/sessions/[sessionId]/chats/sidebar/route.ts
+++ b/services/aris-web/app/api/runtime/sessions/[sessionId]/chats/sidebar/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireApiUser } from '@/lib/auth/guard';
 import { listSessionChats } from '@/lib/happy/chats';
-import { getSessionRuntimeState } from '@/lib/happy/client';
+import { getChatSnapshots } from '@/lib/happy/client';
+import type { SessionChat } from '@/lib/happy/types';
 
 function parseRequestedChatIds(request: NextRequest): string[] {
   const all = request.nextUrl.searchParams.getAll('chatId')
@@ -18,6 +19,24 @@ function parseActiveChatId(request: NextRequest): string | null {
   }
   const trimmed = raw.trim();
   return trimmed || null;
+}
+
+function buildFallbackSnapshot(chatId: string, cached: SessionChat | undefined) {
+  return {
+    chatId,
+    preview: typeof cached?.latestPreview === 'string' ? cached.latestPreview : '',
+    hasEvents: Boolean(
+      (typeof cached?.latestEventId === 'string' && cached.latestEventId.trim().length > 0)
+      || (typeof cached?.latestPreview === 'string' && cached.latestPreview.trim().length > 0)
+    ),
+    hasErrorSignal: Boolean(cached?.latestHasErrorSignal),
+    latestEventId: typeof cached?.latestEventId === 'string' && cached.latestEventId.trim().length > 0
+      ? cached.latestEventId.trim()
+      : null,
+    latestEventAt: cached?.latestEventAt ?? null,
+    latestEventIsUser: Boolean(cached?.latestEventIsUser),
+    isRunning: false,
+  };
 }
 
 export async function GET(
@@ -45,37 +64,26 @@ export async function GET(
       return NextResponse.json({ snapshots: [] });
     }
 
-    const chatMap = new Map(chats.map((chat) => [chat.id, chat]));
-    const runtimeTargetChatIds = targetChatIds.filter((chatId) => chatId === activeChatId);
-    const runningByChat = Object.fromEntries(
-      await Promise.all(runtimeTargetChatIds.map(async (chatId) => {
-        try {
-          const runtime = await getSessionRuntimeState(sessionId, { chatId });
-          return [chatId, runtime.isRunning] as const;
-        } catch {
-          return [chatId, false] as const;
+    // Primary: derive snapshots from backend event stream
+    const backendSnapshots = await getChatSnapshots(sessionId, targetChatIds);
+    if (backendSnapshots && backendSnapshots.length > 0) {
+      const snapshotMap = new Map(backendSnapshots.map((s) => [s.chatId, s]));
+      const chatMap = new Map(chats.map((chat) => [chat.id, chat]));
+      const snapshots = targetChatIds.map((chatId) => {
+        const fromBackend = snapshotMap.get(chatId);
+        if (fromBackend) {
+          return fromBackend;
         }
-      }))
-    );
+        return buildFallbackSnapshot(chatId, chatMap.get(chatId));
+      });
+      return NextResponse.json({ snapshots });
+    }
 
-    const snapshots = targetChatIds.map((chatId) => {
-      const cached = chatMap.get(chatId);
-      return {
-        chatId,
-        preview: typeof cached?.latestPreview === 'string' ? cached.latestPreview : '',
-        hasEvents: Boolean(
-          (typeof cached?.latestEventId === 'string' && cached.latestEventId.trim().length > 0)
-          || (typeof cached?.latestPreview === 'string' && cached.latestPreview.trim().length > 0)
-        ),
-        hasErrorSignal: Boolean(cached?.latestHasErrorSignal),
-        latestEventId: typeof cached?.latestEventId === 'string' && cached.latestEventId.trim().length > 0
-          ? cached.latestEventId.trim()
-          : null,
-        latestEventAt: cached?.latestEventAt ?? null,
-        latestEventIsUser: Boolean(cached?.latestEventIsUser),
-        isRunning: Boolean(runningByChat[chatId]),
-      };
-    });
+    // Fallback: derive from cached SessionChat fields (rolling deploy safety)
+    const chatMap = new Map(chats.map((chat) => [chat.id, chat]));
+    const snapshots = targetChatIds.map((chatId) =>
+      buildFallbackSnapshot(chatId, chatMap.get(chatId)),
+    );
 
     return NextResponse.json({ snapshots });
   } catch (error) {

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -137,7 +137,6 @@ function getFileIcon(name: string, isDirectory: boolean): React.ReactNode {
 const COMPOSER_MAX_HEIGHT_PX = 180;
 const ACTION_COLLAPSE_THRESHOLD = 4;
 const READ_CURSOR_SYNC_DEBOUNCE_MS = 2000;
-const SNAPSHOT_SYNC_DEBOUNCE_MS = 1500;
 const SIDEBAR_CHAT_PAGE_SIZE = 7;
 const SIDEBAR_APPROVAL_FEEDBACK_MS = 3000;
 const SIDEBAR_STATUS_REFRESH_MS = 10000;
@@ -807,17 +806,6 @@ function buildReadMarkerMap(chats: SessionChat[]): Record<string, string> {
     }
   }
   return markers;
-}
-
-function buildSnapshotSyncMap(chats: SessionChat[]): Record<string, string> {
-  const synced: Record<string, string> = {};
-  for (const chat of chats) {
-    const latestEventId = typeof chat.latestEventId === 'string' ? chat.latestEventId.trim() : '';
-    if (latestEventId) {
-      synced[chat.id] = latestEventId;
-    }
-  }
-  return synced;
 }
 
 function buildSnapshotFromChat(chat: SessionChat): ChatSidebarSnapshot | null {
@@ -2576,12 +2564,10 @@ export function ChatInterface({
   const chatSidebarFetchInFlightRef = useRef<Record<string, boolean>>({});
   const readMarkerSyncInFlightRef = useRef<Record<string, boolean>>({});
   const readMarkerSyncedRef = useRef<Record<string, string>>(buildReadMarkerMap(initialChats));
-  const snapshotSyncInFlightRef = useRef<Record<string, boolean>>({});
   const sidebarFileRequestNonceRef = useRef(0);
   const isRightSidebarPinnedLayout = !isMobileLayout && (viewportWidth > CUSTOMIZATION_OVERLAY_MAX_WIDTH_PX || isCustomizationPinned);
   const isLeftSidebarOverlayLayout = isMobileLayout
     || (isRightSidebarPinnedLayout && viewportWidth < RIGHT_PIN_PREFERS_LEFT_OVERLAY_MIN_WIDTH_PX);
-  const snapshotSyncedEventRef = useRef<Record<string, string>>(buildSnapshotSyncMap(initialChats));
 
   const defaultAgentFlavor = normalizeAgentFlavor(agentFlavor, 'codex');
   const providerSelections = modelSettings?.providers;
@@ -3239,22 +3225,6 @@ export function ChatInterface({
       }
     }
     readMarkerSyncedRef.current = nextReadSynced;
-
-    const nextSnapshotSyncInFlight: Record<string, boolean> = {};
-    for (const [chatId, inFlight] of Object.entries(snapshotSyncInFlightRef.current)) {
-      if (chatIds.has(chatId)) {
-        nextSnapshotSyncInFlight[chatId] = inFlight;
-      }
-    }
-    snapshotSyncInFlightRef.current = nextSnapshotSyncInFlight;
-
-    const nextSnapshotSyncedEvent: Record<string, string> = {};
-    for (const [chatId, eventId] of Object.entries(snapshotSyncedEventRef.current)) {
-      if (chatIds.has(chatId)) {
-        nextSnapshotSyncedEvent[chatId] = eventId;
-      }
-    }
-    snapshotSyncedEventRef.current = nextSnapshotSyncedEvent;
   }, [chats]);
 
   useEffect(() => {
@@ -3328,64 +3298,6 @@ export function ChatInterface({
         }
     ));
   }, [activeChatIdResolved, chatSidebarSnapshots, eventsForChatId, visibleEvents]);
-
-  useEffect(() => {
-    if (!activeChatIdResolved) {
-      return;
-    }
-    const snapshot = chatSidebarSnapshots[activeChatIdResolved];
-    const latestEventId = snapshot?.latestEventId?.trim() ?? '';
-    if (!latestEventId) {
-      return;
-    }
-    if (snapshotSyncedEventRef.current[activeChatIdResolved] === latestEventId) {
-      return;
-    }
-    if (snapshotSyncInFlightRef.current[activeChatIdResolved]) {
-      return;
-    }
-
-    const latestEventAt = snapshot.latestEventAt;
-    const timer = window.setTimeout(() => {
-      snapshotSyncInFlightRef.current[activeChatIdResolved] = true;
-      void fetch(
-        `/api/runtime/sessions/${encodeURIComponent(sessionId)}/chats/${encodeURIComponent(activeChatIdResolved)}`,
-        {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            latestPreview: snapshot.preview,
-            latestEventId,
-            latestEventAt,
-            latestEventIsUser: snapshot.latestEventIsUser,
-            latestHasErrorSignal: snapshot.hasErrorSignal,
-          }),
-        },
-      )
-        .then(async (response) => {
-          if (!response.ok) {
-            return;
-          }
-          snapshotSyncedEventRef.current[activeChatIdResolved] = latestEventId;
-          const payload = (await response.json().catch(() => ({}))) as { chat?: SessionChat };
-          if (!payload.chat) {
-            return;
-          }
-          setChats((prev) => sortSessionChats(prev.map((chat) => (
-            chat.id === payload.chat?.id ? payload.chat : chat
-          ))));
-        })
-        .catch(() => {
-        })
-        .finally(() => {
-          delete snapshotSyncInFlightRef.current[activeChatIdResolved];
-        });
-    }, SNAPSHOT_SYNC_DEBOUNCE_MS);
-
-    return () => {
-      window.clearTimeout(timer);
-    };
-  }, [activeChatIdResolved, chatSidebarSnapshots, isSessionSyncLeader, sessionId]);
 
   useEffect(() => {
     if (!isSessionSyncLeader) {

--- a/services/aris-web/lib/happy/client.ts
+++ b/services/aris-web/lib/happy/client.ts
@@ -1003,6 +1003,56 @@ export async function getSessionRuntimeState(
   };
 }
 
+export type BackendChatSnapshot = {
+  chatId: string;
+  preview: string;
+  hasEvents: boolean;
+  hasErrorSignal: boolean;
+  latestEventId: string | null;
+  latestEventAt: string | null;
+  latestEventIsUser: boolean;
+  isRunning: boolean;
+};
+
+let chatSnapshotsEndpointSupported: boolean | null = null;
+
+export async function getChatSnapshots(
+  sessionId: string,
+  chatIds: string[],
+): Promise<BackendChatSnapshot[] | null> {
+  if (chatSnapshotsEndpointSupported === false || chatIds.length === 0) {
+    return null;
+  }
+  try {
+    const query = chatIds.map((id) => `chatId=${encodeURIComponent(id)}`).join('&');
+    const raw = await fetchHappy(
+      `/v1/sessions/${encodeURIComponent(sessionId)}/chats/snapshots?${query}`,
+    );
+    chatSnapshotsEndpointSupported = true;
+    const obj = asObject(raw);
+    const arr = Array.isArray(obj?.snapshots) ? obj.snapshots as unknown[] : [];
+    return arr.map((item) => {
+      const o = asObject(item);
+      return {
+        chatId: String(o?.chatId ?? ''),
+        preview: String(o?.preview ?? ''),
+        hasEvents: Boolean(o?.hasEvents),
+        hasErrorSignal: Boolean(o?.hasErrorSignal),
+        latestEventId: typeof o?.latestEventId === 'string' ? o.latestEventId : null,
+        latestEventAt: typeof o?.latestEventAt === 'string' ? o.latestEventAt : null,
+        latestEventIsUser: Boolean(o?.latestEventIsUser),
+        isRunning: Boolean(o?.isRunning),
+      };
+    });
+  } catch (error) {
+    if (error instanceof HappyHttpError && error.status === 404) {
+      chatSnapshotsEndpointSupported = false;
+      return null;
+    }
+    throw error;
+  }
+}
+
 export async function runSessionAction(
   sessionId: string,
   action: SessionAction,

--- a/services/aris-web/tests/chatSidebarRoute.test.ts
+++ b/services/aris-web/tests/chatSidebarRoute.test.ts
@@ -5,8 +5,7 @@ const mocks = vi.hoisted(() => ({
   requireApiUser: vi.fn(),
   listSessionChats: vi.fn(),
   updateSessionChat: vi.fn(),
-  getSessionRuntimeState: vi.fn(),
-  listLatestEventsByChat: vi.fn(),
+  getChatSnapshots: vi.fn(),
 }));
 
 vi.mock('@/lib/auth/guard', () => ({
@@ -19,8 +18,7 @@ vi.mock('@/lib/happy/chats', () => ({
 }));
 
 vi.mock('@/lib/happy/client', () => ({
-  getSessionRuntimeState: mocks.getSessionRuntimeState,
-  listLatestEventsByChat: mocks.listLatestEventsByChat,
+  getChatSnapshots: mocks.getChatSnapshots,
 }));
 
 import { GET } from '@/app/api/runtime/sessions/[sessionId]/chats/sidebar/route';
@@ -29,30 +27,35 @@ describe('chat sidebar route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.requireApiUser.mockResolvedValue({ user: { id: 'user-1' } });
-    mocks.listLatestEventsByChat.mockResolvedValue({});
     mocks.updateSessionChat.mockResolvedValue(undefined);
-    mocks.getSessionRuntimeState.mockResolvedValue({ isRunning: true });
   });
 
-  it('only fetches runtime state for the active chat', async () => {
+  it('returns snapshots from backend event stream', async () => {
     mocks.listSessionChats.mockResolvedValue([
+      { id: 'chat-1', title: 'Chat 1' },
+      { id: 'chat-2', title: 'Chat 2' },
+    ]);
+
+    mocks.getChatSnapshots.mockResolvedValue([
       {
-        id: 'chat-1',
-        title: 'Chat 1',
-        latestPreview: 'cached',
+        chatId: 'chat-1',
+        preview: 'Hello',
+        hasEvents: true,
+        hasErrorSignal: false,
         latestEventId: 'evt-1',
         latestEventAt: '2026-03-14T08:00:00.000Z',
         latestEventIsUser: false,
-        latestHasErrorSignal: false,
+        isRunning: false,
       },
       {
-        id: 'chat-2',
-        title: 'Chat 2',
-        latestPreview: 'cached',
+        chatId: 'chat-2',
+        preview: 'World',
+        hasEvents: true,
+        hasErrorSignal: false,
         latestEventId: 'evt-2',
         latestEventAt: '2026-03-14T08:01:00.000Z',
         latestEventIsUser: false,
-        latestHasErrorSignal: false,
+        isRunning: true,
       },
     ]);
 
@@ -65,13 +68,40 @@ describe('chat sidebar route', () => {
 
     const payload = await response.json() as { snapshots: Array<{ chatId: string; isRunning: boolean }> };
 
-    expect(mocks.getSessionRuntimeState).toHaveBeenCalledTimes(1);
-    expect(mocks.getSessionRuntimeState).toHaveBeenCalledWith('session-1', { chatId: 'chat-2' });
-    expect(mocks.listLatestEventsByChat).not.toHaveBeenCalled();
-    expect(mocks.updateSessionChat).not.toHaveBeenCalled();
+    expect(mocks.getChatSnapshots).toHaveBeenCalledTimes(1);
+    expect(mocks.getChatSnapshots).toHaveBeenCalledWith('session-1', ['chat-1', 'chat-2']);
     expect(payload.snapshots).toEqual([
-      expect.objectContaining({ chatId: 'chat-1', isRunning: false }),
-      expect.objectContaining({ chatId: 'chat-2', isRunning: true }),
+      expect.objectContaining({ chatId: 'chat-1', isRunning: false, preview: 'Hello' }),
+      expect.objectContaining({ chatId: 'chat-2', isRunning: true, preview: 'World' }),
+    ]);
+  });
+
+  it('falls back to cached fields when backend returns null', async () => {
+    mocks.listSessionChats.mockResolvedValue([
+      {
+        id: 'chat-1',
+        title: 'Chat 1',
+        latestPreview: 'cached-preview',
+        latestEventId: 'evt-old',
+        latestEventAt: '2026-03-14T07:00:00.000Z',
+        latestEventIsUser: true,
+        latestHasErrorSignal: false,
+      },
+    ]);
+
+    mocks.getChatSnapshots.mockResolvedValue(null);
+
+    const response = await GET(
+      new NextRequest(
+        'http://localhost/api/runtime/sessions/session-1/chats/sidebar?chatId=chat-1&activeChatId=chat-1',
+      ),
+      { params: Promise.resolve({ sessionId: 'session-1' }) },
+    );
+
+    const payload = await response.json() as { snapshots: Array<{ chatId: string; preview: string }> };
+
+    expect(payload.snapshots).toEqual([
+      expect.objectContaining({ chatId: 'chat-1', preview: 'cached-preview', isRunning: false }),
     ]);
   });
 });


### PR DESCRIPTION
## Summary

채팅 상태 관리 리팩토링 3단계 중 **PR 1**: 사이드바 스냅샷의 source-of-truth를 DB 캐시에서 이벤트 스트림으로 전환합니다.

### 변경 내용

- **백엔드**: `GET /v1/sessions/:id/chats/snapshots` API 추가
  - `SessionMessage` 테이블에서 200행 1회 조회 → 채팅별 스냅샷 derive
  - 기존 `resolveChatRunningState()` 재사용
- **웹 클라이언트**: `getChatSnapshots()` 함수 추가 (404 시 null 반환, 롤링 배포 안전)
- **사이드바 API**: `SessionChat` 캐시 필드 대신 백엔드 이벤트에서 스냅샷 derive, 실패 시 기존 캐시 fallback
- **ChatInterface**: 스냅샷 write-back useEffect 제거 (1.5초 debounce PATCH 순환 제거)

### 후속 PR

- PR 2: `Session.status` 필드 제거 (백엔드)
- PR 3: `SessionChat` 스냅샷 캐시 필드 5개 제거 (웹 DB 마이그레이션)

## Test plan

- [x] 백엔드/웹 TypeScript 타입체크 통과
- [x] `chatSidebarRoute.test.ts` 테스트 통과 (2개)
- [ ] dev 서버에서 사이드바 프리뷰, running 인디케이터, 읽음/안읽음 배지 정상 동작 확인
- [ ] 읽음 마커 sync 정상 동작 확인
- [ ] 스냅샷 PATCH 요청이 더 이상 발생하지 않는지 네트워크 탭에서 확인