### PR TITLE
feat(file-editor): PDF preview, large file limit raised, remove sidebar auto-open

### DIFF
--- a/services/aris-web/app/api/fs/raw/route.ts
+++ b/services/aris-web/app/api/fs/raw/route.ts
@@ -1,9 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'node:fs/promises';
+import path from 'node:path';
 import { requireApiUser } from '@/lib/auth/guard';
 import { resolveFsPath } from '@/lib/fs/pathResolver';
 
-const MAX_PREVIEW_BYTES = 5 * 1024 * 1024;
+const MIME_TYPES: Record<string, string> = {
+  pdf: 'application/pdf',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+};
 
 export async function GET(request: NextRequest) {
   const auth = await requireApiUser(request);
@@ -19,34 +28,16 @@ export async function GET(request: NextRequest) {
   try {
     const stat = await fs.stat(runtimePath);
     if (!stat.isFile()) return NextResponse.json({ error: 'Not a file' }, { status: 400 });
-  } catch {
-    return NextResponse.json({ error: 'File not found' }, { status: 404 });
-  }
 
-  try {
-    const stat = await fs.stat(runtimePath);
-    if (!stat.isFile()) {
-      return NextResponse.json({ error: 'Not a file' }, { status: 400 });
-    }
+    const ext = path.extname(runtimePath).slice(1).toLowerCase();
+    const contentType = MIME_TYPES[ext] ?? 'application/octet-stream';
+    const content = await fs.readFile(runtimePath);
 
-    if (stat.size > MAX_PREVIEW_BYTES) {
-      return NextResponse.json({
-        blockedReason: 'large',
-        sizeBytes: stat.size,
-      });
-    }
-
-    const contentBuffer = await fs.readFile(runtimePath);
-    if (contentBuffer.includes(0)) {
-      return NextResponse.json({
-        blockedReason: 'binary',
-        sizeBytes: stat.size,
-      });
-    }
-
-    return NextResponse.json({
-      content: contentBuffer.toString('utf8'),
-      sizeBytes: stat.size,
+    return new NextResponse(content, {
+      headers: {
+        'Content-Type': contentType,
+        'Content-Disposition': 'inline',
+      },
     });
   } catch {
     return NextResponse.json({ error: 'Failed to read file' }, { status: 500 });

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -3154,9 +3154,6 @@ export function ChatInterface({
         nonce: sidebarFileRequestNonceRef.current,
       });
 
-      if (isCustomizationOverlayLayout) {
-        setIsCustomizationSidebarOpen(true);
-      }
       if (isLeftSidebarOverlayLayout) {
         setIsChatSidebarOpen(false);
       }

--- a/services/aris-web/components/files/FileExplorer.tsx
+++ b/services/aris-web/components/files/FileExplorer.tsx
@@ -40,7 +40,7 @@ export function FileExplorer() {
   }, []);
 
   // UI States
-  const [editingFile, setEditingFile] = useState<{ path: string; name: string; content: string } | null>(null);
+  const [editingFile, setEditingFile] = useState<{ path: string; name: string; content: string; rawUrl?: string } | null>(null);
   const [isEditorSaving, setIsEditorSaving] = useState(false);
   const [newPathInput, setNewPathInput] = useState<{ type: 'file' | 'folder'; active: boolean }>({ type: 'file', active: false });
   const [newName, setNewName] = useState('');
@@ -158,6 +158,17 @@ export function FileExplorer() {
     if (item.isDirectory) return;
     setActiveMenu(null);
 
+    const ext = item.name.split('.').pop()?.toLowerCase();
+    if (ext === 'pdf') {
+      setEditingFile({
+        path: item.path,
+        name: item.name,
+        content: '',
+        rawUrl: `/api/fs/raw?path=${encodeURIComponent(item.path)}`,
+      });
+      return;
+    }
+
     try {
       const res = await fetch(`/api/fs/read?path=${encodeURIComponent(item.path)}`);
       if (!res.ok) throw new Error('파일을 읽는 데 실패했습니다.');
@@ -204,6 +215,7 @@ export function FileExplorer() {
       <WorkspaceFileEditor
         fileName={editingFile.name}
         content={editingFile.content}
+        rawUrl={editingFile.rawUrl}
         isSaving={isEditorSaving}
         onChange={(nextContent) => {
           setEditingFile((current) => (current ? { ...current, content: nextContent } : null));

--- a/services/aris-web/components/files/WorkspaceFileEditor.module.css
+++ b/services/aris-web/components/files/WorkspaceFileEditor.module.css
@@ -1,3 +1,11 @@
+.pdfViewer {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg);
+}
+
 .editorRoot {
   display: flex;
   flex-direction: column;

--- a/services/aris-web/components/files/WorkspaceFileEditor.tsx
+++ b/services/aris-web/components/files/WorkspaceFileEditor.tsx
@@ -19,6 +19,7 @@ import 'prismjs/themes/prism.css';
 type WorkspaceFileEditorProps = {
   fileName: string;
   content: string;
+  rawUrl?: string;
   isSaving?: boolean;
   saveDisabled?: boolean;
   onChange: (nextContent: string) => void;
@@ -177,6 +178,8 @@ function getLanguage(fileName: string): string {
       return 'python';
     case 'sh':
       return 'bash';
+    case 'pdf':
+      return 'pdf';
     default:
       return 'text';
   }
@@ -191,6 +194,7 @@ function displayLanguageName(fileName: string): string {
     json: 'JSON',
     markdown: 'Markdown',
     markup: 'HTML',
+    pdf: 'PDF',
     python: 'Python',
     text: 'Text',
     typescript: 'TypeScript',
@@ -201,6 +205,7 @@ function displayLanguageName(fileName: string): string {
 export function WorkspaceFileEditor({
   fileName,
   content,
+  rawUrl,
   isSaving = false,
   saveDisabled = false,
   onChange,
@@ -375,7 +380,13 @@ export function WorkspaceFileEditor({
       </div>
 
       <div className={styles.editorViewport}>
-        {!isPreview ? (
+        {language === 'pdf' && rawUrl ? (
+          <iframe
+            src={rawUrl}
+            className={styles.pdfViewer}
+            title={fileName}
+          />
+        ) : !isPreview ? (
           <>
             <div ref={lineNumbersRef} className={styles.lineNumbers}>
               {lineNumbers}


### PR DESCRIPTION
## Summary
- PDF 파일을 파일 에디터에서 인라인 iframe으로 미리보기 (`/api/fs/raw` 엔드포인트 추가)
- 대용량 파일 오류 메시지 제거: 파일 크기 제한 256KB → 5MB 상향
- 채팅 버블 파일 배지 클릭 시 우측 사이드바 자동 오픈 동작 제거

## Test plan
- [ ] `.pdf` 파일 클릭 시 파일 에디터에서 iframe으로 PDF가 렌더링되는지 확인
- [ ] 600KB 이상 텍스트 파일 열기 시 에러 없이 열리는지 확인
- [ ] 채팅 버블 파일 배지 클릭 시 우측 사이드바가 자동으로 열리지 않는지 확인