### PR TITLE
feat(claude): Edit/Write/MultiEdit 도구 사용 시 CHANGES 카드 표시

### DIFF
--- a/services/aris-backend/src/runtime/providers/claude/claudeProtocolMapper.ts
+++ b/services/aris-backend/src/runtime/providers/claude/claudeProtocolMapper.ts
@@ -1,6 +1,7 @@
 import { inferActionTypeFromCommand, titleForActionType } from '../../actionType.js';
 import { sanitizeAgentMessageText } from '../../agentMessageSanitizer.js';
 import { summarizeDiffText } from '../../diffStats.js';
+import type { DiffStats } from '../../diffStats.js';
 import type { SessionProtocolEnvelope, SessionProtocolStopReason } from '../../contracts/sessionProtocol.js';
 import { collectClaudeNestedRecords, extractClaudeObservedSessionId, extractFirstClaudeStringByKeys, parseClaudeJsonLine } from './claudeProtocolFields.js';
 import type { ClaudeActionEvent } from './types.js';
@@ -84,6 +85,127 @@ export function looksLikeClaudeActionTranscript(value: string): boolean {
     || text.includes('*** delete file:')
     || text.includes('@@ ')
   );
+}
+
+type ClaudeToolUseDetails =
+  | { kind: 'edit'; filePath: string; oldString: string; newString: string }
+  | { kind: 'write'; filePath: string; content: string }
+  | { kind: 'multiedit'; filePath: string; edits: Array<{ oldString: string; newString: string }> };
+
+function findClaudeToolUseDetails(records: Record<string, unknown>[]): ClaudeToolUseDetails | null {
+  for (const record of records) {
+    if (record.type !== 'tool_use' || typeof record.name !== 'string') {
+      continue;
+    }
+    const input = record.input;
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+      continue;
+    }
+    const inp = input as Record<string, unknown>;
+    const toolName = record.name.trim().toLowerCase();
+    const filePath = typeof inp.file_path === 'string' ? inp.file_path.trim() : '';
+
+    if (toolName === 'edit') {
+      const oldString = typeof inp.old_string === 'string' ? inp.old_string : '';
+      const newString = typeof inp.new_string === 'string' ? inp.new_string : '';
+      if (filePath) {
+        return { kind: 'edit', filePath, oldString, newString };
+      }
+    }
+
+    if (toolName === 'write') {
+      const content = typeof inp.content === 'string' ? inp.content : '';
+      if (filePath) {
+        return { kind: 'write', filePath, content };
+      }
+    }
+
+    if (toolName === 'multiedit') {
+      const editsRaw = Array.isArray(inp.edits) ? inp.edits : [];
+      const edits = editsRaw
+        .filter((e): e is Record<string, unknown> => !!e && typeof e === 'object' && !Array.isArray(e))
+        .map((e) => ({
+          oldString: typeof e.old_string === 'string' ? e.old_string : '',
+          newString: typeof e.new_string === 'string' ? e.new_string : '',
+        }));
+      if (filePath) {
+        return { kind: 'multiedit', filePath, edits };
+      }
+    }
+  }
+  return null;
+}
+
+function synthesizeDiffFromToolDetails(details: ClaudeToolUseDetails): { output: string; diffStats: DiffStats } {
+  const { filePath } = details;
+  const escapedPath = filePath.replace(/^\//, '');
+
+  if (details.kind === 'edit') {
+    const oldLines = details.oldString.split('\n');
+    const newLines = details.newString.split('\n');
+    const hunk = `@@ -1,${oldLines.length} +1,${newLines.length} @@`;
+    const output = [
+      `diff --git a/${escapedPath} b/${escapedPath}`,
+      `--- a/${escapedPath}`,
+      `+++ b/${escapedPath}`,
+      hunk,
+      ...oldLines.map((l) => `-${l}`),
+      ...newLines.map((l) => `+${l}`),
+    ].join('\n');
+    return {
+      output,
+      diffStats: { additions: newLines.length, deletions: oldLines.length, hasDiffSignal: true },
+    };
+  }
+
+  if (details.kind === 'write') {
+    const contentLines = details.content.split('\n');
+    const output = [
+      `diff --git a/${escapedPath} b/${escapedPath}`,
+      '--- /dev/null',
+      `+++ b/${escapedPath}`,
+      `@@ -0,0 +1,${contentLines.length} @@`,
+      ...contentLines.map((l) => `+${l}`),
+    ].join('\n');
+    return {
+      output,
+      diffStats: { additions: contentLines.length, deletions: 0, hasDiffSignal: true },
+    };
+  }
+
+  if (details.kind === 'multiedit') {
+    let totalAdditions = 0;
+    let totalDeletions = 0;
+    const diffLines = [
+      `diff --git a/${escapedPath} b/${escapedPath}`,
+      `--- a/${escapedPath}`,
+      `+++ b/${escapedPath}`,
+    ];
+    for (const edit of details.edits) {
+      const oldLines = edit.oldString.split('\n');
+      const newLines = edit.newString.split('\n');
+      diffLines.push(`@@ -1,${oldLines.length} +1,${newLines.length} @@`);
+      diffLines.push(...oldLines.map((l) => `-${l}`));
+      diffLines.push(...newLines.map((l) => `+${l}`));
+      totalAdditions += newLines.length;
+      totalDeletions += oldLines.length;
+    }
+    return {
+      output: diffLines.join('\n'),
+      diffStats: { additions: totalAdditions, deletions: totalDeletions, hasDiffSignal: true },
+    };
+  }
+
+  return { output: '', diffStats: { additions: 0, deletions: 0, hasDiffSignal: false } };
+}
+
+function extractToolUseId(records: Record<string, unknown>[]): string {
+  for (const record of records) {
+    if (record.type === 'tool_use' && typeof record.id === 'string' && record.id.trim()) {
+      return record.id.trim();
+    }
+  }
+  return '';
 }
 
 function buildActionEventKey(action: ClaudeActionEvent): string {
@@ -212,7 +334,7 @@ export function parseClaudeStreamLine(line: string, options?: ParseClaudeStreamL
     'toolCallId',
     'tool_call_id',
     'call',
-  ]);
+  ]) || extractToolUseId(records);
   const sessionId = extractClaudeObservedSessionId(records);
   const turnId = sessionId || extractFirstClaudeStringByKeys(records, ['turnId', 'turn_id']) || undefined;
   const errorText = extractClaudeErrorText(payloadType, payloadSubtype, payload, records);
@@ -231,16 +353,33 @@ export function parseClaudeStreamLine(line: string, options?: ParseClaudeStreamL
 
   if (actionType) {
     const resolvedPath = normalizedPath || extractPathFromCommand(command);
+
+    let finalOutput = outputCandidate;
+    let finalDiffStats = diffStats;
+
+    // When Claude uses native tools (Edit/Write/MultiEdit), there is no shell diff output.
+    // Synthesize a unified diff from the tool input fields so the CHANGES card can appear.
+    if (!diffStats.hasDiffSignal) {
+      const toolDetails = findClaudeToolUseDetails(records);
+      if (toolDetails) {
+        const synthetic = synthesizeDiffFromToolDetails(toolDetails);
+        if (synthetic.diffStats.hasDiffSignal) {
+          finalOutput = synthetic.output;
+          finalDiffStats = synthetic.diffStats;
+        }
+      }
+    }
+
     action = {
       actionType,
       title: titleForActionType(actionType),
       callId: callId || undefined,
       command: command || undefined,
       path: resolvedPath || undefined,
-      output: outputCandidate || undefined,
-      additions: diffStats.additions,
-      deletions: diffStats.deletions,
-      hasDiffSignal: diffStats.hasDiffSignal,
+      output: finalOutput || undefined,
+      additions: finalDiffStats.additions,
+      deletions: finalDiffStats.deletions,
+      hasDiffSignal: finalDiffStats.hasDiffSignal,
     };
   }
 

--- a/services/aris-backend/tests/claudeProtocolMapper.test.ts
+++ b/services/aris-backend/tests/claudeProtocolMapper.test.ts
@@ -247,6 +247,126 @@ session source를 observed 우선 정책으로 조정`);
     ]);
   });
 
+  describe('Claude native tool calls (Edit/Write/MultiEdit) produce CHANGES card signals', () => {
+    it('detects Edit tool call and synthesizes a diff with hasDiffSignal=true', () => {
+      const line = JSON.stringify({
+        type: 'assistant',
+        session_id: 'claude-session-edit',
+        message: {
+          id: 'msg_edit',
+          type: 'message',
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_edit_001',
+              name: 'Edit',
+              input: {
+                file_path: '/project/src/app.ts',
+                old_string: 'const x = 1;',
+                new_string: 'const x = 2;\nconst y = 3;',
+              },
+            },
+          ],
+          stop_reason: 'tool_use',
+        },
+      });
+
+      const parsed = parseClaudeStreamLine(line);
+      expect(parsed.action?.actionType).toBe('file_write');
+      expect(parsed.action?.path).toBe('/project/src/app.ts');
+      expect(parsed.action?.hasDiffSignal).toBe(true);
+      expect(parsed.action?.deletions).toBe(1);
+      expect(parsed.action?.additions).toBe(2);
+      expect(parsed.action?.output).toContain('diff --git');
+      expect(parsed.action?.output).toContain('-const x = 1;');
+      expect(parsed.action?.output).toContain('+const x = 2;');
+      expect(parsed.action?.callId).toBe('toolu_edit_001');
+    });
+
+    it('detects Write tool call and synthesizes additions-only diff', () => {
+      const line = JSON.stringify({
+        type: 'assistant',
+        session_id: 'claude-session-write',
+        message: {
+          id: 'msg_write',
+          type: 'message',
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_write_002',
+              name: 'Write',
+              input: {
+                file_path: '/project/src/new-file.ts',
+                content: 'export const hello = "world";\nexport const foo = 42;',
+              },
+            },
+          ],
+          stop_reason: 'tool_use',
+        },
+      });
+
+      const parsed = parseClaudeStreamLine(line);
+      expect(parsed.action?.actionType).toBe('file_write');
+      expect(parsed.action?.path).toBe('/project/src/new-file.ts');
+      expect(parsed.action?.hasDiffSignal).toBe(true);
+      expect(parsed.action?.deletions).toBe(0);
+      expect(parsed.action?.additions).toBe(2);
+      expect(parsed.action?.output).toContain('diff --git');
+      expect(parsed.action?.output).toContain('--- /dev/null');
+      expect(parsed.action?.output).toContain('+export const hello = "world";');
+    });
+
+    it('detects MultiEdit tool call and aggregates diff from all edits', () => {
+      const line = JSON.stringify({
+        type: 'assistant',
+        session_id: 'claude-session-multiedit',
+        message: {
+          id: 'msg_multiedit',
+          type: 'message',
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_multiedit_003',
+              name: 'MultiEdit',
+              input: {
+                file_path: '/project/src/utils.ts',
+                edits: [
+                  { old_string: 'const a = 1;', new_string: 'const a = 10;' },
+                  { old_string: 'const b = 2;', new_string: 'const b = 20;\nconst c = 30;' },
+                ],
+              },
+            },
+          ],
+          stop_reason: 'tool_use',
+        },
+      });
+
+      const parsed = parseClaudeStreamLine(line);
+      expect(parsed.action?.actionType).toBe('file_write');
+      expect(parsed.action?.hasDiffSignal).toBe(true);
+      expect(parsed.action?.deletions).toBe(2);
+      expect(parsed.action?.additions).toBe(3);
+      expect(parsed.action?.output).toContain('diff --git');
+    });
+
+    it('does not overwrite hasDiffSignal when real diff output already exists', () => {
+      const line = JSON.stringify({
+        type: 'tool',
+        subtype: 'command_execution',
+        callId: 'call-apply',
+        command: 'apply_patch',
+        output: '*** update file: /project/src/app.ts\n-old line\n+new line',
+      });
+
+      const parsed = parseClaudeStreamLine(line);
+      expect(parsed.action?.hasDiffSignal).toBe(true);
+      expect(parsed.action?.output).toContain('*** update file:');
+    });
+  });
+
   it('maps Claude stream output into protocol envelopes directly', () => {
     const streamOutput = [
       JSON.stringify({


### PR DESCRIPTION
## 문제

Claude 에이전트가 `Edit`, `Write`, `MultiEdit` 네이티브 도구를 사용할 때 CHANGES 액션 카드가 표시되지 않는 버그.

## 원인 분석

Claude CLI(`--output-format stream-json`)가 출력하는 stream-json에서 네이티브 도구(Edit 등)의 결과는 다음과 같은 형식:

```json
{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"...","old_string":"old","new_string":"new"}}]}}
```

이 경우 `summarizeDiffText(outputCandidate)`가 빈 문자열을 받아 `hasDiffSignal = false`가 되어 프론트엔드에서 CHANGES 카드 대신 일반 ActionEventCard가 렌더링됨.

Shell 명령(`apply_patch`, `git diff` 등)을 사용할 때와 달리 네이티브 도구는 diff 형식 출력이 없음.

## 해결책

`claudeProtocolMapper.ts`에 3개 함수 추가:

- `findClaudeToolUseDetails()`: tool_use 레코드에서 Edit/Write/MultiEdit 입력 필드 추출
- `synthesizeDiffFromToolDetails()`: 추출한 입력값으로 unified diff 형식 합성
- `extractToolUseId()`: tool_use의 `id` 필드를 callId로 사용

기존 shell diff 출력이 있는 경우에는 합성하지 않음.

## 테스트

- Edit/Write/MultiEdit 세 가지 도구 모두 테스트 추가 (4개 새 테스트)
- 기존 테스트 15개 전체 통과

🤖 Generated with [Claude Code](https://claude.ai/claude-code)