### PR TITLE
fix(chat): reject non-alphanumeric file extensions in badge parser

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -432,7 +432,9 @@ function fileExtension(filename: string): string {
   if (dotIndex <= 0 || dotIndex === base.length - 1) {
     return '';
   }
-  return base.slice(dotIndex + 1).toLowerCase();
+  const ext = base.slice(dotIndex + 1).toLowerCase();
+  if (!/^[a-z0-9]+$/.test(ext)) return '';
+  return ext;
 }
 
 function normalizeWorkspaceClientPath(input: string): string {


### PR DESCRIPTION
## Summary
- `fileExtension()` was returning `"tsx | head -5"` when the filename contained shell command fragments (e.g. from `cat file.tsx | head -5` in agent tool calls)
- Added alphanumeric guard: if the extracted extension contains any non-`[a-z0-9]` character, return empty string
- This prevents `classifyPath` from creating file badges with mangled names like `"FileExplorer.tsx | head -5"`

## Root Cause
```
fileExtension("FileExplorer.tsx | head -5")
  → base = "FileExplorer.tsx | head -5"
  → dotIndex = 13
  → slice(14) = "tsx | head -5"  ← truthy, badge created ❌
```

## Fix
```tsx
const ext = base.slice(dotIndex + 1).toLowerCase();
if (!/^[a-z0-9]+$/.test(ext)) return '';
return ext;
```

## Test plan
- [ ] Open a chat session where agent uses `cat file.tsx | head -5`
- [ ] Verify no badge is created for `"FileExplorer.tsx | head -5"`
- [ ] Verify normal file references like `services/foo/Bar.tsx` still create correct badges