### PR TITLE
fix: 모바일 링크 프리뷰 캐러셀 오버플로우 수정

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -4312,17 +4312,25 @@
 .linkPreviewWrap {
   position: relative;
   margin-top: 0.45rem;
-  max-width: min(92%, 860px);
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .linkPreviewTrack {
   display: flex;
   gap: 0.55rem;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   scrollbar-width: none;
   -ms-overflow-style: none;
   padding: 0.15rem 0;
+  box-sizing: border-box;
+  overscroll-behavior-x: contain;
 }
 
 .linkPreviewTrack::-webkit-scrollbar {
@@ -4331,6 +4339,9 @@
 
 .linkPreviewCard {
   flex: 0 0 280px;
+  width: 280px;
+  max-width: 100%;
+  min-width: 0;
   scroll-snap-align: start;
   display: flex;
   flex-direction: column;
@@ -4343,6 +4354,7 @@
   box-shadow: var(--chat-msg-shadow);
   transition: border-color 0.18s, box-shadow 0.18s, transform 0.15s;
   cursor: pointer;
+  box-sizing: border-box;
 }
 
 .linkPreviewCard:hover {
@@ -4549,7 +4561,9 @@
 
 @media (max-width: 768px) {
   .linkPreviewCard {
-    flex: 0 0 240px;
+    flex: 0 0 clamp(12.5rem, calc(100vw - 7rem), 15rem);
+    width: clamp(12.5rem, calc(100vw - 7rem), 15rem);
+    max-width: 100%;
   }
 
   .linkPreviewImageWrap {

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -2107,8 +2107,13 @@ function LinkPreviewCarousel({ body }: { body: string }) {
   const scroll = useCallback((direction: 'left' | 'right') => {
     const el = scrollRef.current;
     if (!el) return;
-    const cardWidth = 296;
-    el.scrollBy({ left: direction === 'left' ? -cardWidth : cardWidth, behavior: 'smooth' });
+    const firstCard = el.firstElementChild as HTMLElement | null;
+    const trackStyles = window.getComputedStyle(el);
+    const gapValue = trackStyles.columnGap || trackStyles.gap || '0';
+    const gap = Number.parseFloat(gapValue) || 0;
+    const cardWidth = firstCard?.getBoundingClientRect().width ?? Math.min(el.clientWidth, 296);
+    const scrollAmount = cardWidth + gap;
+    el.scrollBy({ left: direction === 'left' ? -scrollAmount : scrollAmount, behavior: 'smooth' });
   }, []);
 
   const meaningful = previews.filter(p =>

--- a/services/aris-web/tests/linkPreviewCarouselLayout.test.ts
+++ b/services/aris-web/tests/linkPreviewCarouselLayout.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cssPath = resolve(__dirname, '../app/sessions/[sessionId]/ChatInterface.module.css');
+const tsxPath = resolve(__dirname, '../app/sessions/[sessionId]/ChatInterface.tsx');
+const css = readFileSync(cssPath, 'utf8');
+const tsx = readFileSync(tsxPath, 'utf8');
+
+describe('link preview carousel mobile layout', () => {
+  it('keeps the carousel wrapper constrained to the message body width', () => {
+    expect(css).toMatch(/\.linkPreviewWrap\s*\{[^}]*width:\s*100%;/s);
+    expect(css).toMatch(/\.linkPreviewWrap\s*\{[^}]*max-width:\s*100%;/s);
+    expect(css).toMatch(/\.linkPreviewWrap\s*\{[^}]*min-width:\s*0;/s);
+    expect(css).toMatch(/\.linkPreviewTrack\s*\{[^}]*max-width:\s*100%;/s);
+  });
+
+  it('uses a viewport-safe card width on mobile instead of a fixed pixel basis', () => {
+    expect(css).toMatch(/@media\s*\(max-width:\s*768px\)\s*\{[\s\S]*?\.linkPreviewCard\s*\{[^}]*flex:\s*0 0 clamp\(/s);
+    expect(css).toMatch(/@media\s*\(max-width:\s*768px\)\s*\{[\s\S]*?\.linkPreviewCard\s*\{[^}]*max-width:\s*100%;/s);
+  });
+
+  it('scrolls by the rendered card width instead of a hard-coded desktop value', () => {
+    expect(tsx).not.toContain('const cardWidth = 296;');
+    expect(tsx).toMatch(/firstElementChild as HTMLElement \| null/);
+  });
+});


### PR DESCRIPTION
## 요약

- 모바일에서 링크 프리뷰 카드 캐러셀이 메시지 폭을 넘지 않도록 래퍼/카드 폭 제약을 조정했습니다.
- 캐러셀 좌우 이동량을 실제 렌더된 카드 폭 기준으로 계산하도록 수정했습니다.
- 모바일 오버플로우 회귀 테스트를 추가했습니다.

## 검증

- `cd services/aris-web && npm test -- tests/linkPreviewCarouselLayout.test.ts tests/chatSidebarThemeTokens.test.ts`
- `cd services/aris-web && ./node_modules/.bin/tsc --noEmit`
- `cd services/aris-web && npm run build`
