### PR TITLE
fix: runtime persistence conflict and payload overflow

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -2561,7 +2561,7 @@ export class HappyRuntimeStore {
     meta: Record<string, unknown> = {},
     options: { type?: string; title?: string } = {},
   ): Promise<void> {
-    const cleanedText = text.replace(/\n?0;\s*$/g, '').trim();
+    const cleanedText = trimOutput(text.replace(/\n?0;\s*$/g, '').trim());
     const localId = `aris-agent-${randomUUID()}`;
     const type = options.type ?? 'message';
     const title = options.title ?? (type === 'message' ? 'Text Reply' : 'Command Execution');

--- a/services/aris-backend/src/runtime/prismaStore.ts
+++ b/services/aris-backend/src/runtime/prismaStore.ts
@@ -184,9 +184,25 @@ function getPrismaErrorCode(error: unknown): string | null {
   return typeof code === 'string' ? code : null;
 }
 
+function getErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return '';
+  }
+  return error.message.trim();
+}
+
 function isRetryableSessionMessageWriteError(error: unknown): boolean {
   const code = getPrismaErrorCode(error);
-  return code === 'P2002' || code === 'P2034';
+  if (code === 'P2002' || code === 'P2034') {
+    return true;
+  }
+
+  const message = getErrorMessage(error);
+  return (
+    message.includes('TransactionWriteConflict')
+    || message.includes('could not serialize access')
+    || message.includes('serialization failure')
+  );
 }
 
 export class PrismaRuntimeStore {

--- a/services/aris-backend/tests/happyClient.streamJson.test.ts
+++ b/services/aris-backend/tests/happyClient.streamJson.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { happyClientTestHooks } from '../src/runtime/happyClient.js';
+import { HappyRuntimeStore, happyClientTestHooks } from '../src/runtime/happyClient.js';
 import { parseGeminiStreamLine } from '../src/runtime/providers/gemini/geminiProtocolMapper.js';
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe('happyClient stream-json parsing', () => {
@@ -443,5 +445,41 @@ registry/controller를 ClaudeSession 중심으로 재편`);
 
     clearInterval(timer);
     expect(activityTick).toBeGreaterThan(0);
+  });
+
+  it('truncates oversized persisted app-server messages before posting them', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const store = new HappyRuntimeStore({
+      serverUrl: 'http://runtime.test',
+      token: 'token',
+      workspaceRoot: '/workspace',
+    }) as unknown as {
+      appendAgentMessage: (
+        sessionId: string,
+        text: string,
+        meta?: Record<string, unknown>,
+        options?: { type?: string; title?: string },
+      ) => Promise<void>;
+    };
+
+    await store.appendAgentMessage('session-1', 'x'.repeat(200_000), { streamEvent: 'command_execution' }, {
+      type: 'tool',
+      title: 'Command Execution',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const payload = JSON.parse(String(requestInit.body)) as {
+      messages: Array<{ content: string }>;
+    };
+    const content = JSON.parse(payload.messages[0]!.content) as { text: string };
+
+    expect(content.text.length).toBeLessThanOrEqual(32_000);
   });
 });

--- a/services/aris-backend/tests/prismaRuntimeStore.test.ts
+++ b/services/aris-backend/tests/prismaRuntimeStore.test.ts
@@ -107,4 +107,54 @@ describe('PrismaRuntimeStore.appendMessage', () => {
     expect(create).toHaveBeenCalledTimes(2);
     expect(update).toHaveBeenCalledTimes(1);
   });
+
+  it('retries when the database surfaces TransactionWriteConflict without a Prisma error code', async () => {
+    const aggregate = vi.fn()
+      .mockResolvedValueOnce({ _max: { seq: 1 } })
+      .mockResolvedValueOnce({ _max: { seq: 1 } });
+    const create = vi.fn()
+      .mockRejectedValueOnce(new Error('TransactionWriteConflict'))
+      .mockImplementationOnce(async ({ data }: { data: Record<string, unknown> }) => ({
+        id: 'message-2',
+        sessionId: data.sessionId,
+        type: data.type,
+        title: data.title,
+        text: data.text,
+        meta: data.meta,
+        seq: data.seq,
+        createdAt: new Date('2026-04-11T00:00:00.000Z'),
+      }));
+    const update = vi.fn().mockResolvedValue({ id: 'session-1', status: 'idle' });
+    const session = {
+      findUnique: vi.fn().mockResolvedValue({ id: 'session-1', status: 'idle' }),
+      update,
+    };
+    const sessionMessage = {
+      aggregate,
+      create,
+    };
+    const db = {
+      session,
+      sessionMessage,
+      $transaction: vi.fn(async (input: unknown) => {
+        if (typeof input === 'function') {
+          return input({ session, sessionMessage });
+        }
+        return Promise.all(input as Promise<unknown>[]);
+      }),
+    };
+    const store = buildStoreWithMockDb(db);
+
+    const message = await store.appendMessage('session-1', {
+      type: 'message',
+      title: 'Text Reply',
+      text: '조사 중입니다.',
+      meta: { role: 'agent' },
+    });
+
+    expect(message.meta?.seq).toBe(2);
+    expect(aggregate).toHaveBeenCalledTimes(2);
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(update).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- 세션 메시지 저장 시 `TransactionWriteConflict`가 코드 없는 문자열로 올라와도 재시도하도록 수정
- codex app-server persistence 경로에서 과도하게 큰 메시지를 저장 전에 잘라 413을 방지
- 두 회귀 케이스를 테스트로 추가

## Test Plan
- npm test -- prismaRuntimeStore.test.ts happyClient.streamJson.test.ts
- npm run build
