### PR TITLE
fix(chat): restore mobile bottom scrolling behavior

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -2404,7 +2404,7 @@
 .scrollBottomButton {
   position: fixed;
   right: max(0.9rem, env(safe-area-inset-right));
-  bottom: calc(var(--composer-dock-height) + 0.92rem + var(--safe-area-bottom-effective));
+  bottom: calc(var(--composer-dock-height) + 0.92rem + var(--safe-area-bottom-effective) + var(--keyboard-inset-height, 0px));
   width: 36px;
   height: 36px;
   border-radius: 999px;
@@ -2738,7 +2738,7 @@
   position: fixed;
   left: var(--composer-dock-left);
   width: var(--composer-dock-width);
-  bottom: calc(0.5rem + var(--safe-area-bottom-effective));
+  bottom: calc(0.5rem + var(--safe-area-bottom-effective) + var(--keyboard-inset-height, 0px));
   z-index: 220;
   border-top: none;
   background: transparent;
@@ -3669,7 +3669,7 @@
 
   .scrollBottomButton {
     right: max(0.8rem, env(safe-area-inset-right));
-    bottom: calc(var(--composer-dock-height) + 0.7rem + var(--safe-area-bottom-effective));
+    bottom: calc(var(--composer-dock-height) + 0.7rem + var(--safe-area-bottom-effective) + var(--keyboard-inset-height, 0px));
   }
 }
 

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -85,6 +85,11 @@ import {
   resolveNextSelectedChatId,
   shouldShowChatTransitionLoading,
 } from './chatSelection';
+import {
+  resolveMobileWindowScrollTop,
+  resolveScrollToBottomTarget,
+  shouldResetScrollForChatChange,
+} from './chatScroll';
 
 // SSR을 비활성화해 react-syntax-highlighter의 window 참조 오류 방지
 const SyntaxHighlighter = dynamic(
@@ -2629,6 +2634,7 @@ export function ChatInterface({
   const plusMenuRef = useRef<HTMLDivElement>(null);
   const modelDropdownRef = useRef<HTMLDivElement>(null);
   const geminiModeDropdownRef = useRef<HTMLDivElement>(null);
+  const previousActiveChatIdRef = useRef<string | null>(activeChatIdResolved);
   const shouldStickToBottomRef = useRef(true);
   const disconnectNoticeAwaitingRef = useRef<string | null>(null);
   const runtimeStartedSinceAwaitingRef = useRef(false);
@@ -3957,13 +3963,15 @@ export function ChatInterface({
   }, [syncComposerDockMetrics]);
 
   const scrollConversationToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
-    if (isMobileLayout) {
-      const keyboardOpen = document.documentElement.dataset.keyboardOpen === 'true';
-      if (keyboardOpen) {
-        return;
-      }
-
-      const top = Math.max(document.documentElement.scrollHeight, document.body.scrollHeight);
+    const target = resolveScrollToBottomTarget({
+      isMobileLayout,
+      keyboardOpen: document.documentElement.dataset.keyboardOpen === 'true',
+    });
+    if (target === 'window') {
+      const top = resolveMobileWindowScrollTop({
+        scrollHeight: Math.max(document.documentElement.scrollHeight, document.body.scrollHeight),
+        viewportHeight: window.visualViewport?.height ?? window.innerHeight,
+      });
       window.scrollTo({ top, behavior });
       return;
     }
@@ -4260,6 +4268,39 @@ export function ChatInterface({
       window.clearTimeout(timeoutId);
     };
   }, [events, isAwaitingReply, effectivePendingPermissions.length, pendingUserEvents.length, scrollConversationToBottom]);
+
+  useEffect(() => {
+    const previousChatId = previousActiveChatIdRef.current;
+    previousActiveChatIdRef.current = activeChatIdResolved;
+
+    if (!shouldResetScrollForChatChange({
+      previousChatId,
+      nextChatId: activeChatIdResolved,
+      isNewChatPlaceholder,
+    })) {
+      return;
+    }
+
+    shouldStickToBottomRef.current = true;
+    setShowScrollToBottom(false);
+    scrollConversationToBottom('auto');
+
+    const rafId = window.requestAnimationFrame(() => {
+      if (shouldStickToBottomRef.current) {
+        scrollConversationToBottom('auto');
+      }
+    });
+    const timeoutId = window.setTimeout(() => {
+      if (shouldStickToBottomRef.current) {
+        scrollConversationToBottom('auto');
+      }
+    }, 140);
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      window.clearTimeout(timeoutId);
+    };
+  }, [activeChatIdResolved, isNewChatPlaceholder, scrollConversationToBottom]);
 
   const hasAgentEventSince = useCallback((since: string | null): boolean => {
     if (!since) {

--- a/services/aris-web/app/sessions/[sessionId]/chatScroll.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chatScroll.ts
@@ -1,0 +1,33 @@
+type ScrollToBottomTargetInput = {
+  isMobileLayout: boolean;
+  keyboardOpen: boolean;
+};
+
+type MobileWindowScrollTopInput = {
+  scrollHeight: number;
+  viewportHeight: number;
+};
+
+type ResetScrollForChatChangeInput = {
+  previousChatId: string | null;
+  nextChatId: string | null;
+  isNewChatPlaceholder: boolean;
+};
+
+export function resolveScrollToBottomTarget(input: ScrollToBottomTargetInput): 'window' | 'stream' {
+  if (input.isMobileLayout) {
+    return 'window';
+  }
+  return 'stream';
+}
+
+export function resolveMobileWindowScrollTop(input: MobileWindowScrollTopInput): number {
+  return Math.max(0, input.scrollHeight - input.viewportHeight);
+}
+
+export function shouldResetScrollForChatChange(input: ResetScrollForChatChangeInput): boolean {
+  if (input.isNewChatPlaceholder || !input.nextChatId) {
+    return false;
+  }
+  return input.previousChatId !== input.nextChatId;
+}

--- a/services/aris-web/tests/chatScroll.test.ts
+++ b/services/aris-web/tests/chatScroll.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveMobileWindowScrollTop,
+  resolveScrollToBottomTarget,
+  shouldResetScrollForChatChange,
+} from '@/app/sessions/[sessionId]/chatScroll';
+
+describe('chatScroll', () => {
+  it('keeps mobile scroll-to-bottom enabled even while the virtual keyboard is open', () => {
+    expect(resolveScrollToBottomTarget({ isMobileLayout: true, keyboardOpen: false })).toBe('window');
+    expect(resolveScrollToBottomTarget({ isMobileLayout: true, keyboardOpen: true })).toBe('window');
+    expect(resolveScrollToBottomTarget({ isMobileLayout: false, keyboardOpen: false })).toBe('stream');
+  });
+
+  it('computes the bottom window scroll position from document and viewport height', () => {
+    expect(resolveMobileWindowScrollTop({ scrollHeight: 2200, viewportHeight: 700 })).toBe(1500);
+    expect(resolveMobileWindowScrollTop({ scrollHeight: 640, viewportHeight: 800 })).toBe(0);
+  });
+
+  it('resets conversation scroll when switching to a different active chat', () => {
+    expect(shouldResetScrollForChatChange({
+      previousChatId: 'chat-1',
+      nextChatId: 'chat-2',
+      isNewChatPlaceholder: false,
+    })).toBe(true);
+
+    expect(shouldResetScrollForChatChange({
+      previousChatId: 'chat-2',
+      nextChatId: 'chat-2',
+      isNewChatPlaceholder: false,
+    })).toBe(false);
+
+    expect(shouldResetScrollForChatChange({
+      previousChatId: 'chat-1',
+      nextChatId: null,
+      isNewChatPlaceholder: false,
+    })).toBe(false);
+
+    expect(shouldResetScrollForChatChange({
+      previousChatId: 'chat-1',
+      nextChatId: 'chat-2',
+      isNewChatPlaceholder: true,
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- fix mobile chat scroll-to-bottom so it still works while the virtual keyboard is open
- reset conversation scroll to the latest message when switching chats
- lift the composer and bottom button by the keyboard inset and add regression tests

## Test Plan
- npm test -- chatScroll.test.ts chatSelection.test.ts chatComposer.test.ts
- npm run lint
- npm run build