### PR TITLE
[codex] 백엔드 재배포 중 에이전트 런타임 연속성 보장

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -67,10 +67,16 @@ deploy/
 ### Backend only
 
 ```bash
+cd services/aris-backend && npx prisma migrate deploy && cd /home/ubuntu/project/ARIS
 DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env ./deploy/deploy_backend_zero_downtime.sh
 ```
 
 This builds `services/aris-backend`, stages runtime files under `.runtime/aris-backend`, then reloads PM2 in cluster mode.
+
+When the backend release contains Prisma schema changes:
+- Run `npx prisma migrate deploy` in `services/aris-backend` before the backend deploy script.
+- Keep `ARIS_BACKEND_DRAIN_TIMEOUT_MS` aligned with the maximum time you want in-flight agent runs to survive a PM2 reload.
+- `deploy/ecosystem.config.cjs` now maps `ARIS_BACKEND_DRAIN_TIMEOUT_MS` to PM2 `kill_timeout`, so reloads wait for run draining instead of terminating immediately.
 
 ### Web only
 
@@ -90,6 +96,7 @@ Default behavior:
 Useful overrides:
 
 ```bash
+DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env ARIS_BACKEND_DRAIN_TIMEOUT_MS=600000 ./deploy/deploy_backend_zero_downtime.sh
 DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env WEB_DRAIN_SECONDS=12 ./deploy/deploy_web.sh
 DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env PULL_BASE=1 ./deploy/deploy_web.sh
 DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env SKIP_BUILD_IF_UNCHANGED=0 ./deploy/deploy_web.sh
@@ -111,6 +118,11 @@ docker compose --env-file /home/ubuntu/.config/aris/prod.env logs --tail=120 ari
 pm2 logs aris-backend --lines 120 --nostream
 curl -sS http://127.0.0.1:4080/health
 ```
+
+Recommended runtime continuity checks after a backend deploy:
+- Start a long-running agent turn and confirm `/v1/sessions/{id}/runtime` stays `isRunning=true` during `pm2 startOrReload`.
+- While the old worker is draining, approve one pending permission and confirm the turn resumes instead of hanging.
+- Trigger `abort` or disconnected-chat `retry` once during the drain window and confirm the action is honored by the active run/new worker.
 
 Current web routing expectations:
 - Production traffic: `https://aris.lawdigest.cloud` through nginx

--- a/deploy/ecosystem.config.cjs
+++ b/deploy/ecosystem.config.cjs
@@ -84,6 +84,15 @@ function resolveBackendInstances() {
   return value;
 }
 
+function resolveBackendKillTimeout() {
+  const raw = resolveEnvValue('ARIS_BACKEND_DRAIN_TIMEOUT_MS', '600000');
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isFinite(value) || value < 5000) {
+    return 600000;
+  }
+  return value;
+}
+
 module.exports = {
   apps: [
     {
@@ -93,7 +102,7 @@ module.exports = {
       exec_mode: 'cluster',
       instances: resolveBackendInstances(),
       listen_timeout: 10000,
-      kill_timeout: 5000,
+      kill_timeout: resolveBackendKillTimeout(),
       env: {
         NODE_ENV: 'production',
         HOST: '0.0.0.0',

--- a/deploy/ops/debug-runbook.md
+++ b/deploy/ops/debug-runbook.md
@@ -103,6 +103,34 @@ DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env \
 
 ---
 
+## 재배포 중 런타임 연속성 검증
+
+백엔드가 PM2 reload 되는 동안 진행 중인 에이전트 run이 유지되는지 확인할 때는 아래 순서를 사용한다.
+
+```bash
+# 1) 대상 세션/채팅의 isRunning 확인
+./deploy/ops/debug-session-status.sh <sessionId> <chatId>
+
+# 2) 같은 시점에 백엔드 reload 수행
+DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env \
+  ARIS_BACKEND_DRAIN_TIMEOUT_MS=600000 \
+  ./deploy/deploy_backend_zero_downtime.sh
+
+# 3) reload 직후에도 isRunning 유지되는지 재확인
+./deploy/ops/debug-session-status.sh <sessionId> <chatId>
+
+# 4) permission 승인/abort/retry 후 로그에서 후속 이벤트 확인
+pm2 logs aris-backend --lines 200 --nostream
+./deploy/ops/debug-chat-log.sh <chatId>
+```
+
+체크 포인트:
+- reload 직후에도 `isRunning=true` 가 유지되어야 한다.
+- pending permission을 승인하면 old worker가 결정을 받아 turn이 계속 진행되어야 한다.
+- `abort` 또는 disconnected-chat `retry` 요청은 DB에 기록된 뒤 active run/new worker에 반영되어야 한다.
+
+---
+
 ## 로그 파일 위치 및 형식
 
 ```

--- a/services/aris-backend/prisma/migrations/0003_permission_decision/migration.sql
+++ b/services/aris-backend/prisma/migrations/0003_permission_decision/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Permission"
+ADD COLUMN "decision" TEXT;

--- a/services/aris-backend/prisma/schema.prisma
+++ b/services/aris-backend/prisma/schema.prisma
@@ -120,6 +120,7 @@ model Permission {
   reason      String
   risk        String
   state       String    @default("pending")
+  decision    String?
   requestedAt DateTime  @default(now())
   decidedAt   DateTime?
 

--- a/services/aris-backend/src/index.ts
+++ b/services/aris-backend/src/index.ts
@@ -3,6 +3,13 @@ import { buildServer } from './server.js';
 
 async function bootstrap() {
   const app = buildServer(config);
+  const drainTimeoutMs = (() => {
+    const parsed = Number.parseInt(process.env.ARIS_BACKEND_DRAIN_TIMEOUT_MS || '', 10);
+    if (Number.isFinite(parsed) && parsed >= 5_000) {
+      return parsed;
+    }
+    return 10 * 60 * 1000;
+  })();
 
   try {
     await app.listen({ host: config.HOST, port: config.PORT });
@@ -12,8 +19,21 @@ async function bootstrap() {
     process.exit(1);
   }
 
+  let shuttingDown = false;
   const shutdown = async () => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    const runtimeStore = (app as typeof app & {
+      arisRuntimeStore?: {
+        beginShutdownDrain: () => void;
+        awaitDrain: (timeoutMs: number) => Promise<void>;
+      };
+    }).arisRuntimeStore;
+    runtimeStore?.beginShutdownDrain();
     await app.close();
+    await runtimeStore?.awaitDrain(drainTimeoutMs);
     process.exit(0);
   };
 

--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -1492,6 +1492,11 @@ export const happyClientTestHooks = {
   resolveClaudeLaunchMode,
   resolveAgentCommandTimeoutMs,
   resolveGeminiStreamBackendV2Enabled,
+  finalizeCodexRuntimePermissions: (
+    store: HappyRuntimeStore,
+    permissionIds: Iterable<string>,
+    options?: { preservePending?: boolean },
+  ) => (store as any).finalizeCodexRuntimePermissions(permissionIds, options),
 };
 
 export class HappyRuntimeStore {
@@ -1556,6 +1561,38 @@ export class HappyRuntimeStore {
 
   private getActiveRunCount(): number {
     return this.activeRuns.size + this.claudeSessionRegistry.activeRunCount();
+  }
+
+  private async finalizeCodexRuntimePermissions(
+    permissionIds: Iterable<string>,
+    options: { preservePending?: boolean } = {},
+  ): Promise<void> {
+    for (const permissionId of permissionIds) {
+      this.codexPermissionResponders.delete(permissionId);
+
+      for (const [key, mappedPermissionId] of this.codexPermissionIndex.entries()) {
+        if (mappedPermissionId === permissionId) {
+          this.codexPermissionIndex.delete(key);
+        }
+      }
+
+      const existing = this.permissions.get(permissionId);
+      if (!existing || existing.state !== 'pending' || options.preservePending) {
+        continue;
+      }
+
+      if (this.coordinationStore) {
+        try {
+          const denied = await this.coordinationStore.decidePermission(permissionId, 'deny');
+          this.permissions.set(permissionId, denied);
+          continue;
+        } catch {
+          // Fall through to the in-memory copy when the persisted store is unavailable.
+        }
+      }
+
+      this.permissions.set(permissionId, { ...existing, state: 'denied', decision: 'deny' });
+    }
   }
 
   private resolveSessionApprovalPolicy(session: RuntimeSession): ApprovalPolicy {
@@ -3621,29 +3658,9 @@ export class HappyRuntimeStore {
       await permissionChain.catch(() => undefined);
       await appendChain.catch(() => undefined);
 
-      for (const permissionId of runtimePermissionIds) {
-        this.codexPermissionResponders.delete(permissionId);
-
-        for (const [key, mappedPermissionId] of this.codexPermissionIndex.entries()) {
-          if (mappedPermissionId === permissionId) {
-            this.codexPermissionIndex.delete(key);
-          }
-        }
-
-        const existing = this.permissions.get(permissionId);
-        if (existing?.state === 'pending') {
-          if (this.coordinationStore) {
-            try {
-              const denied = await this.coordinationStore.decidePermission(permissionId, 'deny');
-              this.permissions.set(permissionId, denied);
-            } catch {
-              this.permissions.set(permissionId, { ...existing, state: 'denied', decision: 'deny' });
-            }
-          } else {
-            this.permissions.set(permissionId, { ...existing, state: 'denied', decision: 'deny' });
-          }
-        }
-      }
+      await this.finalizeCodexRuntimePermissions(runtimePermissionIds, {
+        preservePending: this.draining && !signal?.aborted,
+      });
 
       if (!turnCompleted && !signal?.aborted && stderr.trim()) {
         if (runStatus === 'running') {

--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
-import { execFile, spawn } from 'node:child_process';
+import { execFile, spawn, type SpawnOptionsWithoutStdio } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { createServer } from 'node:net';
 import * as path from 'node:path';
 import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'node:url';
@@ -1476,6 +1477,241 @@ function buildAgentCommand(
   });
 }
 
+function buildCodexAppServerSpawnOptions(input: {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
+}): SpawnOptionsWithoutStdio {
+  return {
+    cwd: input.cwd,
+    env: input.env,
+    stdio: 'pipe',
+    signal: input.signal,
+    detached: true,
+  };
+}
+
+function buildCodexAppServerListenUrl(port: number): string {
+  return `ws://127.0.0.1:${port}`;
+}
+
+async function reserveCodexAppServerPort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('failed to reserve codex app-server websocket port'));
+        return;
+      }
+      const port = address.port;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+    server.unref?.();
+  });
+}
+
+type CodexAppServerSocket = {
+  readonly readyState: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(type: 'open', listener: () => void): void;
+  addEventListener(type: 'message', listener: (event: { data: unknown }) => void): void;
+  addEventListener(type: 'error', listener: (event: unknown) => void): void;
+  addEventListener(type: 'close', listener: () => void): void;
+  removeEventListener(type: 'open', listener: () => void): void;
+  removeEventListener(type: 'message', listener: (event: { data: unknown }) => void): void;
+  removeEventListener(type: 'error', listener: (event: unknown) => void): void;
+  removeEventListener(type: 'close', listener: () => void): void;
+};
+
+function createCodexAppServerSocket(url: string): CodexAppServerSocket {
+  const WebSocketCtor = (globalThis as { WebSocket?: new (url: string) => CodexAppServerSocket }).WebSocket;
+  if (typeof WebSocketCtor !== 'function') {
+    throw new Error('global WebSocket constructor is unavailable');
+  }
+  return new WebSocketCtor(url);
+}
+
+async function connectCodexAppServerSocket(
+  url: string,
+  options: { signal?: AbortSignal; timeoutMs?: number } = {},
+): Promise<CodexAppServerSocket> {
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const deadline = Date.now() + timeoutMs;
+  let lastError: Error | null = null;
+
+  while (Date.now() < deadline) {
+    if (options.signal?.aborted) {
+      throw new Error('codex app-server websocket connection aborted');
+    }
+
+    try {
+      const socket = await new Promise<CodexAppServerSocket>((resolve, reject) => {
+        const candidate = createCodexAppServerSocket(url);
+        let settled = false;
+
+        const cleanup = () => {
+          candidate.removeEventListener('open', handleOpen);
+          candidate.removeEventListener('error', handleError);
+          candidate.removeEventListener('close', handleClose);
+          options.signal?.removeEventListener('abort', handleAbort);
+          clearTimeout(timer);
+        };
+
+        const finishResolve = () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          resolve(candidate);
+        };
+
+        const finishReject = (error: Error) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          try {
+            candidate.close();
+          } catch {
+            // ignore close failures while cleaning up failed attempts
+          }
+          reject(error);
+        };
+
+        const handleOpen = () => finishResolve();
+        const handleError = () => finishReject(new Error('codex app-server websocket connection failed'));
+        const handleClose = () => finishReject(new Error('codex app-server websocket closed before opening'));
+        const handleAbort = () => finishReject(new Error('codex app-server websocket connection aborted'));
+        const timer = setTimeout(() => finishReject(new Error('timed out waiting for codex app-server websocket')), 750);
+
+        candidate.addEventListener('open', handleOpen);
+        candidate.addEventListener('error', handleError);
+        candidate.addEventListener('close', handleClose);
+        options.signal?.addEventListener('abort', handleAbort, { once: true });
+      });
+      return socket;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (Date.now() >= deadline) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
+  throw lastError ?? new Error('failed to connect to codex app-server websocket');
+}
+
+function normalizeCodexAppServerMessageData(data: unknown): string {
+  if (typeof data === 'string') {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString('utf8');
+  }
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString('utf8');
+  }
+  return String(data ?? '');
+}
+
+async function launchDetachedCodexAppServerProcess(input: {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  args: string[];
+  signal?: AbortSignal;
+}): Promise<number> {
+  const launcherScript = `
+    const { spawn } = require('node:child_process');
+    const command = process.argv[1];
+    const args = JSON.parse(process.argv[2]);
+    const cwd = process.argv[3];
+    try {
+      const child = spawn(command, args, {
+        cwd,
+        env: process.env,
+        detached: true,
+        stdio: 'ignore',
+      });
+      if (!child.pid || !Number.isInteger(child.pid) || child.pid <= 0) {
+        console.error('missing detached codex app-server pid');
+        process.exit(1);
+      }
+      console.log(String(child.pid));
+      child.unref();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(message);
+      process.exit(1);
+    }
+  `;
+  const launcher = spawn(process.execPath, ['-e', launcherScript, 'codex', JSON.stringify(input.args), input.cwd], {
+    cwd: input.cwd,
+    env: input.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    signal: input.signal,
+  });
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  launcher.stdout?.on('data', (chunk: Buffer | string) => {
+    stdoutChunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+  });
+  launcher.stderr?.on('data', (chunk: Buffer | string) => {
+    stderrChunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+  });
+
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    launcher.once('error', reject);
+    launcher.once('close', (code) => resolve(code));
+  });
+  if (exitCode !== 0) {
+    const detail = stderrChunks.join('').trim() || stdoutChunks.join('').trim() || `exit code ${exitCode ?? 'null'}`;
+    throw new Error(`failed to launch detached codex app-server: ${detail}`);
+  }
+
+  const pid = Number.parseInt(stdoutChunks.join('').trim(), 10);
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error(`failed to parse detached codex app-server pid: ${stdoutChunks.join('').trim()}`);
+  }
+  return pid;
+}
+
+function terminateCodexAppServerProcess(
+  child: { pid?: number; killed?: boolean; kill: (signal?: NodeJS.Signals | number) => boolean },
+  killProcess: (pid: number, signal?: NodeJS.Signals | number) => void = process.kill,
+  signal: NodeJS.Signals = 'SIGTERM',
+): void {
+  if (child.killed) {
+    return;
+  }
+
+  const pid = typeof child.pid === 'number' && Number.isInteger(child.pid) && child.pid > 0
+    ? child.pid
+    : null;
+  if (pid !== null) {
+    try {
+      killProcess(-pid, signal);
+      return;
+    } catch {
+      // Fall back to the direct child signal if the process group no longer exists.
+    }
+  }
+
+  child.kill(signal);
+}
+
 export const happyClientTestHooks = {
   parseAgentStreamLine,
   parseAgentStreamOutput,
@@ -1488,6 +1724,9 @@ export const happyClientTestHooks = {
   shouldSkipDuplicateAgentMessage,
   buildClaudeSessionId,
   buildAgentCommand,
+  buildCodexAppServerListenUrl,
+  buildCodexAppServerSpawnOptions,
+  terminateCodexAppServerProcess,
   waitForStableActivity,
   resolveClaudeLaunchMode,
   resolveAgentCommandTimeoutMs,
@@ -2881,17 +3120,19 @@ export class HappyRuntimeStore {
     const autoApproveAll = sessionApprovalPolicy === 'yolo';
     const effectiveSandboxMode = autoApproveAll ? 'danger-full-access' : CODEX_SANDBOX_MODE;
     const mergedPath = `${process.env.PATH || ''}:${AGENT_EXTRA_PATHS}`;
+    const listenPort = await reserveCodexAppServerPort();
+    const listenUrl = buildCodexAppServerListenUrl(listenPort);
     const args = [
       ...(selectedModel ? ['-c', `model=${JSON.stringify(selectedModel)}`] : []),
       ...(selectedReasoningEffort ? ['-c', `model_reasoning_effort=${JSON.stringify(selectedReasoningEffort)}`] : []),
       'app-server',
       '--listen',
-      'stdio://',
+      listenUrl,
     ];
-    const child = spawn('codex', args, {
+    const appServerPid = await launchDetachedCodexAppServerProcess({
       cwd: safeCwd,
       env: { ...process.env, PATH: mergedPath },
-      stdio: ['pipe', 'pipe', 'pipe'],
+      args,
       signal,
     });
     this.happyEventLogger.logParsed({
@@ -2905,23 +3146,20 @@ export class HappyRuntimeStore {
       payload: {
         mode: 'app-server',
         args,
+        listenUrl,
+        appServerPid,
       },
     });
 
-    if (!child.stdin || !child.stdout || !child.stderr) {
-      throw new Error('codex app-server stdio streams are unavailable');
-    }
-
-    const stdoutLines = createInterface({ input: child.stdout });
-    let stderr = '';
+    const socket = await connectCodexAppServerSocket(listenUrl, { signal });
     let appendChain: Promise<void> = Promise.resolve();
     let permissionChain: Promise<void> = Promise.resolve();
     let lastAgentMessage = '';
     let pendingAgentMessage = '';
     let streamedPersisted = false;
     let agentMessagePersisted = false;
-    let stdoutActivityTick = 0;
-    let lastStdoutActivityAt = Date.now();
+    let transportActivityTick = 0;
+    let lastTransportActivityAt = Date.now();
     let resolvedThreadId = typeof threadId === 'string' && threadId.trim().length > 0
       ? threadId.trim()
       : '';
@@ -2944,9 +3182,12 @@ export class HappyRuntimeStore {
       resolveTurnCompletion = resolve;
     });
 
-    const childClosed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
-      child.once('error', reject);
-      child.once('close', (code, closeSignal) => resolve({ code, signal: closeSignal }));
+    const transportClosed = new Promise<never>((_, reject) => {
+      const handleClose = () => {
+        socket.removeEventListener('close', handleClose);
+        reject(new Error('codex app-server websocket closed before turn completion'));
+      };
+      socket.addEventListener('close', handleClose);
     });
 
     const enqueueAppend = (
@@ -2976,18 +3217,17 @@ export class HappyRuntimeStore {
     };
 
     const sendJsonRpc = (payload: Record<string, unknown>): Promise<void> => new Promise((resolve, reject) => {
-      if (!child.stdin || child.stdin.destroyed || !child.stdin.writable) {
-        reject(new Error('codex app-server stdin is not writable'));
+      if (socket.readyState !== 1) {
+        reject(new Error('codex app-server websocket is not open'));
         return;
       }
 
-      child.stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
+      try {
+        socket.send(JSON.stringify(payload));
         resolve();
-      });
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
     });
 
     const sendJsonRpcResult = async (id: JsonRpcId | unknown, result: Record<string, unknown>) => {
@@ -3390,14 +3630,10 @@ export class HappyRuntimeStore {
       }
     };
 
-    child.stderr.on('data', (chunk: Buffer | string) => {
-      stderr += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
-    });
-
-    stdoutLines.on('line', (line) => {
-      stdoutActivityTick += 1;
-      lastStdoutActivityAt = Date.now();
-      const rawLine = line.trim();
+    const handleIncomingPayloadText = (rawText: string) => {
+      transportActivityTick += 1;
+      lastTransportActivityAt = Date.now();
+      const rawLine = rawText.trim();
       this.happyEventLogger.logRaw({
         sessionId: session.id,
         agent: 'codex',
@@ -3467,20 +3703,28 @@ export class HappyRuntimeStore {
 
       const resultPayload = asRecord(payload.result) ?? {};
       pending.resolve(resultPayload);
+    };
+
+    socket.addEventListener('message', (event) => {
+      handleIncomingPayloadText(normalizeCodexAppServerMessageData(event.data));
+    });
+    socket.addEventListener('close', () => {
+      for (const [key, pending] of pendingRequests.entries()) {
+        pending.reject(new Error(`JSON-RPC request cancelled: ${pending.method}`));
+        pendingRequests.delete(key);
+      }
     });
 
     const closeChild = async () => {
-      stdoutLines.close();
-      if (child.stdin && !child.stdin.destroyed) {
-        child.stdin.end();
+      try {
+        socket.close(1000, 'turn-complete');
+      } catch {
+        // ignore websocket close failures during shutdown
       }
-      if (!child.killed) {
-        child.kill('SIGTERM');
-      }
-      await Promise.race([
-        childClosed,
-        new Promise<void>((resolve) => setTimeout(resolve, 1_500)),
-      ]).catch(() => undefined);
+      const pseudoChild = { pid: appServerPid, killed: false, kill: () => false };
+      terminateCodexAppServerProcess(pseudoChild, process.kill, 'SIGTERM');
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      terminateCodexAppServerProcess(pseudoChild, process.kill, 'SIGKILL');
     };
 
     const waitForPostTurnDrain = async () => {
@@ -3488,23 +3732,23 @@ export class HappyRuntimeStore {
 
       while (Date.now() < drainDeadline) {
         await waitForStableActivity({
-          getActivityTick: () => stdoutActivityTick,
-          getLastActivityAt: () => lastStdoutActivityAt,
+          getActivityTick: () => transportActivityTick,
+          getLastActivityAt: () => lastTransportActivityAt,
           quietMs: CODEX_APP_SERVER_POST_TURN_QUIET_MS,
           timeoutMs: Math.max(10, drainDeadline - Date.now()),
         });
 
-        const activityTickSnapshot = stdoutActivityTick;
+        const activityTickSnapshot = transportActivityTick;
         const appendSnapshot = appendChain;
         const permissionSnapshot = permissionChain;
         await appendSnapshot;
         await permissionSnapshot;
 
         if (
-          activityTickSnapshot === stdoutActivityTick
+          activityTickSnapshot === transportActivityTick
           && appendSnapshot === appendChain
           && permissionSnapshot === permissionChain
-          && Date.now() - lastStdoutActivityAt >= CODEX_APP_SERVER_POST_TURN_QUIET_MS
+          && Date.now() - lastTransportActivityAt >= CODEX_APP_SERVER_POST_TURN_QUIET_MS
         ) {
           return;
         }
@@ -3597,9 +3841,7 @@ export class HappyRuntimeStore {
       let turnTimeout: NodeJS.Timeout | undefined;
       const completion = await Promise.race([
         turnCompletion,
-        childClosed.then(({ code }) => {
-          throw new Error(`codex app-server closed before turn completion (exit code ${code ?? 'null'})`);
-        }),
+        transportClosed,
         new Promise<{ status: string; errorMessage?: string }>((_resolve, reject) => {
           turnTimeout = setTimeout(() => {
             runStatus = 'timed_out';
@@ -3662,7 +3904,7 @@ export class HappyRuntimeStore {
         preservePending: this.draining && !signal?.aborted,
       });
 
-      if (!turnCompleted && !signal?.aborted && stderr.trim()) {
+      if (!turnCompleted && !signal?.aborted) {
         if (runStatus === 'running') {
           runStatus = 'failed';
           runErrorMessage = 'turn did not complete before process close';
@@ -3678,10 +3920,11 @@ export class HappyRuntimeStore {
           payload: {
             threadId: resolvedThreadId || undefined,
             turnId: activeTurnId || undefined,
-            stderrPreview: stripAnsi(stderr).slice(0, 800),
+            listenUrl,
+            appServerPid,
           },
         });
-        console.error(`codex app-server stderr: ${stripAnsi(stderr).slice(0, 800)}`);
+        console.error(`codex app-server transport closed early; pid=${appServerPid} listenUrl=${listenUrl}`);
       }
       this.happyEventLogger.logParsed({
         sessionId: session.id,

--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -179,6 +179,19 @@ type HappyRuntimePermissionInput = {
   risk: PermissionRisk;
 };
 
+type RuntimeCoordinationStore = {
+  listPermissions(state?: PermissionState): Promise<PermissionRequest[]>;
+  createPermission(input: HappyRuntimePermissionInput): Promise<PermissionRequest>;
+  decidePermission(permissionId: string, decision: PermissionDecision): Promise<PermissionRequest>;
+  getPermissionById(permissionId: string): Promise<PermissionRequest | null>;
+  hasRequestedAction(input: {
+    sessionId: string;
+    action: SessionAction;
+    chatId?: string;
+    createdAfter?: Date;
+  }): Promise<boolean>;
+};
+
 type SessionRealtimeEventRecord = {
   cursor: number;
   event: RuntimeMessage;
@@ -1499,23 +1512,50 @@ export class HappyRuntimeStore {
   private readonly sessionRealtimeEvents = new Map<string, SessionRealtimeEventRecord[]>();
   private readonly sessionRealtimeCursor = new Map<string, number>();
   private readonly geminiPartialTextStates = new Map<string, GeminiPartialTextState>();
+  private readonly coordinationStore: RuntimeCoordinationStore | null;
 
   private readonly serverUrl: string;
   private readonly serverToken: string;
   private readonly workspaceRoot: string;
   private readonly hostProjectsRoot: string;
   private readonly happyEventLogger: HappyEventLogger;
+  private draining = false;
 
   // listSessions() 응답을 1초간 캐시하여 getSession() 호출 시 happy-server 왕복을 줄임
   private sessionListCache: { sessions: RuntimeSession[]; expiresAt: number } | null = null;
   private readonly SESSION_LIST_CACHE_TTL_MS = 1_000;
 
-  constructor(opts: { serverUrl: string; token: string; workspaceRoot?: string; hostProjectsRoot?: string }) {
+  constructor(opts: {
+    serverUrl: string;
+    token: string;
+    workspaceRoot?: string;
+    hostProjectsRoot?: string;
+    coordinationStore?: RuntimeCoordinationStore | null;
+  }) {
     this.serverUrl = opts.serverUrl.replace(/\/+$/, '');
     this.serverToken = opts.token;
     this.workspaceRoot = (opts.workspaceRoot || '/workspace').replace(/\/+$/, '');
     this.hostProjectsRoot = (opts.hostProjectsRoot || '').replace(/\/+$/, '');
+    this.coordinationStore = opts.coordinationStore ?? null;
     this.happyEventLogger = new HappyEventLogger(HAPPY_EVENT_LOG_DIR, HAPPY_EVENT_LOG_MAX_BYTES);
+  }
+
+  beginShutdownDrain(): void {
+    this.draining = true;
+  }
+
+  async awaitDrain(timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    while (Date.now() <= deadline) {
+      if (this.getActiveRunCount() === 0) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+
+  private getActiveRunCount(): number {
+    return this.activeRuns.size + this.claudeSessionRegistry.activeRunCount();
   }
 
   private resolveSessionApprovalPolicy(session: RuntimeSession): ApprovalPolicy {
@@ -1668,10 +1708,43 @@ export class HappyRuntimeStore {
     }
   }
 
+  private async waitForPersistedPermissionDecision(
+    permissionId: string,
+    signal?: AbortSignal,
+  ): Promise<PermissionDecision> {
+    if (!this.coordinationStore) {
+      throw new Error('PERSISTED_PERMISSION_COORDINATION_UNAVAILABLE');
+    }
+
+    while (true) {
+      if (signal?.aborted) {
+        throw new Error('The operation was aborted');
+      }
+
+      const persisted = await this.coordinationStore.getPermissionById(permissionId);
+      if (!persisted) {
+        throw new Error('PERMISSION_NOT_FOUND');
+      }
+      this.permissions.set(permissionId, persisted);
+      if (persisted.state === 'denied') {
+        return 'deny';
+      }
+      if (persisted.state === 'approved') {
+        return persisted.decision === 'allow_session' ? 'allow_session' : 'allow_once';
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    }
+  }
+
   private async awaitProviderPermissionDecision(
     permissionId: string,
     signal?: AbortSignal,
   ): Promise<PermissionDecision> {
+    if (this.coordinationStore) {
+      return this.waitForPersistedPermissionDecision(permissionId, signal);
+    }
+
     const knownDecision = this.providerPermissionDecisions.get(permissionId);
     if (knownDecision) {
       return knownDecision;
@@ -1709,6 +1782,70 @@ export class HappyRuntimeStore {
       });
       signal?.addEventListener('abort', handleAbort, { once: true });
     });
+  }
+
+  private watchExternalPermissionDecision(input: {
+    permissionId: string;
+    responder: (decision: PermissionDecision) => Promise<void>;
+    signal?: AbortSignal;
+  }): void {
+    if (!this.coordinationStore) {
+      return;
+    }
+
+    void this.waitForPersistedPermissionDecision(input.permissionId, input.signal)
+      .then((decision) => input.responder(decision))
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!message.includes('aborted')) {
+          console.error(`failed to resolve persisted permission decision: ${message}`);
+        }
+      });
+  }
+
+  private monitorExternalAbortSignal(input: {
+    sessionId: string;
+    chatId?: string;
+    startedAt: number;
+    controller: AbortController;
+  }): () => void {
+    if (!this.coordinationStore) {
+      return () => {};
+    }
+
+    let disposed = false;
+    const startedAt = new Date(input.startedAt);
+    const tick = async () => {
+      if (disposed || input.controller.signal.aborted) {
+        return;
+      }
+      try {
+        const abortRequested = await this.coordinationStore!.hasRequestedAction({
+          sessionId: input.sessionId,
+          action: 'abort',
+          ...(input.chatId ? { chatId: input.chatId } : {}),
+          createdAfter: startedAt,
+        });
+        if (abortRequested && !input.controller.signal.aborted) {
+          input.controller.abort();
+          return;
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`failed to poll external abort signal: ${message}`);
+      }
+      if (!disposed && !input.controller.signal.aborted) {
+        const timer = setTimeout(() => {
+          void tick();
+        }, 500);
+        timer.unref?.();
+      }
+    };
+
+    void tick();
+    return () => {
+      disposed = true;
+    };
   }
 
   private async handleProviderPermissionRequest(input: {
@@ -2869,7 +3006,15 @@ export class HappyRuntimeStore {
       if (knownPermissionId) {
         const knownPermission = this.permissions.get(knownPermissionId);
         if (knownPermission?.state === 'pending') {
-          this.codexPermissionResponders.set(knownPermissionId, responder);
+          if (this.coordinationStore) {
+            this.watchExternalPermissionDecision({
+              permissionId: knownPermissionId,
+              responder,
+              signal,
+            });
+          } else {
+            this.codexPermissionResponders.set(knownPermissionId, responder);
+          }
           runtimePermissionIds.add(knownPermissionId);
           if (autoApproveAll) {
             await this.decidePermission(knownPermissionId, 'allow_session');
@@ -2889,7 +3034,15 @@ export class HappyRuntimeStore {
       });
 
       this.codexPermissionIndex.set(key, created.id);
-      this.codexPermissionResponders.set(created.id, responder);
+      if (this.coordinationStore) {
+        this.watchExternalPermissionDecision({
+          permissionId: created.id,
+          responder,
+          signal,
+        });
+      } else {
+        this.codexPermissionResponders.set(created.id, responder);
+      }
       runtimePermissionIds.add(created.id);
       if (autoApproveAll) {
         await this.decidePermission(created.id, 'allow_session');
@@ -3479,7 +3632,16 @@ export class HappyRuntimeStore {
 
         const existing = this.permissions.get(permissionId);
         if (existing?.state === 'pending') {
-          this.permissions.set(permissionId, { ...existing, state: 'denied' });
+          if (this.coordinationStore) {
+            try {
+              const denied = await this.coordinationStore.decidePermission(permissionId, 'deny');
+              this.permissions.set(permissionId, denied);
+            } catch {
+              this.permissions.set(permissionId, { ...existing, state: 'denied', decision: 'deny' });
+            }
+          } else {
+            this.permissions.set(permissionId, { ...existing, state: 'denied', decision: 'deny' });
+          }
         }
       }
 
@@ -4074,6 +4236,12 @@ export class HappyRuntimeStore {
       agent: flavor,
       ...(selectedModel ? { model: selectedModel } : {}),
       ...(selectedGeminiMode ? { geminiMode: selectedGeminiMode } : {}),
+    });
+    const stopExternalAbortWatcher = this.monitorExternalAbortSignal({
+      sessionId: session.id,
+      ...(scopedChatId ? { chatId: scopedChatId } : {}),
+      startedAt: Date.now(),
+      controller,
     });
 
     try {
@@ -4729,6 +4897,7 @@ export class HappyRuntimeStore {
         ...(selectedModel ? { model: selectedModel } : {}),
       });
     } finally {
+      stopExternalAbortWatcher();
       if (flavor === 'gemini') {
         this.clearGeminiRealtimePartialsForScope({
           sessionId: session.id,
@@ -5121,6 +5290,13 @@ export class HappyRuntimeStore {
   }
 
   async listPermissions(state?: PermissionState): Promise<PermissionRequest[]> {
+    if (this.coordinationStore) {
+      const persisted = await this.coordinationStore.listPermissions(state);
+      for (const permission of persisted) {
+        this.permissions.set(permission.id, permission);
+      }
+      return persisted;
+    }
     const list = [...this.permissions.values()].sort((a, b) => b.requestedAt.localeCompare(a.requestedAt));
     return state ? list.filter((permission) => permission.state === state) : list;
   }
@@ -5131,19 +5307,21 @@ export class HappyRuntimeStore {
       throw new Error('SESSION_NOT_FOUND');
     }
 
-    const permission: PermissionRequest = {
-      id: randomUUID(),
-      sessionId: input.sessionId,
-      ...(typeof input.chatId === 'string' && input.chatId.trim().length > 0
-        ? { chatId: input.chatId.trim() }
-        : {}),
-      agent: input.agent,
-      command: input.command,
-      reason: input.reason,
-      risk: input.risk,
-      requestedAt: new Date().toISOString(),
-      state: 'pending',
-    };
+    const permission = this.coordinationStore
+      ? await this.coordinationStore.createPermission(input)
+      : {
+          id: randomUUID(),
+          sessionId: input.sessionId,
+          ...(typeof input.chatId === 'string' && input.chatId.trim().length > 0
+            ? { chatId: input.chatId.trim() }
+            : {}),
+          agent: input.agent,
+          command: input.command,
+          reason: input.reason,
+          risk: input.risk,
+          requestedAt: new Date().toISOString(),
+          state: 'pending' as const,
+        };
 
     this.permissions.set(permission.id, permission);
     await this.persistPermissionEvent(permission, 'permission_request');
@@ -5158,13 +5336,21 @@ export class HappyRuntimeStore {
   }
 
   async decidePermission(permissionId: string, decision: PermissionDecision): Promise<PermissionRequest> {
-    const permission = this.permissions.get(permissionId);
+    const knownPermission = this.permissions.get(permissionId);
+    const permission = knownPermission
+      ?? await this.coordinationStore?.getPermissionById(permissionId)
+      ?? null;
     if (!permission) {
       throw new Error('PERMISSION_NOT_FOUND');
     }
 
-    const state: PermissionState = decision === 'deny' ? 'denied' : 'approved';
-    const updated = { ...permission, state };
+    const updated = this.coordinationStore
+      ? await this.coordinationStore.decidePermission(permissionId, decision)
+      : {
+          ...permission,
+          state: (decision === 'deny' ? 'denied' : 'approved') as PermissionState,
+          decision,
+        };
     this.permissions.set(permissionId, updated);
     await this.persistPermissionEvent(updated, 'permission_decision', decision);
 

--- a/services/aris-backend/src/runtime/prismaStore.ts
+++ b/services/aris-backend/src/runtime/prismaStore.ts
@@ -170,6 +170,7 @@ function toPermissionRequest(row: {
   reason: string;
   risk: string;
   state: string;
+  decision?: string | null;
   requestedAt: Date;
 }): PermissionRequest {
   return {
@@ -182,6 +183,9 @@ function toPermissionRequest(row: {
     risk: row.risk as PermissionRisk,
     state: row.state as PermissionRequest['state'],
     requestedAt: row.requestedAt.toISOString(),
+    ...(typeof row.decision === 'string' && row.decision.trim().length > 0
+      ? { decision: row.decision as PermissionDecision }
+      : {}),
   };
 }
 
@@ -635,6 +639,60 @@ export class PrismaRuntimeStore {
     return rows.map(toPermissionRequest);
   }
 
+  async getPermissionById(permissionId: string): Promise<PermissionRequest | null> {
+    const row = await this.db.permission.findUnique({
+      where: { id: permissionId },
+    });
+    return row ? toPermissionRequest(row) : null;
+  }
+
+  async hasRequestedAction(input: {
+    sessionId: string;
+    action: SessionAction;
+    chatId?: string;
+    createdAfter?: Date;
+  }): Promise<boolean> {
+    const normalizedChatId = typeof input.chatId === 'string' && input.chatId.trim().length > 0
+      ? input.chatId.trim()
+      : null;
+    const createdAfter = input.createdAfter instanceof Date && Number.isFinite(input.createdAfter.getTime())
+      ? input.createdAfter
+      : null;
+    const row = await this.db.sessionMessage.findFirst({
+      where: {
+        sessionId: input.sessionId,
+        ...(createdAfter ? { createdAt: { gt: createdAfter } } : {}),
+        ...(normalizedChatId
+          ? {
+              meta: {
+                path: ['action'],
+                equals: input.action,
+              },
+            }
+          : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, meta: true },
+    });
+
+    if (!row) {
+      return false;
+    }
+
+    const meta = row.meta && typeof row.meta === 'object' && !Array.isArray(row.meta)
+      ? row.meta as Record<string, unknown>
+      : {};
+    const action = typeof meta.action === 'string' ? meta.action.trim() : '';
+    const chatId = typeof meta.chatId === 'string' ? meta.chatId.trim() : '';
+    if (action !== input.action) {
+      return false;
+    }
+    if (normalizedChatId && chatId !== normalizedChatId) {
+      return false;
+    }
+    return true;
+  }
+
   async createPermission(input: CreatePermissionInput): Promise<PermissionRequest> {
     const session = await this.db.session.findUnique({ where: { id: input.sessionId } });
     if (!session) throw new Error('SESSION_NOT_FOUND');
@@ -649,6 +707,7 @@ export class PrismaRuntimeStore {
         reason: input.reason,
         risk: input.risk,
         state: 'pending',
+        decision: null,
       },
     });
     return toPermissionRequest(row);
@@ -662,6 +721,7 @@ export class PrismaRuntimeStore {
       where: { id: permissionId },
       data: {
         state: decision === 'deny' ? 'denied' : 'approved',
+        decision,
         decidedAt: new Date(),
       },
     });

--- a/services/aris-backend/src/runtime/prismaStore.ts
+++ b/services/aris-backend/src/runtime/prismaStore.ts
@@ -639,6 +639,61 @@ export class PrismaRuntimeStore {
     return rows.map(toPermissionRequest);
   }
 
+  async getLatestUserMessageForAction(sessionId: string, chatId?: string): Promise<AppendMessageInput | null> {
+    const normalizedChatId = typeof chatId === 'string' && chatId.trim().length > 0
+      ? chatId.trim()
+      : null;
+    if (normalizedChatId) {
+      const db = this.db as any;
+      const row = await db.sessionChatEvent.findFirst({
+        where: {
+          sessionId,
+          chatId: normalizedChatId,
+          meta: {
+            path: ['role'],
+            equals: 'user',
+          },
+        },
+        orderBy: { seq: 'desc' },
+      });
+      if (!row) {
+        return null;
+      }
+      return {
+        type: row.type,
+        title: row.title ?? undefined,
+        text: row.text,
+        meta: {
+          ...(row.meta && typeof row.meta === 'object' && !Array.isArray(row.meta) ? row.meta as Record<string, unknown> : {}),
+          chatId: row.chatId,
+          ...(row.runId ? { runId: row.runId } : {}),
+        },
+      };
+    }
+
+    const row = await this.db.sessionMessage.findFirst({
+      where: {
+        sessionId,
+        meta: {
+          path: ['role'],
+          equals: 'user',
+        },
+      },
+      orderBy: { seq: 'desc' },
+    });
+    if (!row) {
+      return null;
+    }
+    return {
+      type: row.type,
+      title: row.title ?? undefined,
+      text: row.text,
+      meta: row.meta && typeof row.meta === 'object' && !Array.isArray(row.meta)
+        ? row.meta as Record<string, unknown>
+        : undefined,
+    };
+  }
+
   async getPermissionById(permissionId: string): Promise<PermissionRequest | null> {
     const row = await this.db.permission.findUnique({
       where: { id: permissionId },

--- a/services/aris-backend/src/runtime/providers/claude/claudeSessionRegistry.ts
+++ b/services/aris-backend/src/runtime/providers/claude/claudeSessionRegistry.ts
@@ -103,4 +103,8 @@ export class ClaudeSessionRegistry implements ClaudeSessionOwner {
     }
     return false;
   }
+
+  activeRunCount(): number {
+    return this.runs.size;
+  }
 }

--- a/services/aris-backend/src/server.ts
+++ b/services/aris-backend/src/server.ts
@@ -240,6 +240,7 @@ export function buildServer(config: ServerConfig) {
     `http://127.0.0.1:${config.PORT}`,
     config.RUNTIME_API_TOKEN,
   );
+  Object.assign(app, { arisRuntimeStore: store });
   const rateLimitBuckets = new Map<string, RequestBucket>();
 
   const isRateLimitExceeded = (path: string, ip: string): boolean => {

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -658,7 +658,23 @@ export class RuntimeStore {
 
   async decidePermission(permissionId: string, decision: PermissionDecision) {
     if (this.runtimeExecutor) {
-      return this.runtimeExecutor.decidePermission(permissionId, decision);
+      const updated = await this.runtimeExecutor.decidePermission(permissionId, decision);
+      const normalizedChatId = typeof updated.chatId === 'string' && updated.chatId.trim().length > 0
+        ? updated.chatId.trim()
+        : undefined;
+      if (
+        decision !== 'deny'
+        && typeof this.delegate.getLatestUserMessageForAction === 'function'
+      ) {
+        const runtimeStillRunning = await this.runtimeExecutor.isSessionRunning(updated.sessionId, normalizedChatId);
+        if (!runtimeStillRunning) {
+          const latestUserMessage = await this.delegate.getLatestUserMessageForAction(updated.sessionId, normalizedChatId);
+          if (latestUserMessage) {
+            await this.runtimeExecutor.triggerPersistedUserMessage(updated.sessionId, latestUserMessage);
+          }
+        }
+      }
+      return updated;
     }
     return this.delegate.decidePermission(permissionId, decision);
   }

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -84,6 +84,8 @@ type RuntimeExecutor = Pick<
   | 'createPermission'
   | 'decidePermission'
   | 'getGeminiSessionCapabilities'
+  | 'beginShutdownDrain'
+  | 'awaitDrain'
 >;
 
 class MockRuntimeStore implements RuntimeStoreBackend {
@@ -435,6 +437,23 @@ export class RuntimeStore {
         token: runtimeApiToken ?? '',
         workspaceRoot: defaultProjectPath,
         hostProjectsRoot: hostProjectsRoot ?? '',
+        coordinationStore: {
+          listPermissions: (state) => this.delegate.listPermissions(state),
+          createPermission: (input) => this.delegate.createPermission(input),
+          decidePermission: (permissionId, decision) => this.delegate.decidePermission(permissionId, decision),
+          getPermissionById: (permissionId) => {
+            if (this.delegate instanceof PrismaRuntimeStore) {
+              return this.delegate.getPermissionById(permissionId);
+            }
+            return Promise.resolve(null);
+          },
+          hasRequestedAction: (input) => {
+            if (this.delegate instanceof PrismaRuntimeStore) {
+              return this.delegate.hasRequestedAction(input);
+            }
+            return Promise.resolve(false);
+          },
+        },
       });
       return;
     }
@@ -558,9 +577,24 @@ export class RuntimeStore {
 
   async isSessionRunning(sessionId: string, chatId?: string) {
     if (this.runtimeExecutor) {
-      return this.runtimeExecutor.isSessionRunning(sessionId, chatId);
+      const [runtimeRunning, persistedRunning] = await Promise.all([
+        this.runtimeExecutor.isSessionRunning(sessionId, chatId),
+        this.delegate.isSessionRunning(sessionId, chatId),
+      ]);
+      return runtimeRunning || persistedRunning;
     }
     return this.delegate.isSessionRunning(sessionId, chatId);
+  }
+
+  beginShutdownDrain(): void {
+    this.runtimeExecutor?.beginShutdownDrain();
+  }
+
+  async awaitDrain(timeoutMs: number): Promise<void> {
+    if (!this.runtimeExecutor) {
+      return;
+    }
+    await this.runtimeExecutor.awaitDrain(timeoutMs);
   }
 
   async listPermissions(state?: PermissionRequest['state']) {

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -67,6 +67,7 @@ interface RuntimeStoreBackend {
     chatId: string,
     input: { sessionId: string; runId?: string; type: string; title?: string; text: string; meta?: Record<string, unknown> },
   ): Promise<RuntimeMessage>;
+  getLatestUserMessageForAction?(sessionId: string, chatId?: string): Promise<AppendMessageInput | null>;
   applySessionAction(sessionId: string, action: SessionAction, chatId?: string): Promise<{ accepted: boolean; message: string; at: string }>;
   isSessionRunning(sessionId: string, chatId?: string): Promise<boolean>;
   listPermissions(state?: PermissionRequest['state']): Promise<PermissionRequest[]>;
@@ -303,6 +304,40 @@ class MockRuntimeStore implements RuntimeStoreBackend {
     session.updatedAt = message.createdAt;
     this.sessions.set(input.sessionId, session);
     return message;
+  }
+
+  async getLatestUserMessageForAction(sessionId: string, chatId?: string): Promise<AppendMessageInput | null> {
+    if (chatId && chatId.trim().length > 0) {
+      const events = this.chatEvents.get(chatId.trim()) ?? [];
+      for (let index = events.length - 1; index >= 0; index -= 1) {
+        const event = events[index];
+        const role = typeof event.meta?.role === 'string' ? event.meta.role.trim() : '';
+        if (event.sessionId === sessionId && role === 'user') {
+          return {
+            type: event.type,
+            title: event.title,
+            text: event.text,
+            meta: event.meta,
+          };
+        }
+      }
+      return null;
+    }
+
+    const messages = this.messages.get(sessionId) ?? [];
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      const role = typeof message.meta?.role === 'string' ? message.meta.role.trim() : '';
+      if (role === 'user') {
+        return {
+          type: message.type,
+          title: message.title,
+          text: message.text,
+          meta: message.meta,
+        };
+      }
+    }
+    return null;
   }
 
   async applySessionAction(sessionId: string, action: SessionAction, _chatId?: string): Promise<{ accepted: boolean; message: string; at: string }> {
@@ -565,6 +600,16 @@ export class RuntimeStore {
 
   async applySessionAction(sessionId: string, action: SessionAction, chatId?: string) {
     if (this.runtimeExecutor) {
+      if (action === 'retry' || action === 'resume') {
+        const result = await this.delegate.applySessionAction(sessionId, action, chatId);
+        const latestUserMessage = typeof this.delegate.getLatestUserMessageForAction === 'function'
+          ? await this.delegate.getLatestUserMessageForAction(sessionId, chatId)
+          : null;
+        if (latestUserMessage) {
+          await this.runtimeExecutor.triggerPersistedUserMessage(sessionId, latestUserMessage);
+        }
+        return result;
+      }
       if (action === 'kill') {
         await this.runtimeExecutor.applySessionAction(sessionId, 'abort');
         return this.delegate.applySessionAction(sessionId, action, chatId);

--- a/services/aris-backend/src/types.ts
+++ b/services/aris-backend/src/types.ts
@@ -62,4 +62,5 @@ export type PermissionRequest = {
   risk: PermissionRisk;
   requestedAt: string;
   state: PermissionState;
+  decision?: PermissionDecision | null;
 };

--- a/services/aris-backend/tests/happyClient.streamJson.test.ts
+++ b/services/aris-backend/tests/happyClient.streamJson.test.ts
@@ -529,4 +529,49 @@ registry/controller를 ClaudeSession 중심으로 재편`);
     expect(fetchMock).toHaveBeenCalledTimes(3);
     vi.useRealTimers();
   });
+
+  it('preserves pending codex permissions during shutdown drain cleanup', async () => {
+    const persistedPermission = {
+      id: 'perm-1',
+      sessionId: 'session-1',
+      chatId: 'chat-1',
+      agent: 'codex' as const,
+      command: 'curl -I https://example.com',
+      reason: 'network approval',
+      risk: 'medium' as const,
+      state: 'pending' as const,
+      requestedAt: '2026-04-14T00:00:00.000Z',
+    };
+    const coordinationStore = {
+      decidePermission: vi.fn(),
+    };
+    const store = new HappyRuntimeStore({
+      serverUrl: 'http://runtime.test',
+      token: 'token',
+      workspaceRoot: '/workspace',
+      coordinationStore: coordinationStore as never,
+    }) as unknown as {
+      permissions: Map<string, typeof persistedPermission>;
+      codexPermissionIndex: Map<string, string>;
+      codexPermissionResponders: Map<string, (decision: 'allow_once' | 'allow_session' | 'deny') => Promise<void>>;
+      draining: boolean;
+    };
+
+    store.permissions.set('perm-1', persistedPermission);
+    store.codexPermissionIndex.set('chat-1:session-1:perm-1', 'perm-1');
+    store.codexPermissionResponders.set('perm-1', vi.fn());
+    store.draining = true;
+
+    await happyClientTestHooks.finalizeCodexRuntimePermissions(store as never, ['perm-1'], {
+      preservePending: true,
+    });
+
+    expect(coordinationStore.decidePermission).not.toHaveBeenCalled();
+    expect(store.permissions.get('perm-1')).toMatchObject({
+      id: 'perm-1',
+      state: 'pending',
+    });
+    expect(store.codexPermissionIndex.size).toBe(0);
+    expect(store.codexPermissionResponders.size).toBe(0);
+  });
 });

--- a/services/aris-backend/tests/happyClient.streamJson.test.ts
+++ b/services/aris-backend/tests/happyClient.streamJson.test.ts
@@ -395,6 +395,40 @@ registry/controller를 ClaudeSession 중심으로 재편`);
     expect(parsed.output).toBe('Gemini 응답 완료');
   });
 
+  it('spawns codex app-server in its own detached process group', () => {
+    const options = happyClientTestHooks.buildCodexAppServerSpawnOptions({
+      cwd: '/tmp/aris-redeploy-stream-fix',
+      env: { PATH: '/usr/bin' },
+      signal: undefined,
+    });
+
+    expect(options).toMatchObject({
+      cwd: '/tmp/aris-redeploy-stream-fix',
+      detached: true,
+      stdio: 'pipe',
+      env: { PATH: '/usr/bin' },
+    });
+  });
+
+  it('kills the detached codex app-server process group when closing', () => {
+    const killMock = vi.fn();
+
+    happyClientTestHooks.terminateCodexAppServerProcess(
+      {
+        pid: 4321,
+        killed: false,
+        kill: vi.fn(),
+      },
+      killMock,
+    );
+
+    expect(killMock).toHaveBeenCalledWith(-4321, 'SIGTERM');
+  });
+
+  it('uses a loopback websocket transport URL for codex app-server', () => {
+    expect(happyClientTestHooks.buildCodexAppServerListenUrl(38991)).toBe('ws://127.0.0.1:38991');
+  });
+
   it('waits for a quiet window after the latest app-server activity', async () => {
     vi.useFakeTimers();
 

--- a/services/aris-backend/tests/runtimeCoordination.test.ts
+++ b/services/aris-backend/tests/runtimeCoordination.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PrismaRuntimeStore } from '../src/runtime/prismaStore.js';
+
+function buildStoreWithMockDb(db: Record<string, unknown>): PrismaRuntimeStore {
+  const store = Object.create(PrismaRuntimeStore.prototype) as PrismaRuntimeStore & {
+    db: Record<string, unknown>;
+  };
+  store.db = db;
+  return store;
+}
+
+describe('PrismaRuntimeStore runtime coordination', () => {
+  it('loads a persisted permission by id', async () => {
+    const permission = {
+      id: 'perm-1',
+      sessionId: 'session-1',
+      chatId: 'chat-1',
+      agent: 'codex',
+      command: 'npm test',
+      reason: 'Need approval',
+      risk: 'medium',
+      state: 'approved',
+      requestedAt: new Date('2026-04-14T12:00:00.000Z'),
+      decidedAt: new Date('2026-04-14T12:01:00.000Z'),
+    };
+    const db = {
+      permission: {
+        findUnique: vi.fn().mockResolvedValue(permission),
+      },
+    };
+    const store = buildStoreWithMockDb(db) as PrismaRuntimeStore & {
+      getPermissionById: (permissionId: string) => Promise<{ state: string } | null>;
+    };
+
+    await expect(store.getPermissionById('perm-1')).resolves.toMatchObject({
+      state: 'approved',
+    });
+    expect(db.permission.findUnique).toHaveBeenCalledWith({
+      where: { id: 'perm-1' },
+    });
+  });
+
+  it('detects a persisted abort action scoped to a chat', async () => {
+    const db = {
+      sessionMessage: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: 'message-1',
+          meta: {
+            action: 'abort',
+            chatId: 'chat-1',
+          },
+        }),
+      },
+    };
+    const store = buildStoreWithMockDb(db) as PrismaRuntimeStore & {
+      hasRequestedAction: (input: {
+        sessionId: string;
+        action: 'abort' | 'retry' | 'resume' | 'kill';
+        chatId?: string;
+        createdAfter?: Date;
+      }) => Promise<boolean>;
+    };
+    const startedAt = new Date('2026-04-14T12:00:00.000Z');
+
+    await expect(store.hasRequestedAction({
+      sessionId: 'session-1',
+      action: 'abort',
+      chatId: 'chat-1',
+      createdAfter: startedAt,
+    })).resolves.toBe(true);
+
+    expect(db.sessionMessage.findFirst).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        sessionId: 'session-1',
+        createdAt: { gt: startedAt },
+      }),
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, meta: true },
+    });
+  });
+});

--- a/services/aris-backend/tests/store.test.ts
+++ b/services/aris-backend/tests/store.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RuntimeStore } from '../src/store.js';
+
+function buildRuntimeStore(input: {
+  delegate: Record<string, unknown>;
+  runtimeExecutor?: Record<string, unknown> | null;
+}) {
+  const store = Object.create(RuntimeStore.prototype) as RuntimeStore & {
+    delegate: Record<string, unknown>;
+    runtimeExecutor: Record<string, unknown> | null;
+  };
+  store.delegate = input.delegate;
+  store.runtimeExecutor = input.runtimeExecutor ?? null;
+  return store;
+}
+
+describe('RuntimeStore.isSessionRunning', () => {
+  it('falls back to persisted state when the in-memory executor lost the active run', async () => {
+    const delegate = {
+      isSessionRunning: vi.fn().mockResolvedValue(true),
+    };
+    const runtimeExecutor = {
+      isSessionRunning: vi.fn().mockResolvedValue(false),
+    };
+    const store = buildRuntimeStore({ delegate, runtimeExecutor });
+
+    await expect(store.isSessionRunning('session-1', 'chat-1')).resolves.toBe(true);
+    expect(runtimeExecutor.isSessionRunning).toHaveBeenCalledWith('session-1', 'chat-1');
+    expect(delegate.isSessionRunning).toHaveBeenCalledWith('session-1', 'chat-1');
+  });
+});

--- a/services/aris-backend/tests/store.test.ts
+++ b/services/aris-backend/tests/store.test.ts
@@ -29,3 +29,50 @@ describe('RuntimeStore.isSessionRunning', () => {
     expect(delegate.isSessionRunning).toHaveBeenCalledWith('session-1', 'chat-1');
   });
 });
+
+describe('RuntimeStore.applySessionAction', () => {
+  it('replays the latest persisted chat user message when retry is requested', async () => {
+    const delegate = {
+      applySessionAction: vi.fn().mockResolvedValue({
+        accepted: true,
+        message: 'RETRY acknowledged',
+        at: '2026-04-14T00:00:00.000Z',
+      }),
+      getLatestUserMessageForAction: vi.fn().mockResolvedValue({
+        type: 'message',
+        title: 'User Instruction',
+        text: 'please continue',
+        meta: {
+          role: 'user',
+          chatId: 'chat-1',
+          agent: 'codex',
+        },
+      }),
+    };
+    const runtimeExecutor = {
+      applySessionAction: vi.fn().mockResolvedValue({
+        accepted: true,
+        message: 'RETRY acknowledged',
+        at: '2026-04-14T00:00:00.000Z',
+      }),
+      triggerPersistedUserMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    const store = buildRuntimeStore({ delegate, runtimeExecutor });
+
+    await expect(store.applySessionAction('session-1', 'retry', 'chat-1')).resolves.toMatchObject({
+      accepted: true,
+    });
+
+    expect(delegate.getLatestUserMessageForAction).toHaveBeenCalledWith('session-1', 'chat-1');
+    expect(runtimeExecutor.triggerPersistedUserMessage).toHaveBeenCalledWith('session-1', {
+      type: 'message',
+      title: 'User Instruction',
+      text: 'please continue',
+      meta: {
+        role: 'user',
+        chatId: 'chat-1',
+        agent: 'codex',
+      },
+    });
+  });
+});

--- a/services/aris-backend/tests/store.test.ts
+++ b/services/aris-backend/tests/store.test.ts
@@ -76,3 +76,83 @@ describe('RuntimeStore.applySessionAction', () => {
     });
   });
 });
+
+describe('RuntimeStore.decidePermission', () => {
+  it('replays the latest persisted user message when approval is granted after the active run is gone', async () => {
+    const delegate = {
+      getLatestUserMessageForAction: vi.fn().mockResolvedValue({
+        type: 'message',
+        title: 'User Instruction',
+        text: 'retry the network request',
+        meta: {
+          role: 'user',
+          chatId: 'chat-1',
+          agent: 'codex',
+        },
+      }),
+    };
+    const runtimeExecutor = {
+      decidePermission: vi.fn().mockResolvedValue({
+        id: 'perm-1',
+        sessionId: 'session-1',
+        chatId: 'chat-1',
+        agent: 'codex',
+        command: 'curl -I https://example.com',
+        reason: 'network approval',
+        risk: 'medium',
+        state: 'approved',
+        decision: 'allow_once',
+        requestedAt: '2026-04-14T00:00:00.000Z',
+      }),
+      isSessionRunning: vi.fn().mockResolvedValue(false),
+      triggerPersistedUserMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    const store = buildRuntimeStore({ delegate, runtimeExecutor });
+
+    await expect(store.decidePermission('perm-1', 'allow_once')).resolves.toMatchObject({
+      id: 'perm-1',
+      state: 'approved',
+    });
+
+    expect(runtimeExecutor.isSessionRunning).toHaveBeenCalledWith('session-1', 'chat-1');
+    expect(delegate.getLatestUserMessageForAction).toHaveBeenCalledWith('session-1', 'chat-1');
+    expect(runtimeExecutor.triggerPersistedUserMessage).toHaveBeenCalledWith('session-1', {
+      type: 'message',
+      title: 'User Instruction',
+      text: 'retry the network request',
+      meta: {
+        role: 'user',
+        chatId: 'chat-1',
+        agent: 'codex',
+      },
+    });
+  });
+
+  it('does not replay a user message when the approved run is still active in memory', async () => {
+    const delegate = {
+      getLatestUserMessageForAction: vi.fn(),
+    };
+    const runtimeExecutor = {
+      decidePermission: vi.fn().mockResolvedValue({
+        id: 'perm-1',
+        sessionId: 'session-1',
+        chatId: 'chat-1',
+        agent: 'codex',
+        command: 'curl -I https://example.com',
+        reason: 'network approval',
+        risk: 'medium',
+        state: 'approved',
+        decision: 'allow_once',
+        requestedAt: '2026-04-14T00:00:00.000Z',
+      }),
+      isSessionRunning: vi.fn().mockResolvedValue(true),
+      triggerPersistedUserMessage: vi.fn(),
+    };
+    const store = buildRuntimeStore({ delegate, runtimeExecutor });
+
+    await store.decidePermission('perm-1', 'allow_once');
+
+    expect(delegate.getLatestUserMessageForAction).not.toHaveBeenCalled();
+    expect(runtimeExecutor.triggerPersistedUserMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 요약

백엔드 PM2 재배포 중 진행 중이던 Codex/Claude/Gemini 채팅 런타임이 끊기던 문제를 정리한 PR입니다.

이번 브랜치에서는 단순히 SSE 응답만 이어지게 한 수준이 아니라, 재배포 중에도 아래 제어가 끊기지 않도록 런타임 제어 평면을 보강했습니다.

- pending permission 승인/거절
- abort
- retry / resume replay
- Codex `app-server` 기반 turn 연속성

특히 후속 이슈인 `#202`의 원인으로 드러난 `codex app-server fallback` 문제까지 포함해, 최종적으로는 재배포 중 old worker가 들고 있던 Codex turn이 끊기지 않고 끝까지 이어지도록 수정했습니다.

Closes #202

## 문제 배경

재배포 전 구조에서는 다음 상태가 백엔드 프로세스 메모리에 강하게 묶여 있었습니다.

- `activeRuns`
- Codex permission responder
- `isRunning` 판별 일부
- `codex app-server` child process lifecycle

그래서 PM2 reload 시 새 백엔드는 뜨더라도 old backend가 내려가는 과정에서 진행 중 turn이 끊기거나, pending permission 승인 이후 old turn으로 결정을 전달하지 못하는 문제가 있었습니다.

추가 조사 과정에서 `codex app-server`도 old backend의 자식으로 떠 있었기 때문에 reload 중 old backend가 살아 있는 동안에도 자식 app-server가 먼저 종료되고, 그 결과 `exec` fallback으로 떨어지는 현상까지 확인했습니다.

## 이번 변경

### 1. 재배포 중 런타임 제어를 DB 기준으로 유지

- `Permission`에 실제 결정값을 보존하는 `decision` 컬럼 추가
- in-memory responder가 사라져도 persisted decision을 polling해서 old run이 승인/거절을 계속 반영하도록 변경
- `isRunning` 판단을 메모리 단독이 아니라 persisted run 상태와 함께 계산하도록 보강
- shutdown 시 pending permission을 자동 deny 하지 않고 drain 동안 유지하도록 수정

관련 파일:

- `services/aris-backend/prisma/schema.prisma`
- `services/aris-backend/prisma/migrations/0003_permission_decision/migration.sql`
- `services/aris-backend/src/runtime/prismaStore.ts`
- `services/aris-backend/src/store.ts`
- `services/aris-backend/src/index.ts`
- `deploy/ecosystem.config.cjs`

### 2. retry / resume / abort 제어 연속성 보강

- 재배포 후 새 인스턴스가 받은 retry / resume 요청을 최신 persisted user prompt 기준으로 다시 실행
- abort도 DB coordination을 통해 old run에 전달되도록 polling 경로 보강
- drain / runtime continuity 검증 절차를 runbook과 deploy 문서에 반영

관련 파일:

- `services/aris-backend/src/store.ts`
- `deploy/README.md`
- `deploy/ops/debug-runbook.md`
- `services/aris-backend/tests/runtimeCoordination.test.ts`
- `services/aris-backend/tests/store.test.ts`

### 3. `codex app-server fallback` 제거

이슈 `#202`의 직접 원인은 reload 중 `codex app-server` child가 old backend보다 먼저 내려가는 점이었습니다.

이를 해결하기 위해 Codex app-server 실행 방식을 다음처럼 바꿨습니다.

- backend가 직접 stdio child를 오래 붙들지 않음
- 짧은 launcher가 detached `codex app-server`를 별도 프로세스 그룹으로 기동
- backend는 `ws://127.0.0.1:<ephemeral-port>` loopback websocket transport로 app-server에 연결
- 종료 시에는 websocket 종료 + pid 기반 process group kill로 정리

이 구조로 바뀌면서 reload 이후에도 `codex app-server`가 `PPID=1` 상태로 backend와 분리되어 유지되고, 새 backend에서 permission 결정을 받아 old run이 그대로 이어질 수 있게 됐습니다.

관련 파일:

- `services/aris-backend/src/runtime/happyClient.ts`
- `services/aris-backend/tests/happyClient.streamJson.test.ts`

## 운영 검증

2026-04-14 실제 운영 환경에서 아래 시나리오를 검증했습니다.

1. pending permission 상태에서 backend zero-downtime reload
2. reload 직후 새 인스턴스에서 permission `allow_once`
3. 기존 turn이 이어져 최종 응답 `permission-drain-ok` 도달

추가로 abort 시나리오도 검증했습니다.

1. 장시간 실행 turn 중 reload
2. 새 인스턴스에서 abort
3. 세션이 `run status: aborted`로 종료되고 금지한 최종 문구는 출력되지 않음

마지막으로 `#202` 대응 검증도 운영에서 다시 수행했습니다.

1. pending permission 상태의 Codex app-server turn 생성
2. reload 중 old backend / app-server pid 추적
3. `app-server`가 `PPID=1` 상태로 reload 후에도 유지되는 것 확인
4. 새 backend에서 `allow_once`
5. 같은 turn이 이어져 최종 응답 `app-server-detached-ok` 및 `run status: completed` 확인

## 검증 명령

```bash
cd services/aris-backend
npm run typecheck
npm run build
npm test -- prismaRuntimeStore.test.ts runtimeCoordination.test.ts store.test.ts server.test.ts happyClient.streamJson.test.ts
```

## 배포 메모

- backend deploy는 공식 스크립트 `deploy/deploy_backend_zero_downtime.sh`로 수행해 운영 검증까지 마쳤습니다.
- `Permission.decision` 컬럼이 필요하므로 운영 반영 시 migration 적용이 선행되어야 합니다.
