### PR TITLE
fix(file-badge): resolve worktree paths to main workspace on file badge click

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -3143,9 +3143,28 @@ export function ChatInterface({
       }
 
       const normalizedTarget = normalizeWorkspaceClientPath(resolvedPath);
-      const finalPath = isWorkspacePathWithinRoot(normalizedTarget, normalizedWorkspaceRootPath)
-        ? normalizedTarget
-        : joinWorkspacePath(normalizedWorkspaceRootPath, normalizedTarget);
+      let finalPath: string;
+      if (isWorkspacePathWithinRoot(normalizedTarget, normalizedWorkspaceRootPath)) {
+        // 이미 workspace root 내의 경로 → 그대로 사용
+        finalPath = normalizedTarget;
+      } else {
+        // 절대 경로(worktree 등 sibling 디렉터리)인 경우:
+        // /home/ubuntu/project/ARIS-wt-xxx/services/file.ts
+        // → /home/ubuntu/project/ARIS/services/file.ts 로 재매핑
+        const workspaceParentDir = normalizedWorkspaceRootPath.includes('/')
+          ? normalizedWorkspaceRootPath.slice(0, normalizedWorkspaceRootPath.lastIndexOf('/'))
+          : '';
+        if (workspaceParentDir && normalizedTarget.startsWith(`${workspaceParentDir}/`)) {
+          const afterParent = normalizedTarget.slice(workspaceParentDir.length + 1);
+          const slashIdx = afterParent.indexOf('/');
+          const relPart = slashIdx !== -1 ? afterParent.slice(slashIdx + 1) : '';
+          finalPath = relPart
+            ? joinWorkspacePath(normalizedWorkspaceRootPath, relPart)
+            : normalizedWorkspaceRootPath;
+        } else {
+          finalPath = joinWorkspacePath(normalizedWorkspaceRootPath, normalizedTarget);
+        }
+      }
 
       sidebarFileRequestNonceRef.current += 1;
       setSidebarFileRequest({


### PR DESCRIPTION
## Summary
채팅 내 파일 배지 클릭 시 "File not found" 에러 수정.

**원인**: 에이전트가 worktree 경로(`/home/ubuntu/project/ARIS-wt-xxx/services/.../CustomizationSidebar.tsx`)를 chat에 기록한 후, worktree가 삭제되면 해당 경로가 존재하지 않아 File not found 발생.

**수정**: `handleWorkspaceFileOpen`에서 workspace root의 sibling 경로(worktree 등)를 감지하여 자동으로 main workspace 경로로 재매핑.
- `/home/ubuntu/project/ARIS-wt-xxx/services/file.ts` → `/home/ubuntu/project/ARIS/services/file.ts`

## Test plan
- [ ] 이전 worktree에서 수정된 파일 배지(`CustomizationSidebar.tsx` 등) 클릭 시 File not found 없이 파일이 열리는지 확인
- [ ] 일반 상대 경로 배지 클릭 시 정상 동작 확인