### PR TITLE
fix: show link preview cards for private GitHub repos

### DIFF
--- a/services/aris-web/app/api/link-preview/route.ts
+++ b/services/aris-web/app/api/link-preview/route.ts
@@ -246,7 +246,13 @@ async function fetchOgMeta(url: string): Promise<OgMeta> {
     clearTimeout(timer);
 
     if (!res.ok) {
-      return { url, title: '', description: '', image: '', siteName: '', favicon: '', siteType, extra: {} };
+      let fallback: OgMeta = { url, title: '', description: '', image: '', siteName: tryHostname(url), favicon: '', siteType, extra: {} };
+      if (siteType === 'youtube') {
+        fallback = enrichYouTube(fallback);
+      } else if (siteType.startsWith('github')) {
+        fallback = enrichGitHub(fallback, siteType);
+      }
+      return fallback;
     }
 
     const reader = res.body?.getReader();
@@ -300,7 +306,13 @@ async function fetchOgMeta(url: string): Promise<OgMeta> {
     return meta;
   } catch {
     clearTimeout(timer);
-    return { url, title: '', description: '', image: '', siteName: tryHostname(url), favicon: '', siteType, extra: {} };
+    let fallback: OgMeta = { url, title: '', description: '', image: '', siteName: tryHostname(url), favicon: '', siteType, extra: {} };
+    if (siteType === 'youtube') {
+      fallback = enrichYouTube(fallback);
+    } else if (siteType.startsWith('github')) {
+      fallback = enrichGitHub(fallback, siteType);
+    }
+    return fallback;
   }
 }
 

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -1883,7 +1883,7 @@ interface LinkPreviewMeta {
   extra: Record<string, string>;
 }
 
-const LINK_URL_RE = /https?:\/\/[^\s)<>]+/g;
+const LINK_URL_RE = /https?:\/\/[^\s)<>"'`\]]+/g;
 
 function extractExternalUrls(text: string): string[] {
   const matches = text.match(LINK_URL_RE);
@@ -2111,7 +2111,11 @@ function LinkPreviewCarousel({ body }: { body: string }) {
     el.scrollBy({ left: direction === 'left' ? -cardWidth : cardWidth, behavior: 'smooth' });
   }, []);
 
-  const meaningful = previews.filter(p => p.title || p.description || p.image);
+  const meaningful = previews.filter(p =>
+    p.title || p.description || p.image ||
+    p.siteType === 'github_issue' || p.siteType === 'github_pr' || p.siteType === 'github_repo' ||
+    p.siteType === 'youtube'
+  );
   if (meaningful.length === 0) return null;
 
   return (


### PR DESCRIPTION
## Summary
- Private GitHub repos return 404 → `fetchOgMeta` returned empty data with no enrichment → `meaningful` filter excluded all cards → no cards shown
- Fix: apply URL-based enrichment (owner/repo/issue#) even when HTTP fetch fails
- Fix: `meaningful` filter now includes GitHub/YouTube siteType cards even without OG metadata  
- Fix: URL regex excludes trailing `"` and backticks common in markdown formatting

## Test plan
- [ ] Send a message with a private GitHub issue link → card should show repo name + issue badge
- [ ] Send a message with a YouTube link → card should show thumbnail
- [ ] Markdown link `[text](url)` should extract clean URL without trailing `"`