### PR TITLE
백엔드 세션 메시지 seq 충돌 및 Claude commentary 정렬 수정

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -4076,11 +4076,10 @@ export class HappyRuntimeStore {
         protocolEnvelopes?: SessionProtocolEnvelope[];
         inferredActions?: ParsedAgentActionEvent[];
       };
-      const streamedClaudeTextReplies = new Set<string>();
       const streamedGeminiTextReplies = new Set<string>();
       let streamedGeminiCompletedTextPersisted = false;
-      // onText 콜백에서 claude 텍스트를 실제로 저장했는지 추적하는 플래그
-      let claudeTextStreamed = false;
+      const streamedClaudeTextReplies = new Set<string>();
+      let streamedClaudeCompletedTextPersisted = false;
       let claudeMessageQueue: ClaudeMessageQueue | null = null;
       let geminiMessageQueue: GeminiMessageQueue | null = null;
       const persistClaudeProjection = async (projection: {
@@ -4199,23 +4198,48 @@ export class HappyRuntimeStore {
               streamedActionIndex += 1;
             },
             onText: async (event, meta) => {
-              // Claude CLI는 동일한 텍스트를 'assistant' 이벤트와 'result' 이벤트로 두 번 방출
-              // 'result' 이벤트는 스트리밍 완료 후 최종 출력을 다시 전달하는 것이므로 우선 무시.
-              // 단, 'assistant' 스트리밍이 누락된 예외적인 경우를 대비해 fallback으로 활용
-              if (event.source === 'result' && claudeTextStreamed) {
-                return;
-              }
               const normalizedText = sanitizeAgentMessageText(event.text);
               if (!normalizedText) {
                 return;
               }
-              claudeTextStreamed = true;
+              const eventPhase = event.phase === 'commentary'
+                ? 'commentary'
+                : event.source === 'result'
+                  ? 'final'
+                  : 'commentary';
+              const textKey = buildStreamedTextReplyKey({
+                source: event.source,
+                phase: eventPhase,
+                threadId: meta.threadId,
+                text: normalizedText,
+              });
+              if (streamedClaudeTextReplies.has(textKey)) {
+                return;
+              }
+
+              if (event.source === 'result') {
+                const assistantTwinKey = buildStreamedTextReplyKey({
+                  source: 'assistant',
+                  phase: eventPhase,
+                  threadId: meta.threadId,
+                  text: normalizedText,
+                });
+                if (streamedClaudeTextReplies.has(assistantTwinKey)) {
+                  return;
+                }
+              }
+
+              streamedClaudeTextReplies.add(textKey);
+              if (eventPhase === 'final') {
+                streamedClaudeCompletedTextPersisted = true;
+              }
               await claudeMessageQueue?.enqueueText({
                 output: normalizedText,
                 execCwd: nonCodexCwd,
                 threadId: meta.threadId,
                 messageMeta: {
                   streamEvent: 'agent_message',
+                  ...(eventPhase === 'commentary' ? { messagePhase: eventPhase } : {}),
                 },
                 envelopes: event.envelopes,
               });
@@ -4243,9 +4267,7 @@ export class HappyRuntimeStore {
             output: claudeResponse.output,
             cwd: claudeResponse.cwd,
             streamedPersisted: false,
-            // onText 콜백에서 실제로 텍스트를 저장한 경우 true로 설정
-            // → persistFinalAgentOutput이 중복 실행되지 않도록 차단
-            agentMessagePersisted: claudeTextStreamed,
+            agentMessagePersisted: streamedClaudeCompletedTextPersisted,
             streamedActionsPersisted: claudeResponse.streamedActionsPersisted,
             inferredActions: claudeResponse.inferredActions,
             threadId: claudeResponse.threadId ?? claudeResponse.actionThreadId,
@@ -4516,9 +4538,36 @@ export class HappyRuntimeStore {
 
       const finalAgentOutput = sanitizeAgentMessageText(response.output);
       const streamedPersisted = Boolean(response.streamedPersisted);
-      // claudeTextStreamed가 true이면 이미 onText에서 저장 완료이므로 중복 저장 방지
-      // (이전의 Set 기반 중복 감지 로직은 claudeTextStreamed 플래그로 대체)
       const agentMessagePersisted = Boolean(response.agentMessagePersisted)
+        || (
+          flavor === 'claude'
+          && (
+            streamedClaudeCompletedTextPersisted
+            || (
+              finalAgentOutput.length > 0
+              && (
+                streamedClaudeTextReplies.has(buildStreamedTextReplyKey({
+                  source: 'assistant',
+                  phase: 'final',
+                  threadId: response.threadId,
+                  text: finalAgentOutput,
+                }))
+                || streamedClaudeTextReplies.has(buildStreamedTextReplyKey({
+                  source: 'assistant',
+                  phase: 'commentary',
+                  threadId: response.threadId,
+                  text: finalAgentOutput,
+                }))
+                || streamedClaudeTextReplies.has(buildStreamedTextReplyKey({
+                  source: 'result',
+                  phase: 'final',
+                  threadId: response.threadId,
+                  text: finalAgentOutput,
+                }))
+              )
+            )
+          )
+        )
         || (
           flavor === 'gemini'
           && (

--- a/services/aris-backend/src/runtime/prismaStore.ts
+++ b/services/aris-backend/src/runtime/prismaStore.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import type {
   ApprovalPolicy,
@@ -38,6 +38,8 @@ type CreatePermissionInput = {
   reason: string;
   risk: PermissionRisk;
 };
+
+const SESSION_MESSAGE_WRITE_MAX_RETRIES = 5;
 
 function toRuntimeSession(row: {
   id: string;
@@ -174,6 +176,19 @@ function toPermissionRequest(row: {
   };
 }
 
+function getPrismaErrorCode(error: unknown): string | null {
+  if (!error || typeof error !== 'object') {
+    return null;
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : null;
+}
+
+function isRetryableSessionMessageWriteError(error: unknown): boolean {
+  const code = getPrismaErrorCode(error);
+  return code === 'P2002' || code === 'P2034';
+}
+
 export class PrismaRuntimeStore {
   private readonly db: PrismaClient;
 
@@ -190,6 +205,25 @@ export class PrismaRuntimeStore {
 
   async disconnect(): Promise<void> {
     await this.db.$disconnect();
+  }
+
+  private async runSessionMessageMutationWithRetry<T>(
+    operation: (tx: Prisma.TransactionClient) => Promise<T>,
+  ): Promise<T> {
+    for (let attempt = 1; attempt <= SESSION_MESSAGE_WRITE_MAX_RETRIES; attempt += 1) {
+      try {
+        return await this.db.$transaction(
+          async (tx) => operation(tx),
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        );
+      } catch (error) {
+        if (!isRetryableSessionMessageWriteError(error) || attempt === SESSION_MESSAGE_WRITE_MAX_RETRIES) {
+          throw error;
+        }
+      }
+    }
+
+    throw new Error('SESSION_MESSAGE_WRITE_RETRY_EXHAUSTED');
   }
 
   async listSessions(): Promise<RuntimeSession[]> {
@@ -303,32 +337,34 @@ export class PrismaRuntimeStore {
     const isAgentMessage = input.meta?.role === 'agent';
     const isUserPrompt = input.type === 'message' && !isAgentMessage;
 
-    // next seq number
-    const agg = await this.db.sessionMessage.aggregate({
-      where: { sessionId },
-      _max: { seq: true },
-    });
-    const nextSeq = (agg._max.seq ?? 0) + 1;
-
     const newStatus: SessionStatus = isUserPrompt ? 'running' : isAgentMessage ? 'idle' : (session.status as SessionStatus);
 
-    const [row] = await this.db.$transaction([
-      this.db.sessionMessage.create({
+    const row = await this.runSessionMessageMutationWithRetry(async (tx) => {
+      const agg = await tx.sessionMessage.aggregate({
+        where: { sessionId },
+        _max: { seq: true },
+      });
+      const nextSeq = (agg._max.seq ?? 0) + 1;
+
+      const created = await tx.sessionMessage.create({
         data: {
           id: randomUUID(),
           sessionId,
           type: input.type,
           title: input.title ?? input.type,
           text: input.text,
-          meta: (input.meta ?? {}) as Parameters<typeof this.db.sessionMessage.create>[0]['data']['meta'],
+          meta: (input.meta ?? {}) as Parameters<typeof tx.sessionMessage.create>[0]['data']['meta'],
           seq: nextSeq,
         },
-      }),
-      this.db.session.update({
+      });
+
+      await tx.session.update({
         where: { id: sessionId },
         data: { status: newStatus, updatedAt: new Date() },
-      }),
-    ]);
+      });
+
+      return created;
+    });
 
     return toRuntimeMessage(row);
   }
@@ -364,12 +400,17 @@ export class PrismaRuntimeStore {
       updates.riskScore = Math.max(10, session.riskScore - 15);
     }
 
-    await this.db.$transaction([
-      this.db.session.update({
+    await this.runSessionMessageMutationWithRetry(async (tx) => {
+      const nextSeq = await tx.sessionMessage
+        .aggregate({ where: { sessionId }, _max: { seq: true } })
+        .then((a) => (a._max.seq ?? 0) + 1);
+
+      await tx.session.update({
         where: { id: sessionId },
         data: { ...updates, updatedAt: new Date(at) },
-      }),
-      this.db.sessionMessage.create({
+      });
+
+      await tx.sessionMessage.create({
         data: {
           id: randomUUID(),
           sessionId,
@@ -381,12 +422,10 @@ export class PrismaRuntimeStore {
             action,
             ...(normalizedChatId ? { chatId: normalizedChatId } : {}),
           },
-          seq: await this.db.sessionMessage
-            .aggregate({ where: { sessionId }, _max: { seq: true } })
-            .then((a) => (a._max.seq ?? 0) + 1),
+          seq: nextSeq,
         },
-      }),
-    ]);
+      });
+    });
 
     return { accepted: true, message: `${action.toUpperCase()} acknowledged`, at };
   }

--- a/services/aris-backend/tests/prismaRuntimeStore.test.ts
+++ b/services/aris-backend/tests/prismaRuntimeStore.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  PrismaRuntimeStore,
   filterRealtimeRowsByChat,
   resolveChatRunningState,
 } from '../src/runtime/prismaStore.js';
+
+function buildStoreWithMockDb(db: Record<string, unknown>): PrismaRuntimeStore {
+  const store = Object.create(PrismaRuntimeStore.prototype) as PrismaRuntimeStore & {
+    db: Record<string, unknown>;
+  };
+  store.db = db;
+  return store;
+}
 
 describe('filterRealtimeRowsByChat', () => {
   it('returns only rows for the requested chat id', () => {
@@ -45,5 +54,57 @@ describe('resolveChatRunningState', () => {
     ];
 
     expect(resolveChatRunningState(rows, 'chat-a')).toBe(false);
+  });
+});
+
+describe('PrismaRuntimeStore.appendMessage', () => {
+  it('retries when the next seq collides with an existing message in the same session', async () => {
+    const aggregate = vi.fn()
+      .mockResolvedValueOnce({ _max: { seq: 1 } })
+      .mockResolvedValueOnce({ _max: { seq: 2 } });
+    const create = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('duplicate seq'), { code: 'P2002' }))
+      .mockImplementationOnce(async ({ data }: { data: Record<string, unknown> }) => ({
+        id: 'message-2',
+        sessionId: data.sessionId,
+        type: data.type,
+        title: data.title,
+        text: data.text,
+        meta: data.meta,
+        seq: data.seq,
+        createdAt: new Date('2026-04-11T00:00:00.000Z'),
+      }));
+    const update = vi.fn().mockResolvedValue({ id: 'session-1', status: 'idle' });
+    const session = {
+      findUnique: vi.fn().mockResolvedValue({ id: 'session-1', status: 'idle' }),
+      update,
+    };
+    const sessionMessage = {
+      aggregate,
+      create,
+    };
+    const db = {
+      session,
+      sessionMessage,
+      $transaction: vi.fn(async (input: unknown) => {
+        if (typeof input === 'function') {
+          return input({ session, sessionMessage });
+        }
+        return Promise.all(input as Promise<unknown>[]);
+      }),
+    };
+    const store = buildStoreWithMockDb(db);
+
+    const message = await store.appendMessage('session-1', {
+      type: 'message',
+      title: 'Text Reply',
+      text: '조사 중입니다.',
+      meta: { role: 'agent' },
+    });
+
+    expect(message.meta?.seq).toBe(3);
+    expect(aggregate).toHaveBeenCalledTimes(2);
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(update).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## 요약
- Prisma `sessionMessage.create()` 의 `(sessionId, seq)` 유니크 충돌을 `Serializable` 트랜잭션 + 재시도로 보강했습니다.
- Claude intermediate commentary 와 final output 의 영속화 순서를 보정했습니다.
- 관련 회귀 테스트와 전체 백엔드 테스트를 통과시켰습니다.

## 검증
- `npm run typecheck`
- `npm test`

## 운영 반영
- `DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env ./deploy/deploy_backend_zero_downtime.sh`
- `./deploy/ops/check-runtime-connection.sh` 재검증 통과
