### PR TITLE
fix: 링크 프리뷰 폭을 에이전트 버블 기준으로 고정

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -1772,6 +1772,18 @@
   background: var(--chat-msg-agent-bg);
   backdrop-filter: blur(12px);
   box-shadow: var(--chat-msg-shadow-strong);
+  width: fit-content;
+  max-width: 100%;
+}
+
+.agentMessageStack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.45rem;
+  width: fit-content;
+  max-width: min(100%, 48rem);
+  min-width: 0;
 }
 
 .messageBubbleAction {
@@ -4311,7 +4323,8 @@
 
 .linkPreviewWrap {
   position: relative;
-  margin-top: 0.45rem;
+  margin-top: 0;
+  align-self: stretch;
   width: 100%;
   max-width: 100%;
   min-width: 0;

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -6252,12 +6252,14 @@ export function ChatInterface({
                         <span className={styles.msgSender}>{agentMeta.label}</span>
                         <span className={styles.msgTime}>{formatClock(event.timestamp)}</span>
                       </div>
-                      <div className={`${styles.messageBubble} ${styles.messageBubbleAgent}`}>
-                        {renderEventPayload(event, false, expandedResultIds[event.id] ?? false, () => toggleResult(event.id), isDebugMode)}
+                      <div className={styles.agentMessageStack}>
+                        <div className={`${styles.messageBubble} ${styles.messageBubbleAgent}`}>
+                          {renderEventPayload(event, false, expandedResultIds[event.id] ?? false, () => toggleResult(event.id), isDebugMode)}
+                        </div>
+                        {!isDebugMode && !isActionKind(event.kind) && (event.body || event.title) && (
+                          <LinkPreviewCarousel body={event.body || event.title} />
+                        )}
                       </div>
-                      {!isDebugMode && !isActionKind(event.kind) && (event.body || event.title) && (
-                        <LinkPreviewCarousel body={event.body || event.title} />
-                      )}
                     </div>
                   </div>
                 </article>

--- a/services/aris-web/tests/linkPreviewCarouselLayout.test.ts
+++ b/services/aris-web/tests/linkPreviewCarouselLayout.test.ts
@@ -10,10 +10,14 @@ const css = readFileSync(cssPath, 'utf8');
 const tsx = readFileSync(tsxPath, 'utf8');
 
 describe('link preview carousel mobile layout', () => {
-  it('keeps the carousel wrapper constrained to the message body width', () => {
+  it('keeps the carousel wrapper constrained to the agent bubble stack width', () => {
+    expect(tsx).toMatch(/className=\{styles\.agentMessageStack\}/);
+    expect(css).toMatch(/\.agentMessageStack\s*\{[^}]*width:\s*fit-content;/s);
+    expect(css).toMatch(/\.agentMessageStack\s*\{[^}]*max-width:\s*min\(100%,\s*48rem\);/s);
     expect(css).toMatch(/\.linkPreviewWrap\s*\{[^}]*width:\s*100%;/s);
     expect(css).toMatch(/\.linkPreviewWrap\s*\{[^}]*max-width:\s*100%;/s);
     expect(css).toMatch(/\.linkPreviewWrap\s*\{[^}]*min-width:\s*0;/s);
+    expect(css).toMatch(/\.linkPreviewWrap\s*\{[^}]*align-self:\s*stretch;/s);
     expect(css).toMatch(/\.linkPreviewTrack\s*\{[^}]*max-width:\s*100%;/s);
   });
 
@@ -25,5 +29,10 @@ describe('link preview carousel mobile layout', () => {
   it('scrolls by the rendered card width instead of a hard-coded desktop value', () => {
     expect(tsx).not.toContain('const cardWidth = 296;');
     expect(tsx).toMatch(/firstElementChild as HTMLElement \| null/);
+  });
+
+  it('lets the agent bubble define the stack width instead of the full message body', () => {
+    expect(css).toMatch(/\.messageBubbleAgent\s*\{[^}]*width:\s*fit-content;/s);
+    expect(css).toMatch(/\.messageBubbleAgent\s*\{[^}]*max-width:\s*100%;/s);
   });
 });


### PR DESCRIPTION
## 요약

- 에이전트 메시지에서 링크 프리뷰 캐러셀 폭이 `msgBody` 전체가 아니라 실제 버블 스택 폭을 기준으로 계산되도록 조정했습니다.
- 에이전트 버블과 캐러셀을 동일 스택으로 묶어 캐러셀이 다음 사용자 버블의 줄바꿈/행 폭을 밀어올리지 못하게 했습니다.
- 관련 모바일 레이아웃 회귀 테스트를 강화했습니다.

## 검증

- `cd services/aris-web && npm test -- tests/linkPreviewCarouselLayout.test.ts tests/chatSidebarThemeTokens.test.ts`
- `cd services/aris-web && ./node_modules/.bin/tsc --noEmit`
- `cd services/aris-web && npm run build`
