### PR TITLE
fix(chat): 사용자 복사 버튼 아이콘화

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -1663,26 +1663,22 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.3rem;
   min-height: 44px;
-  padding: 0.42rem 0.78rem;
+  width: 44px;
+  padding: 0;
+  border: 0;
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.26);
-  background: rgba(15, 23, 42, 0.04);
+  background: transparent;
   color: var(--chat-text-muted);
-  font-size: 0.72rem;
-  font-weight: 700;
   line-height: 1;
   cursor: pointer;
   transition:
     background 0.15s ease,
-    border-color 0.15s ease,
     color 0.15s ease,
     transform 0.12s ease;
 }
 
 .messageCopyButton:hover {
-  border-color: rgba(59, 130, 246, 0.35);
   background: rgba(59, 130, 246, 0.12);
   color: var(--chat-text-primary);
 }
@@ -1697,8 +1693,7 @@
 }
 
 :global(html[data-theme='dark']) .messageCopyButton {
-  border-color: rgba(148, 163, 184, 0.18);
-  background: rgba(148, 163, 184, 0.08);
+  background: transparent;
   color: var(--chat-text-secondary);
 }
 

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -5836,15 +5836,9 @@ export function ChatInterface({
                             title="사용자 메시지 복사"
                           >
                             {copiedUserEventId === event.id ? (
-                              <>
-                                <CheckCircle2 size={12} />
-                                <span>복사됨</span>
-                              </>
+                              <CheckCircle2 size={14} />
                             ) : (
-                              <>
-                                <Copy size={12} />
-                                <span>복사하기</span>
-                              </>
+                              <Copy size={14} />
                             )}
                           </button>
                         </div>


### PR DESCRIPTION
## 변경 사항\n- 사용자 메시지 복사 버튼을 아이콘만 보이도록 축소\n- 텍스트와 테두리를 제거하고 접근성 라벨은 유지\n\n## 검증\n- npm run build