### PR TITLE
feat(file-editor): wikilink click navigation to linked document

### DIFF
--- a/services/aris-web/components/files/WorkspaceFileEditor.module.css
+++ b/services/aris-web/components/files/WorkspaceFileEditor.module.css
@@ -290,7 +290,12 @@
   color: var(--accent-violet);
   font-size: 0.88em;
   font-weight: 500;
-  cursor: default;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.markdownBody :global(.md-wikilink:hover) {
+  opacity: 0.75;
 }
 
 .markdownBody :global(.md-code-block) {

--- a/services/aris-web/components/files/WorkspaceFileEditor.tsx
+++ b/services/aris-web/components/files/WorkspaceFileEditor.tsx
@@ -351,6 +351,19 @@ export function WorkspaceFileEditor({
     }
   }, [onChange]);
 
+  const handleWikilinkClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const target = (e.target as HTMLElement).closest('.md-wikilink');
+    if (!target) return;
+    let wikilinkPath = target.getAttribute('data-path') ?? '';
+    if (!wikilinkPath) return;
+    if (!wikilinkPath.includes('.')) {
+      wikilinkPath = `${wikilinkPath}.md`;
+    }
+    window.dispatchEvent(new CustomEvent('aris-open-workspace-file', {
+      detail: { path: wikilinkPath, name: wikilinkPath.split('/').pop() ?? wikilinkPath },
+    }));
+  }, []);
+
   const handleEditorScroll = useCallback((event: React.UIEvent<HTMLTextAreaElement>) => {
     if (lineNumbersRef.current) {
       lineNumbersRef.current.scrollTop = event.currentTarget.scrollTop;
@@ -431,7 +444,7 @@ export function WorkspaceFileEditor({
             </div>
           </>
         ) : (
-          <div className={styles.markdownBody}>
+          <div className={styles.markdownBody} onClick={handleWikilinkClick}>
             {parsed.frontmatter && <FrontmatterBlock fm={parsed.frontmatter} />}
             <div className={styles.markdownContent} dangerouslySetInnerHTML={{ __html: markdownHtml }} />
           </div>


### PR DESCRIPTION
## Summary
- 마크다운 미리보기에서 `[[path|텍스트]]` wikilink 배지 클릭 시 해당 파일을 파일 에디터에서 열기
- `aris-open-workspace-file` 이벤트 dispatch → `ChatInterface`의 기존 파일 오픈 핸들러로 경로 해석 및 파일 열기
- 확장자 없는 경로는 `.md` 자동 추가 (e.g. `entities/people/hwang-seungwon` → `entities/people/hwang-seungwon.md`)
- hover 시 opacity 변화로 클릭 가능한 요소임을 표시

## Test plan
- [ ] `[[entities/people/hwang-seungwon|황승원]]` 클릭 시 해당 `.md` 파일이 에디터에서 열리는지 확인
- [ ] 존재하지 않는 경로 클릭 시 오류 없이 처리되는지 확인
- [ ] 코드 블록 내부 `[[wikilink]]`는 클릭해도 반응 없는지 확인