### PR TITLE
feat(file-editor): wikilink support in markdown preview

### DIFF
--- a/services/aris-web/components/files/WorkspaceFileEditor.module.css
+++ b/services/aris-web/components/files/WorkspaceFileEditor.module.css
@@ -281,6 +281,18 @@
   }
 }
 
+.markdownBody :global(.md-wikilink) {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.05rem 0.45rem;
+  border-radius: 4px;
+  background: var(--accent-violet-bg);
+  color: var(--accent-violet);
+  font-size: 0.88em;
+  font-weight: 500;
+  cursor: default;
+}
+
 .markdownBody :global(.md-code-block) {
   margin: 0.75rem 0;
   border-radius: 8px;

--- a/services/aris-web/components/files/WorkspaceFileEditor.tsx
+++ b/services/aris-web/components/files/WorkspaceFileEditor.tsx
@@ -6,6 +6,28 @@ import Prism from 'prismjs';
 import { marked } from 'marked';
 import styles from './WorkspaceFileEditor.module.css';
 
+marked.use({
+  extensions: [{
+    name: 'wikilink',
+    level: 'inline' as const,
+    start(src: string) { return src.indexOf('[['); },
+    tokenizer(src: string) {
+      const match = /^\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/.exec(src);
+      if (match) {
+        const path = match[1].trim();
+        const text = match[2] ? match[2].trim() : (path.split('/').pop() ?? path);
+        return { type: 'wikilink', raw: match[0], path, text };
+      }
+      return undefined;
+    },
+    renderer(token) {
+      const safeText = String(token['text']).replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      const safePath = String(token['path']).replace(/"/g, '&quot;');
+      return `<span class="md-wikilink" data-path="${safePath}">${safeText}</span>`;
+    },
+  }],
+});
+
 import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-javascript';
 import 'prismjs/components/prism-json';


### PR DESCRIPTION
## Summary
- `[[path|표시텍스트]]` 및 `[[path]]` 형식의 Obsidian 스타일 wikilink를 마크다운 미리보기에서 violet 배지로 렌더링
- `marked` 인라인 extension으로 구현하여 코드 블록 내부는 변환하지 않음
- path의 마지막 세그먼트를 표시 텍스트로 fallback 사용 (display text 미지정 시)

## Test plan
- [ ] `[[entities/people/hwang-seungwon|황승원]]` → `황승원` 배지로 표시되는지 확인
- [ ] `[[path/to/note]]` → `note` 배지로 표시되는지 확인
- [ ] 코드 블록 내 `[[wikilink]]`는 변환되지 않는지 확인