### PR TITLE
fix: preserve mobile bottom lock during entry restore

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -63,6 +63,7 @@ import {
   hasTailRestoreRenderHydrated,
   isNearBottom,
   isNearWindowBottom,
+  resolveMobileBottomLockState,
   type SessionScrollPhase,
   shouldAutoScrollToBottom,
   shouldBlockLoadOlder,
@@ -1809,9 +1810,12 @@ export function ChatInterface({
       if (sessionScrollPhaseRef.current === 'resuming' || sessionScrollPhaseRef.current === 'viewport-reflow') {
         return;
       }
-      const nearBottom = isNearWindowBottom();
-      shouldStickToBottomRef.current = nearBottom;
-      setShowScrollToBottom(!nearBottom);
+      const nextState = resolveMobileBottomLockState({
+        isNearBottom: isNearWindowBottom(),
+        isTailRestorePending: isChatEntryTailRestorePending,
+      });
+      shouldStickToBottomRef.current = nextState.shouldStickToBottom;
+      setShowScrollToBottom(nextState.showScrollToBottom);
     };
 
     const rafId = window.requestAnimationFrame(updateStickState);
@@ -1825,7 +1829,13 @@ export function ChatInterface({
       window.visualViewport?.removeEventListener('scroll', updateStickState);
       window.visualViewport?.removeEventListener('resize', updateStickState);
     };
-  }, [isMobileLayout, setShowScrollToBottom, shouldStickToBottomRef, syncScrollToBottomButton]);
+  }, [
+    isChatEntryTailRestorePending,
+    isMobileLayout,
+    setShowScrollToBottom,
+    shouldStickToBottomRef,
+    syncScrollToBottomButton,
+  ]);
 
   useEffect(() => {
     if (!isMobileLayout) {

--- a/services/aris-web/app/sessions/[sessionId]/chatScroll.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chatScroll.ts
@@ -48,6 +48,11 @@ type AutoScrollToBottomInput = {
   isTailRestorePending?: boolean;
 };
 
+type MobileBottomLockStateInput = {
+  isNearBottom: boolean;
+  isTailRestorePending?: boolean;
+};
+
 type RestoreTailScrollOnChatEntryInput = {
   activeChatId: string | null;
   eventsForChatId: string | null;
@@ -154,6 +159,23 @@ export function shouldAutoScrollToBottom(input: AutoScrollToBottomInput): boolea
     return false;
   }
   return input.shouldStickToBottom;
+}
+
+export function resolveMobileBottomLockState(input: MobileBottomLockStateInput): {
+  shouldStickToBottom: boolean;
+  showScrollToBottom: boolean;
+} {
+  if (input.isTailRestorePending) {
+    return {
+      shouldStickToBottom: true,
+      showScrollToBottom: false,
+    };
+  }
+
+  return {
+    shouldStickToBottom: input.isNearBottom,
+    showScrollToBottom: !input.isNearBottom,
+  };
 }
 
 export function shouldRestoreTailScrollOnChatEntry(input: RestoreTailScrollOnChatEntryInput): boolean {

--- a/services/aris-web/tests/chatScroll.test.ts
+++ b/services/aris-web/tests/chatScroll.test.ts
@@ -11,6 +11,7 @@ import {
   shouldAutoScrollToBottom,
   shouldResetScrollForChatChange,
   shouldBlockLoadOlder,
+  resolveMobileBottomLockState,
   shouldUseManualScrollRestoration,
   shouldUseWindowScrollFallback,
 } from '@/app/sessions/[sessionId]/chatScroll';
@@ -222,6 +223,24 @@ describe('chatScroll', () => {
     expect(resolveMobileWindowScrollTop({ scrollHeight: 0, viewportHeight: 0 })).toBe(0);
     expect(resolveMobileWindowScrollTop({ scrollHeight: 1000, viewportHeight: 1000 })).toBe(0);
     expect(resolveMobileWindowScrollTop({ scrollHeight: 1001, viewportHeight: 1000 })).toBe(1);
+  });
+
+  it('keeps mobile bottom lock pinned while initial tail restore is still pending', () => {
+    expect(resolveMobileBottomLockState({
+      isNearBottom: false,
+      isTailRestorePending: true,
+    })).toEqual({
+      shouldStickToBottom: true,
+      showScrollToBottom: false,
+    });
+
+    expect(resolveMobileBottomLockState({
+      isNearBottom: false,
+      isTailRestorePending: false,
+    })).toEqual({
+      shouldStickToBottom: false,
+      showScrollToBottom: true,
+    });
   });
 
   describe('shouldBlockLoadOlder', () => {


### PR DESCRIPTION
## Summary
- 모바일 초기 채팅 진입 중에는 `shouldStickToBottom`이 내려가지 않도록 bottom lock 상태를 별도 helper로 고정했습니다.
- entry tail restore가 끝나기 전에 viewport/window scroll 이벤트가 stickiness를 해제해 버리던 경로를 막았습니다.
- `chatScroll` 회귀 테스트에 모바일 bottom lock 유지 케이스를 추가했습니다.

## Test Plan
- `cd services/aris-web && npm test -- chatScroll`
- `cd services/aris-web && npm test -- chatTailRestoreSettle`
- `cd services/aris-web && npm test -- mobileOverflowLayout`
- `cd services/aris-web && npm run build`
