### PR TITLE
feat: 채팅 메시지 Link Preview Card 추가

### DIFF
--- a/services/aris-web/app/api/link-preview/route.ts
+++ b/services/aris-web/app/api/link-preview/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireApiUser } from '@/lib/auth/guard';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface OgMeta {
+  url: string;
+  title: string;
+  description: string;
+  image: string;
+  siteName: string;
+  favicon: string;
+}
+
+const metaCache = new Map<string, { data: OgMeta; ts: number }>();
+const CACHE_TTL_MS = 1000 * 60 * 30; // 30 min
+const MAX_CACHE_SIZE = 200;
+const FETCH_TIMEOUT_MS = 5000;
+
+function extractMetaContent(html: string, property: string): string {
+  // Match both property="og:..." and name="og:..." patterns
+  const patterns = [
+    new RegExp(`<meta[^>]+(?:property|name)=["']${property}["'][^>]+content=["']([^"']*)["']`, 'i'),
+    new RegExp(`<meta[^>]+content=["']([^"']*)["'][^>]+(?:property|name)=["']${property}["']`, 'i'),
+  ];
+  for (const re of patterns) {
+    const m = html.match(re);
+    if (m?.[1]) return m[1];
+  }
+  return '';
+}
+
+function extractTitle(html: string): string {
+  const m = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+  return m?.[1]?.trim() ?? '';
+}
+
+function extractFavicon(html: string, baseUrl: string): string {
+  const patterns = [
+    /<link[^>]+rel=["'](?:icon|shortcut icon)["'][^>]+href=["']([^"']*)["']/i,
+    /<link[^>]+href=["']([^"']*)["'][^>]+rel=["'](?:icon|shortcut icon)["']/i,
+  ];
+  for (const re of patterns) {
+    const m = html.match(re);
+    if (m?.[1]) {
+      return resolveUrl(m[1], baseUrl);
+    }
+  }
+  try {
+    const u = new URL(baseUrl);
+    return `${u.origin}/favicon.ico`;
+  } catch {
+    return '';
+  }
+}
+
+function resolveUrl(raw: string, base: string): string {
+  if (!raw) return '';
+  try {
+    return new URL(raw, base).href;
+  } catch {
+    return raw;
+  }
+}
+
+async function fetchOgMeta(url: string): Promise<OgMeta> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; ARISBot/1.0; +https://aris.lawdigest.cloud)',
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      redirect: 'follow',
+    });
+    clearTimeout(timer);
+
+    if (!res.ok) {
+      return { url, title: '', description: '', image: '', siteName: '', favicon: '' };
+    }
+
+    // Only read first 50KB for meta tags
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return { url, title: '', description: '', image: '', siteName: '', favicon: '' };
+    }
+
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    const MAX_BYTES = 50_000;
+
+    while (totalBytes < MAX_BYTES) {
+      const { done, value } = await reader.read();
+      if (done || !value) break;
+      chunks.push(value);
+      totalBytes += value.length;
+    }
+    reader.cancel().catch(() => {});
+
+    const html = new TextDecoder().decode(
+      chunks.length === 1 ? chunks[0] : Buffer.concat(chunks),
+    );
+
+    const ogTitle = extractMetaContent(html, 'og:title');
+    const ogDesc = extractMetaContent(html, 'og:description');
+    const ogImage = extractMetaContent(html, 'og:image');
+    const ogSiteName = extractMetaContent(html, 'og:site_name');
+    const metaDesc = extractMetaContent(html, 'description');
+    const twitterTitle = extractMetaContent(html, 'twitter:title');
+    const twitterDesc = extractMetaContent(html, 'twitter:description');
+    const twitterImage = extractMetaContent(html, 'twitter:image');
+
+    return {
+      url,
+      title: ogTitle || twitterTitle || extractTitle(html),
+      description: ogDesc || twitterDesc || metaDesc,
+      image: resolveUrl(ogImage || twitterImage, url),
+      siteName: ogSiteName || tryHostname(url),
+      favicon: extractFavicon(html, url),
+    };
+  } catch {
+    clearTimeout(timer);
+    return { url, title: '', description: '', image: '', siteName: tryHostname(url), favicon: '' };
+  }
+}
+
+function tryHostname(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return '';
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await requireApiUser(request);
+  if ('response' in auth) return auth.response;
+
+  const targetUrl = request.nextUrl.searchParams.get('url');
+  if (!targetUrl) {
+    return NextResponse.json({ error: 'Missing url parameter' }, { status: 400 });
+  }
+
+  // Validate URL scheme
+  try {
+    const parsed = new URL(targetUrl);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return NextResponse.json({ error: 'Invalid URL scheme' }, { status: 400 });
+    }
+  } catch {
+    return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
+  }
+
+  // Check cache
+  const cached = metaCache.get(targetUrl);
+  if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+    return NextResponse.json(cached.data, {
+      headers: { 'Cache-Control': 'public, max-age=1800' },
+    });
+  }
+
+  const meta = await fetchOgMeta(targetUrl);
+
+  // Evict oldest if full
+  if (metaCache.size >= MAX_CACHE_SIZE) {
+    const oldest = metaCache.keys().next().value;
+    if (oldest !== undefined) metaCache.delete(oldest);
+  }
+  metaCache.set(targetUrl, { data: meta, ts: Date.now() });
+
+  return NextResponse.json(meta, {
+    headers: { 'Cache-Control': 'public, max-age=1800' },
+  });
+}

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -4306,3 +4306,177 @@
     display: none;
   }
 }
+
+/* ─── Link Preview Cards ─── */
+
+.linkPreviewWrap {
+  position: relative;
+  margin-top: 0.45rem;
+  max-width: min(92%, 860px);
+}
+
+.linkPreviewTrack {
+  display: flex;
+  gap: 0.55rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  padding: 0.15rem 0;
+}
+
+.linkPreviewTrack::-webkit-scrollbar {
+  display: none;
+}
+
+.linkPreviewCard {
+  flex: 0 0 280px;
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  background: var(--chat-msg-agent-bg);
+  border: 1px solid var(--chat-msg-border);
+  border-radius: 12px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  box-shadow: var(--chat-msg-shadow);
+  transition: border-color 0.18s, box-shadow 0.18s, transform 0.15s;
+  cursor: pointer;
+}
+
+.linkPreviewCard:hover {
+  border-color: var(--chat-accent);
+  box-shadow: var(--chat-msg-shadow-strong);
+  transform: translateY(-1px);
+}
+
+.linkPreviewImageWrap {
+  width: 100%;
+  height: 140px;
+  overflow: hidden;
+  background: var(--chat-surface-subtle);
+  flex-shrink: 0;
+}
+
+.linkPreviewImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.linkPreviewBody {
+  padding: 0.55rem 0.65rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.22rem;
+  min-height: 0;
+}
+
+.linkPreviewSite {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  color: var(--chat-text-muted);
+  line-height: 1.2;
+}
+
+.linkPreviewFavicon {
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+  flex-shrink: 0;
+  object-fit: contain;
+}
+
+.linkPreviewGlobe {
+  flex-shrink: 0;
+  opacity: 0.55;
+}
+
+.linkPreviewSiteName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.linkPreviewExtIcon {
+  flex-shrink: 0;
+  opacity: 0.4;
+  margin-left: auto;
+}
+
+.linkPreviewTitle {
+  font-size: 0.82rem;
+  font-weight: 650;
+  line-height: 1.32;
+  color: var(--chat-text-primary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.linkPreviewDesc {
+  font-size: 0.73rem;
+  line-height: 1.38;
+  color: var(--chat-text-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.linkPreviewNavBtn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 1px solid var(--chat-msg-border);
+  background: var(--chat-control-bg);
+  color: var(--chat-control-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.12);
+  transition: background 0.15s, border-color 0.15s;
+  padding: 0;
+}
+
+.linkPreviewNavBtn:hover {
+  border-color: var(--chat-accent);
+  color: var(--chat-accent);
+}
+
+.linkPreviewNavBtnLeft {
+  left: -14px;
+}
+
+.linkPreviewNavBtnRight {
+  right: -14px;
+}
+
+@media (max-width: 768px) {
+  .linkPreviewCard {
+    flex: 0 0 240px;
+  }
+
+  .linkPreviewImageWrap {
+    height: 110px;
+  }
+
+  .linkPreviewNavBtn {
+    display: none;
+  }
+
+  .linkPreviewWrap {
+    max-width: 100%;
+  }
+}

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -45,6 +45,7 @@ import {
   CheckCircle2,
   CornerDownRight,
   ChevronDown,
+  ChevronLeft,
   ChevronUp,
   ChevronRight,
   CircleAlert,
@@ -72,6 +73,8 @@ import {
   Pin,
   Plus,
   Square,
+  ExternalLink,
+  Globe,
   TerminalSquare,
   Trash2,
   X,
@@ -1856,6 +1859,195 @@ function TextReply({ body, isUser }: { body: string; isUser: boolean }) {
   return (
     <div className={isUser ? styles.userText : styles.agentText}>
       <MarkdownContent body={normalized} />
+    </div>
+  );
+}
+
+/* ─── Link Preview ─── */
+
+interface LinkPreviewMeta {
+  url: string;
+  title: string;
+  description: string;
+  image: string;
+  siteName: string;
+  favicon: string;
+}
+
+const LINK_URL_RE = /https?:\/\/[^\s)<>]+/g;
+
+function extractExternalUrls(text: string): string[] {
+  const matches = text.match(LINK_URL_RE);
+  if (!matches) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of matches) {
+    // Strip trailing punctuation that's unlikely part of the URL
+    const url = raw.replace(/[.,;:!?)]+$/, '');
+    if (!seen.has(url)) {
+      seen.add(url);
+      result.push(url);
+    }
+  }
+  return result;
+}
+
+const linkPreviewClientCache = new Map<string, LinkPreviewMeta>();
+
+function useLinkPreviews(urls: string[]): LinkPreviewMeta[] {
+  const [previews, setPreviews] = useState<LinkPreviewMeta[]>([]);
+
+  useEffect(() => {
+    if (urls.length === 0) {
+      setPreviews([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function load() {
+      const results: LinkPreviewMeta[] = [];
+      for (const url of urls) {
+        const cached = linkPreviewClientCache.get(url);
+        if (cached) {
+          results.push(cached);
+          continue;
+        }
+        try {
+          const res = await fetch(`/api/link-preview?url=${encodeURIComponent(url)}`);
+          if (!res.ok) {
+            results.push({ url, title: '', description: '', image: '', siteName: '', favicon: '' });
+            continue;
+          }
+          const meta: LinkPreviewMeta = await res.json();
+          linkPreviewClientCache.set(url, meta);
+          results.push(meta);
+        } catch {
+          results.push({ url, title: '', description: '', image: '', siteName: '', favicon: '' });
+        }
+      }
+      if (!cancelled) setPreviews(results);
+    }
+
+    void load();
+    return () => { cancelled = true; };
+  }, [urls.join('\n')]);
+
+  return previews;
+}
+
+function LinkPreviewCarousel({ body }: { body: string }) {
+  const urls = useMemo(() => extractExternalUrls(body), [body]);
+  const previews = useLinkPreviews(urls);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 2);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 2);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener('scroll', updateScrollState, { passive: true });
+    const ro = new ResizeObserver(updateScrollState);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener('scroll', updateScrollState);
+      ro.disconnect();
+    };
+  }, [previews.length, updateScrollState]);
+
+  const scroll = useCallback((direction: 'left' | 'right') => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const cardWidth = 296;
+    el.scrollBy({ left: direction === 'left' ? -cardWidth : cardWidth, behavior: 'smooth' });
+  }, []);
+
+  const meaningful = previews.filter(p => p.title || p.description || p.image);
+  if (meaningful.length === 0) return null;
+
+  return (
+    <div className={styles.linkPreviewWrap}>
+      {canScrollLeft && (
+        <button
+          type="button"
+          className={`${styles.linkPreviewNavBtn} ${styles.linkPreviewNavBtnLeft}`}
+          onClick={() => scroll('left')}
+          aria-label="이전 링크"
+        >
+          <ChevronLeft size={16} />
+        </button>
+      )}
+      <div className={styles.linkPreviewTrack} ref={scrollRef}>
+        {meaningful.map((meta) => (
+          <a
+            key={meta.url}
+            href={meta.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            className={styles.linkPreviewCard}
+          >
+            {meta.image && (
+              <div className={styles.linkPreviewImageWrap}>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={meta.image}
+                  alt=""
+                  className={styles.linkPreviewImage}
+                  loading="lazy"
+                  onError={(e) => {
+                    (e.currentTarget.parentElement as HTMLElement).style.display = 'none';
+                  }}
+                />
+              </div>
+            )}
+            <div className={styles.linkPreviewBody}>
+              <div className={styles.linkPreviewSite}>
+                {meta.favicon ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={meta.favicon}
+                    alt=""
+                    className={styles.linkPreviewFavicon}
+                    width={14}
+                    height={14}
+                    onError={(e) => {
+                      e.currentTarget.style.display = 'none';
+                      (e.currentTarget.nextElementSibling as HTMLElement | null)?.style.removeProperty('display');
+                    }}
+                  />
+                ) : null}
+                <Globe size={14} className={styles.linkPreviewGlobe} style={meta.favicon ? { display: 'none' } : undefined} />
+                <span className={styles.linkPreviewSiteName}>{meta.siteName || new URL(meta.url).hostname}</span>
+                <ExternalLink size={11} className={styles.linkPreviewExtIcon} />
+              </div>
+              {meta.title && (
+                <div className={styles.linkPreviewTitle}>{meta.title}</div>
+              )}
+              {meta.description && (
+                <div className={styles.linkPreviewDesc}>{meta.description}</div>
+              )}
+            </div>
+          </a>
+        ))}
+      </div>
+      {canScrollRight && (
+        <button
+          type="button"
+          className={`${styles.linkPreviewNavBtn} ${styles.linkPreviewNavBtnRight}`}
+          onClick={() => scroll('right')}
+          aria-label="다음 링크"
+        >
+          <ChevronRight size={16} />
+        </button>
+      )}
     </div>
   );
 }
@@ -5963,6 +6155,9 @@ export function ChatInterface({
                       <div className={`${styles.messageBubble} ${styles.messageBubbleAgent}`}>
                         {renderEventPayload(event, false, expandedResultIds[event.id] ?? false, () => toggleResult(event.id), isDebugMode)}
                       </div>
+                      {!isDebugMode && !isActionKind(event.kind) && (event.body || event.title) && (
+                        <LinkPreviewCarousel body={event.body || event.title} />
+                      )}
                     </div>
                   </div>
                 </article>


### PR DESCRIPTION
## Summary
- 에이전트 메시지에 포함된 URL을 감지하여 채팅 버블 아래에 OG 메타데이터 기반 Link Preview Card 표시
- 여러 URL이 있으면 좌우 스크롤 가능한 캐러셀로 렌더링, 데스크톱에서 좌우 네비게이션 버튼 제공
- 서버사이드 OG 메타 파싱 API (`/api/link-preview`) 추가 (in-memory 캐시 30분, 50KB 제한 읽기)

## 변경 파일
- `services/aris-web/app/api/link-preview/route.ts` — OG 메타 파싱 API 라우트 (신규)
- `services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx` — URL 추출, LinkPreviewCarousel 컴포넌트, 에이전트 버블 통합
- `services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css` — 카드/캐러셀/네비 버튼 스타일 (라이트/다크 테마 자동 대응)

## Test plan
- [ ] 에이전트가 URL 1개 포함된 메시지 전송 시 카드 표시 확인
- [ ] URL 3개 이상 포함 시 좌우 스크롤 + 네비 버튼 동작 확인
- [ ] OG 이미지 없는 URL에서도 title/description만으로 카드 표시 확인
- [ ] 다크 모드에서 스타일 정상 확인
- [ ] 모바일 뷰포트에서 네비 버튼 숨김 + 터치 스크롤 확인