### PR TITLE
fix: stabilize new chat composer width

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -1,7 +1,7 @@
 .chatShell {
   --composer-dock-height: 98px;
   --composer-dock-left: 0.75rem;
-  --composer-dock-width: calc(100vw - 1.5rem);
+  --composer-dock-width: calc(100vw - 1.75rem);
   --center-header-height: 60px;
   --global-header-offset-effective: var(--global-header-offset, 64px);
   --safe-area-bottom-effective: max(0px, calc(env(safe-area-inset-bottom) - var(--keyboard-inset-height, 0px)));
@@ -257,6 +257,23 @@
 
 .chatShellSidebarClosed {
   grid-template-columns: 0 minmax(0, 1fr) 320px;
+}
+
+@media (min-width: 961px) {
+  .chatShell {
+    --composer-dock-left: calc(280px + 1.25rem);
+    --composer-dock-width: max(240px, calc(100vw - 280px - 320px - 2.5rem));
+  }
+
+  .chatShellSidebarClosed {
+    --composer-dock-left: 0.75rem;
+    --composer-dock-width: max(240px, calc(100vw - 320px - 1.5rem));
+  }
+
+  .chatShellLeftOverlay {
+    --composer-dock-left: 0.75rem;
+    --composer-dock-width: calc(100vw - 1.75rem);
+  }
 }
 
 .chatShellRightPinned {

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import type { ChangeEvent, ReactNode } from 'react';
 import { useSessionEvents } from '@/lib/hooks/useSessionEvents';
@@ -4666,6 +4666,18 @@ export function ChatInterface({
   useEffect(() => {
     resizeComposerInput();
   }, [prompt, resizeComposerInput]);
+
+  useLayoutEffect(() => {
+    syncComposerDockMetrics();
+  }, [
+    activeChatIdResolved,
+    isChatSidebarOpen,
+    isLeftSidebarOverlayLayout,
+    isNewChatPlaceholder,
+    isRightSidebarPinnedLayout,
+    isWorkspaceHome,
+    syncComposerDockMetrics,
+  ]);
 
   useEffect(() => {
     syncComposerDockMetrics();

--- a/services/aris-web/tests/chatComposerDockLayout.test.ts
+++ b/services/aris-web/tests/chatComposerDockLayout.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const chatInterfaceTsxPath = resolve(__dirname, '../app/sessions/[sessionId]/ChatInterface.tsx');
+const chatInterfaceCssPath = resolve(__dirname, '../app/sessions/[sessionId]/ChatInterface.module.css');
+
+const chatInterfaceTsx = readFileSync(chatInterfaceTsxPath, 'utf8');
+const chatInterfaceCss = readFileSync(chatInterfaceCssPath, 'utf8');
+
+describe('chat composer dock desktop layout guards', () => {
+  it('syncs composer dock metrics before paint so new chats do not flash into the sidebar lane', () => {
+    expect(chatInterfaceTsx).toMatch(/useLayoutEffect/);
+    expect(chatInterfaceTsx).toMatch(/useLayoutEffect\(\(\) => \{\s*syncComposerDockMetrics\(\);/s);
+  });
+
+  it('uses a desktop-safe default dock width instead of expanding across the full viewport', () => {
+    expect(chatInterfaceCss).not.toContain('--composer-dock-width: calc(100vw - 1.5rem);');
+  });
+});


### PR DESCRIPTION
## Summary
- 데스크톱에서 새 채팅 초기 상태일 때 입력창이 좌측 채팅 목록까지 확장되던 레이아웃 버그를 수정했습니다.
- `useLayoutEffect`로 composer dock 폭/위치를 초기 페인트 전에 동기화하도록 바꿨습니다.
- 데스크톱 안전 기본 폭과 회귀 테스트(`chatComposerDockLayout.test.ts`)를 추가했습니다.

## Test Plan
- npm test -- mobileOverflowLayout.test.ts chatComposer.test.ts chatComposerDockLayout.test.ts
