### PR TITLE
feat: 링크 프리뷰 개선 - 이미지 프록시, 영속 캐시, 특수 사이트 카드

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ services/aris-web/.env.bak-*
 services/aris-backend/.env
 services/aris-backend/.env.bak-*
 **/tsconfig.tsbuildinfo
+**/.cache/
 
 **/logs/
 services/aris-backend/logs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ x-aris-web-common: &aris_web_common
     - ${HOST_HOME_DIR:-/home/ubuntu}/.claude/debug:/agent-home/.claude/debug:ro
     - ${HOST_HOME_DIR:-/home/ubuntu}/.claude/mcp-needs-auth-cache.json:/agent-home/.claude/mcp-needs-auth-cache.json:ro
     - ${HOST_HOME_DIR:-/home/ubuntu}/.claude/.claude.json:/agent-home/.claude/.claude.json:ro
+    - link_preview_cache:/app/.cache
   expose:
     - "3000"
   healthcheck:
@@ -116,6 +117,7 @@ services:
 
 volumes:
   postgres_data:
+  link_preview_cache:
   caddy_data:
   caddy_config:
 

--- a/services/aris-web/.dockerignore
+++ b/services/aris-web/.dockerignore
@@ -1,4 +1,5 @@
 node_modules
 .next
+.cache
 .env
 npm-debug.log*

--- a/services/aris-web/app/api/link-preview/image/route.ts
+++ b/services/aris-web/app/api/link-preview/image/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireApiUser } from '@/lib/auth/guard';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const FETCH_TIMEOUT_MS = 8000;
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5MB
+const ALLOWED_CONTENT_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+  'image/x-icon',
+  'image/vnd.microsoft.icon',
+];
+
+export async function GET(request: NextRequest) {
+  const auth = await requireApiUser(request);
+  if ('response' in auth) return auth.response;
+
+  const targetUrl = request.nextUrl.searchParams.get('url');
+  if (!targetUrl) {
+    return NextResponse.json({ error: 'Missing url parameter' }, { status: 400 });
+  }
+
+  try {
+    const parsed = new URL(targetUrl);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return NextResponse.json({ error: 'Invalid URL scheme' }, { status: 400 });
+    }
+    // Block private/loopback IPs for SSRF prevention
+    const host = parsed.hostname;
+    if (
+      host === 'localhost' ||
+      host === '127.0.0.1' ||
+      host === '::1' ||
+      host.startsWith('10.') ||
+      host.startsWith('192.168.') ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+      host.endsWith('.local')
+    ) {
+      return NextResponse.json({ error: 'Private addresses not allowed' }, { status: 400 });
+    }
+  } catch {
+    return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const upstream = await fetch(targetUrl, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; ARISBot/1.0; +https://aris.lawdigest.cloud)',
+        Accept: 'image/*',
+      },
+      redirect: 'follow',
+    });
+    clearTimeout(timer);
+
+    if (!upstream.ok) {
+      return NextResponse.json({ error: 'Upstream fetch failed' }, { status: 502 });
+    }
+
+    const contentType = upstream.headers.get('content-type')?.split(';')[0]?.trim() ?? '';
+    if (!ALLOWED_CONTENT_TYPES.some((t) => contentType.startsWith(t))) {
+      return NextResponse.json({ error: 'Not an image' }, { status: 400 });
+    }
+
+    const contentLength = parseInt(upstream.headers.get('content-length') ?? '0', 10);
+    if (contentLength > MAX_IMAGE_BYTES) {
+      return NextResponse.json({ error: 'Image too large' }, { status: 413 });
+    }
+
+    // Stream body with size limit
+    const reader = upstream.body?.getReader();
+    if (!reader) {
+      return NextResponse.json({ error: 'No body' }, { status: 502 });
+    }
+
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done || !value) break;
+      totalBytes += value.length;
+      if (totalBytes > MAX_IMAGE_BYTES) {
+        reader.cancel().catch(() => {});
+        return NextResponse.json({ error: 'Image too large' }, { status: 413 });
+      }
+      chunks.push(value);
+    }
+
+    const body = Buffer.from(chunks.length === 1 ? chunks[0] : Buffer.concat(chunks));
+
+    return new NextResponse(body as unknown as BodyInit, {
+      status: 200,
+      headers: {
+        'Content-Type': contentType,
+        'Content-Length': String(totalBytes),
+        'Cache-Control': 'public, max-age=86400, immutable',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch {
+    clearTimeout(timer);
+    return NextResponse.json({ error: 'Fetch failed' }, { status: 502 });
+  }
+}

--- a/services/aris-web/app/api/link-preview/route.ts
+++ b/services/aris-web/app/api/link-preview/route.ts
@@ -1,8 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireApiUser } from '@/lib/auth/guard';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+
+/* ─── Types ─── */
+
+type SiteType = 'github_repo' | 'github_issue' | 'github_pr' | 'youtube' | 'generic';
 
 interface OgMeta {
   url: string;
@@ -11,15 +18,166 @@ interface OgMeta {
   image: string;
   siteName: string;
   favicon: string;
+  siteType: SiteType;
+  extra: Record<string, string>;
 }
 
-const metaCache = new Map<string, { data: OgMeta; ts: number }>();
-const CACHE_TTL_MS = 1000 * 60 * 30; // 30 min
-const MAX_CACHE_SIZE = 200;
+/* ─── File-based persistent cache ─── */
+
+const CACHE_DIR = path.join(process.cwd(), '.cache', 'link-preview');
+const CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
+const MAX_MEMORY_CACHE = 200;
 const FETCH_TIMEOUT_MS = 5000;
 
+const memoryCache = new Map<string, { data: OgMeta; ts: number }>();
+
+function cacheKey(url: string): string {
+  return crypto.createHash('sha256').update(url).digest('hex').slice(0, 24);
+}
+
+function ensureCacheDir(): void {
+  try {
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+  } catch {
+    // ignore
+  }
+}
+
+function readDiskCache(url: string): OgMeta | null {
+  try {
+    const filePath = path.join(CACHE_DIR, `${cacheKey(url)}.json`);
+    const stat = fs.statSync(filePath);
+    if (Date.now() - stat.mtimeMs > CACHE_TTL_MS) {
+      fs.unlinkSync(filePath);
+      return null;
+    }
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    return JSON.parse(raw) as OgMeta;
+  } catch {
+    return null;
+  }
+}
+
+function writeDiskCache(url: string, data: OgMeta): void {
+  try {
+    ensureCacheDir();
+    const filePath = path.join(CACHE_DIR, `${cacheKey(url)}.json`);
+    fs.writeFileSync(filePath, JSON.stringify(data), 'utf-8');
+  } catch {
+    // ignore write errors
+  }
+}
+
+function getCached(url: string): OgMeta | null {
+  const mem = memoryCache.get(url);
+  if (mem && Date.now() - mem.ts < CACHE_TTL_MS) return mem.data;
+  if (mem) memoryCache.delete(url);
+
+  const disk = readDiskCache(url);
+  if (disk) {
+    if (memoryCache.size >= MAX_MEMORY_CACHE) {
+      const oldest = memoryCache.keys().next().value;
+      if (oldest !== undefined) memoryCache.delete(oldest);
+    }
+    memoryCache.set(url, { data: disk, ts: Date.now() });
+    return disk;
+  }
+  return null;
+}
+
+function setCache(url: string, data: OgMeta): void {
+  if (memoryCache.size >= MAX_MEMORY_CACHE) {
+    const oldest = memoryCache.keys().next().value;
+    if (oldest !== undefined) memoryCache.delete(oldest);
+  }
+  memoryCache.set(url, { data, ts: Date.now() });
+  writeDiskCache(url, data);
+}
+
+/* ─── Site type detection ─── */
+
+function detectSiteType(url: string): SiteType {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.replace(/^www\./, '');
+
+    if (host === 'github.com') {
+      const parts = u.pathname.split('/').filter(Boolean);
+      if (parts.length >= 2 && parts[2] === 'pull') return 'github_pr';
+      if (parts.length >= 2 && parts[2] === 'issues') return 'github_issue';
+      if (parts.length === 2) return 'github_repo';
+      return 'github_repo';
+    }
+
+    if (
+      host === 'youtube.com' ||
+      host === 'm.youtube.com' ||
+      host === 'youtu.be'
+    ) {
+      return 'youtube';
+    }
+  } catch {
+    // ignore
+  }
+  return 'generic';
+}
+
+/* ─── Special site enrichment ─── */
+
+function extractYouTubeVideoId(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.hostname === 'youtu.be') return u.pathname.slice(1);
+    return u.searchParams.get('v') ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function enrichYouTube(meta: OgMeta): OgMeta {
+  const videoId = extractYouTubeVideoId(meta.url);
+  if (!videoId) return meta;
+  return {
+    ...meta,
+    image: meta.image || `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`,
+    extra: {
+      ...meta.extra,
+      videoId,
+      embedUrl: `https://www.youtube.com/embed/${videoId}`,
+    },
+  };
+}
+
+function enrichGitHub(meta: OgMeta, siteType: SiteType): OgMeta {
+  try {
+    const u = new URL(meta.url);
+    const parts = u.pathname.split('/').filter(Boolean);
+    const extra: Record<string, string> = { ...meta.extra };
+
+    if (parts.length >= 2) {
+      extra.owner = parts[0];
+      extra.repo = parts[1];
+    }
+    if (siteType === 'github_issue' && parts.length >= 4) {
+      extra.issueNumber = parts[3];
+    }
+    if (siteType === 'github_pr' && parts.length >= 4) {
+      extra.prNumber = parts[3];
+    }
+
+    return {
+      ...meta,
+      favicon: meta.favicon || 'https://github.githubassets.com/favicons/favicon.svg',
+      extra,
+    };
+  } catch {
+    return meta;
+  }
+}
+
+/* ─── HTML parsing helpers ─── */
+
 function extractMetaContent(html: string, property: string): string {
-  // Match both property="og:..." and name="og:..." patterns
   const patterns = [
     new RegExp(`<meta[^>]+(?:property|name)=["']${property}["'][^>]+content=["']([^"']*)["']`, 'i'),
     new RegExp(`<meta[^>]+content=["']([^"']*)["'][^>]+(?:property|name)=["']${property}["']`, 'i'),
@@ -43,13 +201,10 @@ function extractFavicon(html: string, baseUrl: string): string {
   ];
   for (const re of patterns) {
     const m = html.match(re);
-    if (m?.[1]) {
-      return resolveUrl(m[1], baseUrl);
-    }
+    if (m?.[1]) return resolveUrl(m[1], baseUrl);
   }
   try {
-    const u = new URL(baseUrl);
-    return `${u.origin}/favicon.ico`;
+    return `${new URL(baseUrl).origin}/favicon.ico`;
   } catch {
     return '';
   }
@@ -64,7 +219,18 @@ function resolveUrl(raw: string, base: string): string {
   }
 }
 
+function tryHostname(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return '';
+  }
+}
+
+/* ─── Fetch & parse ─── */
+
 async function fetchOgMeta(url: string): Promise<OgMeta> {
+  const siteType = detectSiteType(url);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
@@ -80,13 +246,12 @@ async function fetchOgMeta(url: string): Promise<OgMeta> {
     clearTimeout(timer);
 
     if (!res.ok) {
-      return { url, title: '', description: '', image: '', siteName: '', favicon: '' };
+      return { url, title: '', description: '', image: '', siteName: '', favicon: '', siteType, extra: {} };
     }
 
-    // Only read first 50KB for meta tags
     const reader = res.body?.getReader();
     if (!reader) {
-      return { url, title: '', description: '', image: '', siteName: '', favicon: '' };
+      return { url, title: '', description: '', image: '', siteName: '', favicon: '', siteType, extra: {} };
     }
 
     const chunks: Uint8Array[] = [];
@@ -114,27 +279,32 @@ async function fetchOgMeta(url: string): Promise<OgMeta> {
     const twitterDesc = extractMetaContent(html, 'twitter:description');
     const twitterImage = extractMetaContent(html, 'twitter:image');
 
-    return {
+    let meta: OgMeta = {
       url,
       title: ogTitle || twitterTitle || extractTitle(html),
       description: ogDesc || twitterDesc || metaDesc,
       image: resolveUrl(ogImage || twitterImage, url),
       siteName: ogSiteName || tryHostname(url),
       favicon: extractFavicon(html, url),
+      siteType,
+      extra: {},
     };
+
+    // Enrich based on site type
+    if (siteType === 'youtube') {
+      meta = enrichYouTube(meta);
+    } else if (siteType.startsWith('github_') || siteType === 'github_repo') {
+      meta = enrichGitHub(meta, siteType);
+    }
+
+    return meta;
   } catch {
     clearTimeout(timer);
-    return { url, title: '', description: '', image: '', siteName: tryHostname(url), favicon: '' };
+    return { url, title: '', description: '', image: '', siteName: tryHostname(url), favicon: '', siteType, extra: {} };
   }
 }
 
-function tryHostname(url: string): string {
-  try {
-    return new URL(url).hostname.replace(/^www\./, '');
-  } catch {
-    return '';
-  }
-}
+/* ─── Route handler ─── */
 
 export async function GET(request: NextRequest) {
   const auth = await requireApiUser(request);
@@ -145,7 +315,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Missing url parameter' }, { status: 400 });
   }
 
-  // Validate URL scheme
   try {
     const parsed = new URL(targetUrl);
     if (!['http:', 'https:'].includes(parsed.protocol)) {
@@ -155,22 +324,15 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
   }
 
-  // Check cache
-  const cached = metaCache.get(targetUrl);
-  if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
-    return NextResponse.json(cached.data, {
+  const cached = getCached(targetUrl);
+  if (cached) {
+    return NextResponse.json(cached, {
       headers: { 'Cache-Control': 'public, max-age=1800' },
     });
   }
 
   const meta = await fetchOgMeta(targetUrl);
-
-  // Evict oldest if full
-  if (metaCache.size >= MAX_CACHE_SIZE) {
-    const oldest = metaCache.keys().next().value;
-    if (oldest !== undefined) metaCache.delete(oldest);
-  }
-  metaCache.set(targetUrl, { data: meta, ts: Date.now() });
+  setCache(targetUrl, meta);
 
   return NextResponse.json(meta, {
     headers: { 'Cache-Control': 'public, max-age=1800' },

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -4352,6 +4352,7 @@
 }
 
 .linkPreviewImageWrap {
+  position: relative;
   width: 100%;
   height: 140px;
   overflow: hidden;
@@ -4461,6 +4462,89 @@
 
 .linkPreviewNavBtnRight {
   right: -14px;
+}
+
+/* ─── YouTube card ─── */
+
+.linkPreviewCardYoutube {
+  border-color: rgba(255, 0, 0, 0.15);
+}
+
+.linkPreviewCardYoutube:hover {
+  border-color: rgba(255, 0, 0, 0.45);
+}
+
+.youtubePlayOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.25);
+  transition: background 0.18s;
+  pointer-events: none;
+}
+
+.linkPreviewCardYoutube:hover .youtubePlayOverlay {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.youtubeIcon {
+  color: #ff0000;
+  flex-shrink: 0;
+}
+
+/* ─── GitHub card ─── */
+
+.linkPreviewCardGithub {
+  border-color: rgba(31, 111, 200, 0.15);
+}
+
+.linkPreviewCardGithub:hover {
+  border-color: rgba(31, 111, 200, 0.45);
+}
+
+.ghBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.08rem 0.4rem;
+  border-radius: 10px;
+  line-height: 1.3;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.ghBadgeRepo {
+  background: rgba(31, 111, 200, 0.12);
+  color: #1f6fc8;
+}
+
+.ghBadgeIssue {
+  background: rgba(26, 127, 55, 0.12);
+  color: #1a7f37;
+}
+
+.ghBadgePr {
+  background: rgba(130, 80, 223, 0.12);
+  color: #8250df;
+}
+
+:global(html[data-theme='dark']) .ghBadgeRepo {
+  background: rgba(88, 166, 255, 0.16);
+  color: #58a6ff;
+}
+
+:global(html[data-theme='dark']) .ghBadgeIssue {
+  background: rgba(63, 185, 80, 0.16);
+  color: #3fb950;
+}
+
+:global(html[data-theme='dark']) .ghBadgePr {
+  background: rgba(188, 140, 255, 0.16);
+  color: #bc8cff;
 }
 
 @media (max-width: 768px) {

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -74,7 +74,12 @@ import {
   Plus,
   Square,
   ExternalLink,
+  GitFork,
+  GitPullRequest,
+  CircleDot,
   Globe,
+  Play,
+  Star,
   TerminalSquare,
   Trash2,
   X,
@@ -1865,6 +1870,8 @@ function TextReply({ body, isUser }: { body: string; isUser: boolean }) {
 
 /* ─── Link Preview ─── */
 
+type SiteType = 'github_repo' | 'github_issue' | 'github_pr' | 'youtube' | 'generic';
+
 interface LinkPreviewMeta {
   url: string;
   title: string;
@@ -1872,6 +1879,8 @@ interface LinkPreviewMeta {
   image: string;
   siteName: string;
   favicon: string;
+  siteType: SiteType;
+  extra: Record<string, string>;
 }
 
 const LINK_URL_RE = /https?:\/\/[^\s)<>]+/g;
@@ -1882,7 +1891,6 @@ function extractExternalUrls(text: string): string[] {
   const seen = new Set<string>();
   const result: string[] = [];
   for (const raw of matches) {
-    // Strip trailing punctuation that's unlikely part of the URL
     const url = raw.replace(/[.,;:!?)]+$/, '');
     if (!seen.has(url)) {
       seen.add(url);
@@ -1892,10 +1900,16 @@ function extractExternalUrls(text: string): string[] {
   return result;
 }
 
+function proxyImageUrl(src: string): string {
+  if (!src) return '';
+  return `/api/link-preview/image?url=${encodeURIComponent(src)}`;
+}
+
 const linkPreviewClientCache = new Map<string, LinkPreviewMeta>();
 
 function useLinkPreviews(urls: string[]): LinkPreviewMeta[] {
   const [previews, setPreviews] = useState<LinkPreviewMeta[]>([]);
+  const cacheKeyStr = urls.join('\n');
 
   useEffect(() => {
     if (urls.length === 0) {
@@ -1916,14 +1930,14 @@ function useLinkPreviews(urls: string[]): LinkPreviewMeta[] {
         try {
           const res = await fetch(`/api/link-preview?url=${encodeURIComponent(url)}`);
           if (!res.ok) {
-            results.push({ url, title: '', description: '', image: '', siteName: '', favicon: '' });
+            results.push({ url, title: '', description: '', image: '', siteName: '', favicon: '', siteType: 'generic', extra: {} });
             continue;
           }
           const meta: LinkPreviewMeta = await res.json();
           linkPreviewClientCache.set(url, meta);
           results.push(meta);
         } catch {
-          results.push({ url, title: '', description: '', image: '', siteName: '', favicon: '' });
+          results.push({ url, title: '', description: '', image: '', siteName: '', favicon: '', siteType: 'generic', extra: {} });
         }
       }
       if (!cancelled) setPreviews(results);
@@ -1931,9 +1945,136 @@ function useLinkPreviews(urls: string[]): LinkPreviewMeta[] {
 
     void load();
     return () => { cancelled = true; };
-  }, [urls.join('\n')]);
+  }, [cacheKeyStr]);
 
   return previews;
+}
+
+/* ─── Special site card renderers ─── */
+
+function YouTubeCard({ meta }: { meta: LinkPreviewMeta }) {
+  const videoId = meta.extra.videoId;
+  const thumb = videoId
+    ? proxyImageUrl(`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`)
+    : proxyImageUrl(meta.image);
+
+  return (
+    <a href={meta.url} target="_blank" rel="noreferrer noopener" className={`${styles.linkPreviewCard} ${styles.linkPreviewCardYoutube}`}>
+      {thumb && (
+        <div className={styles.linkPreviewImageWrap}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={thumb} alt="" className={styles.linkPreviewImage} loading="lazy" onError={(e) => { (e.currentTarget.parentElement as HTMLElement).style.display = 'none'; }} />
+          <div className={styles.youtubePlayOverlay}>
+            <Play size={28} fill="white" />
+          </div>
+        </div>
+      )}
+      <div className={styles.linkPreviewBody}>
+        <div className={styles.linkPreviewSite}>
+          <Play size={13} className={styles.youtubeIcon} />
+          <span className={styles.linkPreviewSiteName}>YouTube</span>
+        </div>
+        {meta.title && <div className={styles.linkPreviewTitle}>{meta.title}</div>}
+        {meta.description && <div className={styles.linkPreviewDesc}>{meta.description}</div>}
+      </div>
+    </a>
+  );
+}
+
+function GitHubCard({ meta }: { meta: LinkPreviewMeta }) {
+  const { siteType, extra } = meta;
+  const repoLabel = extra.owner && extra.repo ? `${extra.owner}/${extra.repo}` : '';
+
+  let TypeIcon = GitFork;
+  let typeLabel = 'Repository';
+  let badgeClass = styles.ghBadgeRepo;
+
+  if (siteType === 'github_issue') {
+    TypeIcon = CircleDot;
+    typeLabel = extra.issueNumber ? `Issue #${extra.issueNumber}` : 'Issue';
+    badgeClass = styles.ghBadgeIssue;
+  } else if (siteType === 'github_pr') {
+    TypeIcon = GitPullRequest;
+    typeLabel = extra.prNumber ? `PR #${extra.prNumber}` : 'Pull Request';
+    badgeClass = styles.ghBadgePr;
+  }
+
+  return (
+    <a href={meta.url} target="_blank" rel="noreferrer noopener" className={`${styles.linkPreviewCard} ${styles.linkPreviewCardGithub}`}>
+      {meta.image && (
+        <div className={styles.linkPreviewImageWrap}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={proxyImageUrl(meta.image)} alt="" className={styles.linkPreviewImage} loading="lazy" onError={(e) => { (e.currentTarget.parentElement as HTMLElement).style.display = 'none'; }} />
+        </div>
+      )}
+      <div className={styles.linkPreviewBody}>
+        <div className={styles.linkPreviewSite}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={proxyImageUrl(meta.favicon || 'https://github.githubassets.com/favicons/favicon.svg')} alt="" className={styles.linkPreviewFavicon} width={14} height={14} onError={(e) => { e.currentTarget.style.display = 'none'; }} />
+          <span className={styles.linkPreviewSiteName}>{repoLabel || 'GitHub'}</span>
+          <span className={`${styles.ghBadge} ${badgeClass}`}>
+            <TypeIcon size={11} />
+            {typeLabel}
+          </span>
+        </div>
+        {meta.title && <div className={styles.linkPreviewTitle}>{meta.title}</div>}
+        {meta.description && <div className={styles.linkPreviewDesc}>{meta.description}</div>}
+      </div>
+    </a>
+  );
+}
+
+function GenericCard({ meta }: { meta: LinkPreviewMeta }) {
+  return (
+    <a href={meta.url} target="_blank" rel="noreferrer noopener" className={styles.linkPreviewCard}>
+      {meta.image && (
+        <div className={styles.linkPreviewImageWrap}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={proxyImageUrl(meta.image)} alt="" className={styles.linkPreviewImage} loading="lazy" onError={(e) => { (e.currentTarget.parentElement as HTMLElement).style.display = 'none'; }} />
+        </div>
+      )}
+      <div className={styles.linkPreviewBody}>
+        <div className={styles.linkPreviewSite}>
+          {meta.favicon ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={proxyImageUrl(meta.favicon)}
+              alt=""
+              className={styles.linkPreviewFavicon}
+              width={14}
+              height={14}
+              onError={(e) => {
+                e.currentTarget.style.display = 'none';
+                (e.currentTarget.nextElementSibling as HTMLElement | null)?.style.removeProperty('display');
+              }}
+            />
+          ) : null}
+          <Globe size={14} className={styles.linkPreviewGlobe} style={meta.favicon ? { display: 'none' } : undefined} />
+          <span className={styles.linkPreviewSiteName}>{meta.siteName || tryParseHostname(meta.url)}</span>
+          <ExternalLink size={11} className={styles.linkPreviewExtIcon} />
+        </div>
+        {meta.title && <div className={styles.linkPreviewTitle}>{meta.title}</div>}
+        {meta.description && <div className={styles.linkPreviewDesc}>{meta.description}</div>}
+      </div>
+    </a>
+  );
+}
+
+function tryParseHostname(url: string): string {
+  try { return new URL(url).hostname; } catch { return url; }
+}
+
+function renderPreviewCard(meta: LinkPreviewMeta) {
+  switch (meta.siteType) {
+    case 'youtube':
+      return <YouTubeCard key={meta.url} meta={meta} />;
+    case 'github_repo':
+    case 'github_issue':
+    case 'github_pr':
+      return <GitHubCard key={meta.url} meta={meta} />;
+    default:
+      return <GenericCard key={meta.url} meta={meta} />;
+  }
 }
 
 function LinkPreviewCarousel({ body }: { body: string }) {
@@ -1986,57 +2127,7 @@ function LinkPreviewCarousel({ body }: { body: string }) {
         </button>
       )}
       <div className={styles.linkPreviewTrack} ref={scrollRef}>
-        {meaningful.map((meta) => (
-          <a
-            key={meta.url}
-            href={meta.url}
-            target="_blank"
-            rel="noreferrer noopener"
-            className={styles.linkPreviewCard}
-          >
-            {meta.image && (
-              <div className={styles.linkPreviewImageWrap}>
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={meta.image}
-                  alt=""
-                  className={styles.linkPreviewImage}
-                  loading="lazy"
-                  onError={(e) => {
-                    (e.currentTarget.parentElement as HTMLElement).style.display = 'none';
-                  }}
-                />
-              </div>
-            )}
-            <div className={styles.linkPreviewBody}>
-              <div className={styles.linkPreviewSite}>
-                {meta.favicon ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={meta.favicon}
-                    alt=""
-                    className={styles.linkPreviewFavicon}
-                    width={14}
-                    height={14}
-                    onError={(e) => {
-                      e.currentTarget.style.display = 'none';
-                      (e.currentTarget.nextElementSibling as HTMLElement | null)?.style.removeProperty('display');
-                    }}
-                  />
-                ) : null}
-                <Globe size={14} className={styles.linkPreviewGlobe} style={meta.favicon ? { display: 'none' } : undefined} />
-                <span className={styles.linkPreviewSiteName}>{meta.siteName || new URL(meta.url).hostname}</span>
-                <ExternalLink size={11} className={styles.linkPreviewExtIcon} />
-              </div>
-              {meta.title && (
-                <div className={styles.linkPreviewTitle}>{meta.title}</div>
-              )}
-              {meta.description && (
-                <div className={styles.linkPreviewDesc}>{meta.description}</div>
-              )}
-            </div>
-          </a>
-        ))}
+        {meaningful.map(renderPreviewCard)}
       </div>
       {canScrollRight && (
         <button


### PR DESCRIPTION
## Summary
- **이미지 프록시**: `/api/link-preview/image` 라우트 추가. SSRF 방지(private IP 차단), 5MB 제한, Content-Type 검증
- **캐시 영속화**: 파일 기반 캐시(24시간 TTL) + Docker named volume으로 blue/green 슬롯 간 공유
- **특수 사이트 커스텀 카드**: YouTube(재생 오버레이+썸네일), GitHub(repo/issue/PR 타입 뱃지+컬러 코딩)

## 변경 파일
- `services/aris-web/app/api/link-preview/route.ts` — 파일 캐시, siteType 감지, GitHub/YouTube 인리치먼트
- `services/aris-web/app/api/link-preview/image/route.ts` — 이미지 프록시 (신규)
- `services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx` — YouTubeCard, GitHubCard, GenericCard 컴포넌트
- `services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css` — YouTube/GitHub 전용 스타일 + 다크모드
- `docker-compose.yml` — `link_preview_cache` named volume 추가
- `.gitignore` / `.dockerignore` — `.cache/` 제외

## Test plan
- [ ] YouTube URL 포함 메시지 → 재생 오버레이가 있는 카드 표시 확인
- [ ] GitHub repo/issue/PR URL → 각각 다른 뱃지 색상 카드 표시 확인
- [ ] 일반 URL → 기존 Generic 카드 정상 표시 확인
- [ ] 이미지가 프록시 경로(/api/link-preview/image)로 로드되는지 확인
- [ ] 다크 모드에서 GitHub 뱃지 색상 정상 확인
- [ ] Docker 재배포 후 캐시 유지 확인