### PR TITLE
fix: 긴 URL 채팅 버블 줄바꿈 안정화

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -1760,6 +1760,7 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 0.35rem;
+  width: fit-content;
   max-width: min(92%, 860px);
   min-width: 0;
 }
@@ -2054,6 +2055,9 @@
   line-height: 1.5;
   color: var(--chat-text-primary);
   min-width: 0;
+  max-width: 100%;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
@@ -2114,6 +2118,8 @@
 
 .markdownParagraph {
   margin: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .markdownHeading {
@@ -2262,12 +2268,14 @@
 }
 
 .markdownLink {
+  display: inline;
+  max-width: 100%;
   color: var(--chat-accent);
   font-weight: 600;
   text-decoration: underline;
   text-underline-offset: 2px;
   overflow-wrap: anywhere;
-  word-break: break-word;
+  word-break: break-all;
 }
 
 .markdownStrong {

--- a/services/aris-web/tests/linkPreviewCarouselLayout.test.ts
+++ b/services/aris-web/tests/linkPreviewCarouselLayout.test.ts
@@ -35,4 +35,14 @@ describe('link preview carousel mobile layout', () => {
     expect(css).toMatch(/\.messageBubbleAgent\s*\{[^}]*width:\s*fit-content;/s);
     expect(css).toMatch(/\.messageBubbleAgent\s*\{[^}]*max-width:\s*100%;/s);
   });
+
+  it('forces long url text inside chat bubbles to wrap without triggering mobile text autosizing', () => {
+    expect(css).toMatch(/\.userText,\s*\.agentText\s*\{[^}]*max-width:\s*100%;/s);
+    expect(css).toMatch(/\.userText,\s*\.agentText\s*\{[^}]*-webkit-text-size-adjust:\s*100%;/s);
+    expect(css).toMatch(/\.userText,\s*\.agentText\s*\{[^}]*text-size-adjust:\s*100%;/s);
+    expect(css).toMatch(/\.markdownParagraph\s*\{[^}]*overflow-wrap:\s*anywhere;/s);
+    expect(css).toMatch(/\.markdownParagraph\s*\{[^}]*word-break:\s*break-word;/s);
+    expect(css).toMatch(/\.markdownLink\s*\{[^}]*max-width:\s*100%;/s);
+    expect(css).toMatch(/\.markdownLink\s*\{[^}]*word-break:\s*break-all;/s);
+  });
 });


### PR DESCRIPTION
## 요약

- 긴 URL이 포함된 채팅 버블 본문이 모바일에서 화면 폭을 넘지 않도록 줄바꿈 규칙을 강화했습니다.
- 버블 본문에 모바일 text autosizing 방지 규칙을 추가해 글자 크기 비정상 확대를 막았습니다.
- 링크 프리뷰/버블 폭 회귀 테스트를 확장했습니다.

## 검증

- `cd services/aris-web && npm test -- tests/linkPreviewCarouselLayout.test.ts tests/chatSidebarThemeTokens.test.ts`
- `cd services/aris-web && ./node_modules/.bin/tsc --noEmit`
