### PR TITLE
feat(file-editor): wikilink click navigation to linked document

### DIFF
--- a/services/aris-web/app/api/fs/resolve-wikilink/route.ts
+++ b/services/aris-web/app/api/fs/resolve-wikilink/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { requireApiUser } from '@/lib/auth/guard';
+import { resolveFsPath } from '@/lib/fs/pathResolver';
+
+export async function GET(request: NextRequest) {
+  const auth = await requireApiUser(request);
+  if ('response' in auth) return auth.response;
+  if (auth.user.role !== 'operator') return NextResponse.json({ error: 'Operator role required' }, { status: 403 });
+
+  const { searchParams } = new URL(request.url);
+  const wikilinkPath = searchParams.get('path');
+  const fromFile = searchParams.get('from');
+
+  if (!wikilinkPath) return NextResponse.json({ error: 'path required' }, { status: 400 });
+
+  // 확장자가 없으면 .md 추가
+  const pathWithExt = wikilinkPath.includes('.') ? wikilinkPath : `${wikilinkPath}.md`;
+
+  if (!fromFile) {
+    return NextResponse.json({ resolvedPath: null });
+  }
+
+  let fromRuntimePath: string;
+  try {
+    const resolved = resolveFsPath(fromFile);
+    fromRuntimePath = resolved.runtimePath;
+  } catch {
+    return NextResponse.json({ resolvedPath: null });
+  }
+
+  // 현재 파일의 디렉터리부터 루트까지 올라가며 탐색
+  let dir = path.dirname(fromRuntimePath);
+  const visited = new Set<string>();
+
+  while (true) {
+    if (visited.has(dir)) break;
+    visited.add(dir);
+
+    const candidate = path.join(dir, pathWithExt);
+    try {
+      const stat = await fs.stat(candidate);
+      if (stat.isFile()) {
+        return NextResponse.json({ resolvedPath: candidate });
+      }
+    } catch {
+      // 이 레벨에 파일 없음, 계속 탐색
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // 루트 도달
+    dir = parent;
+  }
+
+  return NextResponse.json({ resolvedPath: null });
+}

--- a/services/aris-web/app/sessions/[sessionId]/CustomizationSidebar.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/CustomizationSidebar.tsx
@@ -370,6 +370,11 @@ export function CustomizationSidebar({
   const [isMounted, setIsMounted] = useState(false);
   const handledRequestedFileNonceRef = useRef<number | null>(null);
 
+  // 파일 탐색 히스토리 (wikilink 네비게이션용)
+  const fileNavHistoryRef = useRef<string[]>([]);
+  const fileNavIndexRef = useRef(-1);
+  const [fileNavState, setFileNavState] = useState({ canGoBack: false, canGoForward: false });
+
   const selectedInstruction = useMemo(
     () => overview?.instructionDocs.find((doc) => doc.id === selectedInstructionId) ?? null,
     [overview, selectedInstructionId],
@@ -892,9 +897,21 @@ export function CustomizationSidebar({
     }
   }, [expandedDirectories, filesEntriesByPath, filesLoadingByPath, loadFilesDirectory]);
 
-  const openFileModal = useCallback((filePath: string, fileName?: string) => {
+  const openFileModal = useCallback((filePath: string, fileName?: string, opts?: { pushHistory?: boolean }) => {
     void loadFile(filePath, fileName);
     setActiveModal({ kind: 'file', id: filePath });
+    if (opts?.pushHistory) {
+      const history = fileNavHistoryRef.current;
+      const index = fileNavIndexRef.current;
+      const trimmed = history.slice(0, index + 1);
+      trimmed.push(filePath);
+      fileNavHistoryRef.current = trimmed;
+      fileNavIndexRef.current = trimmed.length - 1;
+      setFileNavState({
+        canGoBack: fileNavIndexRef.current > 0,
+        canGoForward: false,
+      });
+    }
   }, [loadFile]);
 
   const handleConfirmFileAction = useCallback(async () => {
@@ -1085,6 +1102,10 @@ export function CustomizationSidebar({
                 if (item.isDirectory) {
                   handleToggleDirectory(item.path);
                 } else {
+                  // 파일 목록 직접 클릭: 히스토리 초기화
+                  fileNavHistoryRef.current = [item.path];
+                  fileNavIndexRef.current = 0;
+                  setFileNavState({ canGoBack: false, canGoForward: false });
                   openFileModal(item.path, item.name);
                 }
               }}
@@ -1908,9 +1929,12 @@ export function CustomizationSidebar({
                       {fileStatus ? <div className={styles.fileModalStatus}>{fileStatus}</div> : null}
                       <WorkspaceFileEditor
                         fileName={activeFileModal.name}
+                        filePath={activeFileModal.path}
                         content={fileContent}
                         isSaving={fileSaving}
                         saveDisabled={fileSaving || fileLoading || !fileDirty}
+                        canGoBack={fileNavState.canGoBack}
+                        canGoForward={fileNavState.canGoForward}
                         className={styles.fileModalEditor}
                         onChange={(nextContent) => {
                           setFileContent(nextContent);
@@ -1919,6 +1943,46 @@ export function CustomizationSidebar({
                         }}
                         onSave={() => void handleSaveFile()}
                         onClose={closeModal}
+                        onWikilinkClick={(wikilinkPath) => {
+                          void (async () => {
+                            const pathWithExt = wikilinkPath.includes('.') ? wikilinkPath : `${wikilinkPath}.md`;
+                            let resolvedPath: string | null = null;
+                            try {
+                              const resp = await fetch(
+                                `/api/fs/resolve-wikilink?path=${encodeURIComponent(wikilinkPath)}&from=${encodeURIComponent(activeFileModal.path)}`
+                              );
+                              const data = await resp.json() as { resolvedPath: string | null };
+                              resolvedPath = data.resolvedPath;
+                            } catch { /* fallback */ }
+                            const finalPath = resolvedPath ?? pathWithExt;
+                            const name = finalPath.split('/').pop() ?? finalPath;
+                            openFileModal(finalPath, name, { pushHistory: true });
+                          })();
+                        }}
+                        onBack={() => {
+                          const idx = fileNavIndexRef.current - 1;
+                          if (idx < 0) return;
+                          const path = fileNavHistoryRef.current[idx];
+                          if (!path) return;
+                          fileNavIndexRef.current = idx;
+                          setFileNavState({
+                            canGoBack: idx > 0,
+                            canGoForward: idx < fileNavHistoryRef.current.length - 1,
+                          });
+                          openFileModal(path, path.split('/').pop() ?? path);
+                        }}
+                        onForward={() => {
+                          const idx = fileNavIndexRef.current + 1;
+                          if (idx >= fileNavHistoryRef.current.length) return;
+                          const path = fileNavHistoryRef.current[idx];
+                          if (!path) return;
+                          fileNavIndexRef.current = idx;
+                          setFileNavState({
+                            canGoBack: idx > 0,
+                            canGoForward: idx < fileNavHistoryRef.current.length - 1,
+                          });
+                          openFileModal(path, path.split('/').pop() ?? path);
+                        }}
                       />
                     </>
                   )

--- a/services/aris-web/components/files/FileExplorer.tsx
+++ b/services/aris-web/components/files/FileExplorer.tsx
@@ -42,6 +42,9 @@ export function FileExplorer() {
   // UI States
   const [editingFile, setEditingFile] = useState<{ path: string; name: string; content: string; rawUrl?: string } | null>(null);
   const [isEditorSaving, setIsEditorSaving] = useState(false);
+  const fileNavHistoryRef = useRef<string[]>([]);
+  const fileNavIndexRef = useRef(-1);
+  const [fileNavState, setFileNavState] = useState({ canGoBack: false, canGoForward: false });
   const [newPathInput, setNewPathInput] = useState<{ type: 'file' | 'folder'; active: boolean }>({ type: 'file', active: false });
   const [newName, setNewName] = useState('');
 
@@ -187,7 +190,12 @@ export function FileExplorer() {
       setEditingFile({ path: item.path, name: item.name, content: content ?? '' });
     } catch (err) {
       alert(err instanceof Error ? err.message : '오류 발생');
+      return;
     }
+    // 파일 목록 직접 클릭: 히스토리 초기화
+    fileNavHistoryRef.current = [item.path];
+    fileNavIndexRef.current = 0;
+    setFileNavState({ canGoBack: false, canGoForward: false });
   };
 
   const saveEditedFile = async () => {
@@ -214,14 +222,81 @@ export function FileExplorer() {
     return (
       <WorkspaceFileEditor
         fileName={editingFile.name}
+        filePath={editingFile.path}
         content={editingFile.content}
         rawUrl={editingFile.rawUrl}
         isSaving={isEditorSaving}
+        canGoBack={fileNavState.canGoBack}
+        canGoForward={fileNavState.canGoForward}
         onChange={(nextContent) => {
           setEditingFile((current) => (current ? { ...current, content: nextContent } : null));
         }}
         onSave={() => void saveEditedFile()}
         onClose={() => setEditingFile(null)}
+        onWikilinkClick={(wikilinkPath) => {
+          void (async () => {
+            const currentPath = editingFile.path;
+            let resolvedPath: string | null = null;
+            try {
+              const resp = await fetch(
+                `/api/fs/resolve-wikilink?path=${encodeURIComponent(wikilinkPath)}&from=${encodeURIComponent(currentPath)}`
+              );
+              const data = await resp.json() as { resolvedPath: string | null };
+              resolvedPath = data.resolvedPath;
+            } catch { /* fallback */ }
+            const finalPath = resolvedPath ?? (wikilinkPath.includes('.') ? wikilinkPath : `${wikilinkPath}.md`);
+            const name = finalPath.split('/').pop() ?? finalPath;
+            try {
+              const res = await fetch(`/api/fs/read?path=${encodeURIComponent(finalPath)}`);
+              if (!res.ok) throw new Error('파일을 읽는 데 실패했습니다.');
+              const data = await res.json() as { content?: string; blockedReason?: string };
+              if (data.blockedReason === 'binary') {
+                alert('바이너리 파일은 미리보기를 지원하지 않습니다.');
+                return;
+              }
+              setEditingFile({ path: finalPath, name, content: data.content ?? '' });
+              const history = fileNavHistoryRef.current.slice(0, fileNavIndexRef.current + 1);
+              history.push(finalPath);
+              fileNavHistoryRef.current = history;
+              fileNavIndexRef.current = history.length - 1;
+              setFileNavState({ canGoBack: fileNavIndexRef.current > 0, canGoForward: false });
+            } catch (err) {
+              alert(err instanceof Error ? err.message : '파일을 열 수 없습니다.');
+            }
+          })();
+        }}
+        onBack={() => {
+          const idx = fileNavIndexRef.current - 1;
+          if (idx < 0) return;
+          const path = fileNavHistoryRef.current[idx];
+          if (!path) return;
+          fileNavIndexRef.current = idx;
+          setFileNavState({
+            canGoBack: idx > 0,
+            canGoForward: idx < fileNavHistoryRef.current.length - 1,
+          });
+          void fetch(`/api/fs/read?path=${encodeURIComponent(path)}`).then(async (res) => {
+            const data = await res.json() as { content?: string };
+            const name = path.split('/').pop() ?? path;
+            setEditingFile({ path, name, content: data.content ?? '' });
+          });
+        }}
+        onForward={() => {
+          const idx = fileNavIndexRef.current + 1;
+          if (idx >= fileNavHistoryRef.current.length) return;
+          const path = fileNavHistoryRef.current[idx];
+          if (!path) return;
+          fileNavIndexRef.current = idx;
+          setFileNavState({
+            canGoBack: idx > 0,
+            canGoForward: idx < fileNavHistoryRef.current.length - 1,
+          });
+          void fetch(`/api/fs/read?path=${encodeURIComponent(path)}`).then(async (res) => {
+            const data = await res.json() as { content?: string };
+            const name = path.split('/').pop() ?? path;
+            setEditingFile({ path, name, content: data.content ?? '' });
+          });
+        }}
       />
     );
   };

--- a/services/aris-web/components/files/WorkspaceFileEditor.module.css
+++ b/services/aris-web/components/files/WorkspaceFileEditor.module.css
@@ -63,6 +63,16 @@
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+  align-items: center;
+}
+
+.navButtons {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.buttonIconOnly {
+  padding: 0.4rem !important;
 }
 
 .buttonSmall {

--- a/services/aris-web/components/files/WorkspaceFileEditor.tsx
+++ b/services/aris-web/components/files/WorkspaceFileEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Code, Edit3, Eye, FileText, Loader2, Save, X } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Code, Edit3, Eye, FileText, Loader2, Save, X } from 'lucide-react';
 import Prism from 'prismjs';
 import { marked } from 'marked';
 import styles from './WorkspaceFileEditor.module.css';
@@ -42,11 +42,17 @@ type WorkspaceFileEditorProps = {
   fileName: string;
   content: string;
   rawUrl?: string;
+  filePath?: string;
   isSaving?: boolean;
   saveDisabled?: boolean;
+  canGoBack?: boolean;
+  canGoForward?: boolean;
   onChange: (nextContent: string) => void;
   onSave: () => void | Promise<void>;
   onClose?: () => void;
+  onWikilinkClick?: (wikilinkPath: string) => void;
+  onBack?: () => void;
+  onForward?: () => void;
   className?: string;
 };
 
@@ -228,11 +234,17 @@ export function WorkspaceFileEditor({
   fileName,
   content,
   rawUrl,
+  filePath,
   isSaving = false,
   saveDisabled = false,
+  canGoBack = false,
+  canGoForward = false,
   onChange,
   onSave,
   onClose,
+  onWikilinkClick,
+  onBack,
+  onForward,
   className,
 }: WorkspaceFileEditorProps) {
   const [isPreview, setIsPreview] = useState(() => getLanguage(fileName) === 'markdown');
@@ -354,15 +366,31 @@ export function WorkspaceFileEditor({
   const handleWikilinkClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     const target = (e.target as HTMLElement).closest('.md-wikilink');
     if (!target) return;
-    let wikilinkPath = target.getAttribute('data-path') ?? '';
+    const wikilinkPath = target.getAttribute('data-path') ?? '';
     if (!wikilinkPath) return;
-    if (!wikilinkPath.includes('.')) {
-      wikilinkPath = `${wikilinkPath}.md`;
+
+    if (onWikilinkClick) {
+      onWikilinkClick(wikilinkPath);
+      return;
     }
-    window.dispatchEvent(new CustomEvent('aris-open-workspace-file', {
-      detail: { path: wikilinkPath, name: wikilinkPath.split('/').pop() ?? wikilinkPath },
-    }));
-  }, []);
+
+    // fallback: resolve via API then dispatch event
+    void (async () => {
+      let resolvedPath = wikilinkPath.includes('.') ? wikilinkPath : `${wikilinkPath}.md`;
+      if (filePath) {
+        try {
+          const resp = await fetch(
+            `/api/fs/resolve-wikilink?path=${encodeURIComponent(wikilinkPath)}&from=${encodeURIComponent(filePath)}`
+          );
+          const data = await resp.json() as { resolvedPath: string | null };
+          if (data.resolvedPath) resolvedPath = data.resolvedPath;
+        } catch { /* fallback to default */ }
+      }
+      window.dispatchEvent(new CustomEvent('aris-open-workspace-file', {
+        detail: { path: resolvedPath, name: resolvedPath.split('/').pop() ?? resolvedPath },
+      }));
+    })();
+  }, [filePath, onWikilinkClick]);
 
   const handleEditorScroll = useCallback((event: React.UIEvent<HTMLTextAreaElement>) => {
     if (lineNumbersRef.current) {
@@ -386,6 +414,28 @@ export function WorkspaceFileEditor({
           </div>
         </div>
         <div className={styles.editorActions}>
+          {(onBack || onForward) ? (
+            <div className={styles.navButtons}>
+              <button
+                type="button"
+                onClick={onBack}
+                disabled={!canGoBack}
+                className={`btn-secondary ${styles.buttonSmall} ${styles.buttonIconOnly}`}
+                title="뒤로"
+              >
+                <ArrowLeft size={16} />
+              </button>
+              <button
+                type="button"
+                onClick={onForward}
+                disabled={!canGoForward}
+                className={`btn-secondary ${styles.buttonSmall} ${styles.buttonIconOnly}`}
+                title="앞으로"
+              >
+                <ArrowRight size={16} />
+              </button>
+            </div>
+          ) : null}
           {language === 'markdown' ? (
             <button
               type="button"


### PR DESCRIPTION
## Summary
- **File not found 수정**: `/api/fs/resolve-wikilink` 신규 엔드포인트 — 현재 파일 디렉터리에서 루트 방향으로 순차 탐색하여 wikilink 경로를 정확히 해석 (Obsidian vault 구조 대응)
- **뒤로/앞으로 버튼**: `WorkspaceFileEditor` 헤더에 `←` `→` 버튼 추가, `CustomizationSidebar`와 `FileExplorer` 양쪽에 히스토리 관리 연결
- **wikilink 콜백 분리**: `onWikilinkClick` prop으로 부모가 직접 경로 해석 및 파일 열기를 담당

## Test plan
- [ ] `[[entities/people/hwang-seungwon|황승원]]` 클릭 시 파일이 정상적으로 열리는지 확인
- [ ] wikilink로 이동 후 `←` 버튼으로 이전 파일로 돌아오는지 확인
- [ ] `→` 버튼으로 앞으로 이동 가능한지 확인
- [ ] 파일 목록에서 직접 새 파일 클릭 시 히스토리가 초기화되는지 확인