### PR TITLE
fix: keep chat entry restore pinned through mobile layout reflow

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -59,11 +59,14 @@ import { RightPaneLayout } from './chat-screen/right-pane/RightPaneLayout';
 import styles from './ChatInterface.module.css';
 import { shouldShowChatTransitionLoading } from './chatSelection';
 import {
+  haveComposerDockMetricsChanged,
   hasResumePhaseSettled,
   hasTailRestoreRenderHydrated,
   isNearBottom,
   isNearWindowBottom,
+  resolveTailRestoreLayoutReady,
   resolveMobileBottomLockState,
+  type ComposerDockMetrics,
   type SessionScrollPhase,
   shouldAutoScrollToBottom,
   shouldBlockLoadOlder,
@@ -315,6 +318,7 @@ export function ChatInterface({
     isMobileLayout,
     isMobileLayoutHydrated,
     isMounted,
+    isViewportLayoutReady,
     setChatIdCopyState,
     setExpandedActionRunIds,
     setExpandedResultIds,
@@ -394,6 +398,8 @@ export function ChatInterface({
   const composerDockRef = useRef<HTMLElement>(null);
   const composerInputRef = useRef<HTMLTextAreaElement>(null);
   const composerImageInputRef = useRef<HTMLInputElement>(null);
+  const composerDockMetricsRef = useRef<ComposerDockMetrics | null>(null);
+  const composerDockLayoutReadyTimeoutRef = useRef(0);
   const contextItemsRef = useRef<ContextItem[]>([]);
   const isSubmittingRef = useRef(false);
   const plusMenuRef = useRef<HTMLDivElement>(null);
@@ -408,6 +414,7 @@ export function ChatInterface({
   const runtimeStartedSinceAwaitingRef = useRef(false);
   const sidebarFileRequestNonceRef = useRef(0);
   const userMessageBubbleNodesRef = useRef(new Map<string, HTMLDivElement>());
+  const [isComposerDockLayoutReady, setIsComposerDockLayoutReady] = useState(false);
   const [lastUserMessageJumpTarget, setLastUserMessageJumpTarget] = useState<LastUserMessageJumpTarget | null>(null);
   const handleDeleteEmptyAutoChat = useCallback(() => {
     if (!activeChat) {
@@ -645,6 +652,12 @@ export function ChatInterface({
       streamItems.length,
     ],
   );
+  const isTailRestoreLayoutReady = resolveTailRestoreLayoutReady({
+    isMobileLayout,
+    isMobileLayoutHydrated,
+    isViewportLayoutReady,
+    isComposerDockLayoutReady,
+  });
   const {
     isTailLayoutSettling,
     isTailLayoutSettlingRef,
@@ -663,7 +676,7 @@ export function ChatInterface({
     isNewChatPlaceholder,
     isWorkspaceHome,
     isMobileLayout,
-    isMobileLayoutHydrated,
+    isTailRestoreLayoutReady,
     initialShowChatEntryLoading,
     resetToLatestWindow,
     scrollRef,
@@ -690,6 +703,14 @@ export function ChatInterface({
   useEffect(() => {
     sessionScrollPhaseRef.current = sessionScrollPhase;
   }, [sessionScrollPhase]);
+
+  useEffect(() => {
+    return () => {
+      if (composerDockLayoutReadyTimeoutRef.current) {
+        window.clearTimeout(composerDockLayoutReadyTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const clearResumePhaseSettleLoop = useCallback(() => {
     if (resumeSettleRafRef.current) {
@@ -1405,20 +1426,41 @@ export function ChatInterface({
 
     const height = Math.ceil(dock.getBoundingClientRect().height);
     shell.style.setProperty('--composer-dock-height', `${height}px`);
+    let left = 0;
+    let nextWidth = 0;
+    if (centerPanel) {
+      const viewportWidth = window.innerWidth;
+      const rect = centerPanel.getBoundingClientRect();
+      const inset = viewportWidth <= 960 ? 10 : 12;
+      left = Math.max(inset, Math.round(rect.left) + inset);
+      const maxWidth = Math.max(240, viewportWidth - inset * 2);
+      nextWidth = Math.max(240, Math.min(maxWidth, Math.round(rect.width) - inset * 2));
+    }
+
+    const nextMetrics = {
+      height,
+      left,
+      width: nextWidth,
+    };
+    if (isMobileLayout && haveComposerDockMetricsChanged(composerDockMetricsRef.current, nextMetrics)) {
+      composerDockMetricsRef.current = nextMetrics;
+      if (composerDockLayoutReadyTimeoutRef.current) {
+        window.clearTimeout(composerDockLayoutReadyTimeoutRef.current);
+      }
+      setIsComposerDockLayoutReady(false);
+      composerDockLayoutReadyTimeoutRef.current = window.setTimeout(() => {
+        composerDockLayoutReadyTimeoutRef.current = 0;
+        setIsComposerDockLayoutReady(true);
+      }, 160);
+    }
 
     if (!centerPanel) {
       return;
     }
 
-    const viewportWidth = window.innerWidth;
-    const rect = centerPanel.getBoundingClientRect();
-    const inset = viewportWidth <= 960 ? 10 : 12;
-    const left = Math.max(inset, Math.round(rect.left) + inset);
-    const maxWidth = Math.max(240, viewportWidth - inset * 2);
-    const nextWidth = Math.max(240, Math.min(maxWidth, Math.round(rect.width) - inset * 2));
     shell.style.setProperty('--composer-dock-left', `${left}px`);
     shell.style.setProperty('--composer-dock-width', `${nextWidth}px`);
-  }, []);
+  }, [isMobileLayout]);
 
   const resizeComposerInput = useCallback(() => {
     const input = composerInputRef.current;

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/hooks/useChatLayoutState.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/hooks/useChatLayoutState.ts
@@ -1,9 +1,12 @@
 import { useEffect, useState, type RefObject } from 'react';
+import { VIEWPORT_LAYOUT_CHANGE_EVENT } from '@/components/layout/ViewportHeightSync';
 import {
   CUSTOMIZATION_OVERLAY_MAX_WIDTH_PX,
   MOBILE_LAYOUT_MAX_WIDTH_PX,
   RIGHT_PIN_PREFERS_LEFT_OVERLAY_MIN_WIDTH_PX,
 } from '../constants';
+
+const VIEWPORT_LAYOUT_READY_IDLE_MS = 160;
 
 type UseChatLayoutStateParams = {
   centerHeaderRef: RefObject<HTMLElement | null>;
@@ -14,6 +17,7 @@ export function useChatLayoutState({
 }: UseChatLayoutStateParams) {
   const [isMobileLayout, setIsMobileLayout] = useState(false);
   const [isMobileLayoutHydrated, setIsMobileLayoutHydrated] = useState(false);
+  const [isViewportLayoutReady, setIsViewportLayoutReady] = useState(false);
   const [expandedResultIds, setExpandedResultIds] = useState<Record<string, boolean>>({});
   const [expandedActionRunIds, setExpandedActionRunIds] = useState<Record<string, boolean>>({});
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
@@ -32,6 +36,27 @@ export function useChatLayoutState({
 
   useEffect(() => {
     setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    let readyTimeoutId = 0;
+
+    const scheduleViewportLayoutReady = () => {
+      window.clearTimeout(readyTimeoutId);
+      setIsViewportLayoutReady(false);
+      readyTimeoutId = window.setTimeout(() => {
+        const hasViewportMeasurement = document.documentElement.style.getPropertyValue('--app-vh').trim().length > 0;
+        setIsViewportLayoutReady(hasViewportMeasurement);
+      }, VIEWPORT_LAYOUT_READY_IDLE_MS);
+    };
+
+    scheduleViewportLayoutReady();
+    window.addEventListener(VIEWPORT_LAYOUT_CHANGE_EVENT, scheduleViewportLayoutReady);
+
+    return () => {
+      window.clearTimeout(readyTimeoutId);
+      window.removeEventListener(VIEWPORT_LAYOUT_CHANGE_EVENT, scheduleViewportLayoutReady);
+    };
   }, []);
 
   useEffect(() => {
@@ -146,6 +171,7 @@ export function useChatLayoutState({
     isMobileLayout,
     isMobileLayoutHydrated,
     isMounted,
+    isViewportLayoutReady,
     setChatIdCopyState,
     setExpandedActionRunIds,
     setExpandedResultIds,

--- a/services/aris-web/app/sessions/[sessionId]/chatScroll.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chatScroll.ts
@@ -17,6 +17,8 @@ type TailLayoutSettledInput = {
   nextAnchorBottom: number | null;
   previousScrollHeight: number | null;
   nextScrollHeight: number | null;
+  previousViewportHeight: number | null;
+  nextViewportHeight: number | null;
   tolerancePx?: number;
 };
 
@@ -51,6 +53,19 @@ type AutoScrollToBottomInput = {
 type MobileBottomLockStateInput = {
   isNearBottom: boolean;
   isTailRestorePending?: boolean;
+};
+
+export type ComposerDockMetrics = {
+  height: number;
+  left: number;
+  width: number;
+};
+
+type TailRestoreLayoutReadinessInput = {
+  isMobileLayout: boolean;
+  isMobileLayoutHydrated: boolean;
+  isViewportLayoutReady: boolean;
+  isComposerDockLayoutReady: boolean;
 };
 
 type RestoreTailScrollOnChatEntryInput = {
@@ -109,13 +124,16 @@ export function hasTailLayoutSettled(input: TailLayoutSettledInput): boolean {
     || input.nextAnchorBottom === null
     || input.previousScrollHeight === null
     || input.nextScrollHeight === null
+    || input.previousViewportHeight === null
+    || input.nextViewportHeight === null
   ) {
     return false;
   }
 
   const tolerancePx = input.tolerancePx ?? 1;
   return Math.abs(input.nextAnchorBottom - input.previousAnchorBottom) <= tolerancePx
-    && Math.abs(input.nextScrollHeight - input.previousScrollHeight) <= tolerancePx;
+    && Math.abs(input.nextScrollHeight - input.previousScrollHeight) <= tolerancePx
+    && Math.abs(input.nextViewportHeight - input.previousViewportHeight) <= tolerancePx;
 }
 
 export function hasTailRestoreRenderHydrated(input: TailRestoreRenderHydratedInput): boolean {
@@ -139,6 +157,29 @@ export function hasResumePhaseSettled(input: ResumePhaseSettledInput): boolean {
   const tolerancePx = input.tolerancePx ?? 1;
   return Math.abs(input.nextScrollTop - input.previousScrollTop) <= tolerancePx
     && Math.abs(input.nextViewportHeight - input.previousViewportHeight) <= tolerancePx;
+}
+
+export function resolveTailRestoreLayoutReady(input: TailRestoreLayoutReadinessInput): boolean {
+  if (!input.isMobileLayout) {
+    return true;
+  }
+
+  return input.isMobileLayoutHydrated
+    && input.isViewportLayoutReady
+    && input.isComposerDockLayoutReady;
+}
+
+export function haveComposerDockMetricsChanged(
+  previousMetrics: ComposerDockMetrics | null,
+  nextMetrics: ComposerDockMetrics,
+): boolean {
+  if (!previousMetrics) {
+    return true;
+  }
+
+  return previousMetrics.height !== nextMetrics.height
+    || previousMetrics.left !== nextMetrics.left
+    || previousMetrics.width !== nextMetrics.width;
 }
 
 export function shouldResetScrollForChatChange(input: ResetScrollForChatChangeInput): boolean {

--- a/services/aris-web/app/sessions/[sessionId]/chatScroll.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chatScroll.ts
@@ -160,6 +160,10 @@ export function hasResumePhaseSettled(input: ResumePhaseSettledInput): boolean {
 }
 
 export function resolveTailRestoreLayoutReady(input: TailRestoreLayoutReadinessInput): boolean {
+  if (!input.isMobileLayoutHydrated) {
+    return false;
+  }
+
   if (!input.isMobileLayout) {
     return true;
   }

--- a/services/aris-web/app/sessions/[sessionId]/useChatTailRestore.ts
+++ b/services/aris-web/app/sessions/[sessionId]/useChatTailRestore.ts
@@ -23,6 +23,7 @@ import {
 import { recordScrollDebugEvent } from './scrollDebug';
 
 const TAIL_LAYOUT_SETTLE_TIMEOUT_MS = 1200;
+const TAIL_LAYOUT_SETTLE_IDLE_MS = 160;
 
 export type UseChatTailRestoreInput = {
   activeChatIdResolved: string | null;
@@ -36,7 +37,7 @@ export type UseChatTailRestoreInput = {
   isNewChatPlaceholder: boolean;
   isWorkspaceHome: boolean;
   isMobileLayout: boolean;
-  isMobileLayoutHydrated: boolean;
+  isTailRestoreLayoutReady: boolean;
   initialShowChatEntryLoading: boolean;
   resetToLatestWindow: () => Promise<void>;
   scrollRef: RefObject<HTMLDivElement | null>;
@@ -47,7 +48,7 @@ type ResolveTailRestoreSettleActionInput = {
   activeChatIdResolved: string | null;
   eventsForChatId: string | null;
   hasLoadedCurrentChat: boolean;
-  isMobileLayoutHydrated: boolean;
+  isTailRestoreLayoutReady: boolean;
   isSettleInFlight: boolean;
   isTailRestoreHydrated: boolean;
   isNewChatPlaceholder: boolean;
@@ -93,12 +94,12 @@ export async function jumpToLatestPageWindow(input: {
 export function resolveTailRestoreSettleAction(
   input: ResolveTailRestoreSettleActionInput,
 ): 'skip' | 'start' | 'continue' {
-  if (!input.isMobileLayoutHydrated) {
-    return 'skip';
-  }
-
   if (input.isSettleInFlight && input.restoredForChatId === input.activeChatIdResolved) {
     return 'continue';
+  }
+
+  if (!input.isTailRestoreLayoutReady) {
+    return 'skip';
   }
 
   if (shouldRestoreTailScrollOnChatEntry({
@@ -124,7 +125,7 @@ export function useChatTailRestore({
   isNewChatPlaceholder,
   isWorkspaceHome,
   isMobileLayout,
-  isMobileLayoutHydrated,
+  isTailRestoreLayoutReady,
   initialShowChatEntryLoading,
   resetToLatestWindow,
   scrollRef,
@@ -248,6 +249,7 @@ export function useChatTailRestore({
     return {
       anchorBottom: anchor ? anchor.getBoundingClientRect().bottom : null,
       scrollHeight: shouldUseWindow ? documentScrollHeight : (stream?.scrollHeight ?? null),
+      viewportHeight,
     };
   }, [isMobileLayout, latestVisibleEventIdRef, scrollRef]);
 
@@ -305,16 +307,12 @@ export function useChatTailRestore({
 
   // Tail-restore settle loop
   useEffect(() => {
-    if (!isMobileLayoutHydrated) {
-      return;
-    }
-
     const wasMidSettle = tailRestoreCancelRef.current !== null;
     const settleAction = resolveTailRestoreSettleAction({
       activeChatIdResolved,
       eventsForChatId,
       hasLoadedCurrentChat,
-      isMobileLayoutHydrated,
+      isTailRestoreLayoutReady,
       isSettleInFlight: wasMidSettle,
       isTailRestoreHydrated,
       isNewChatPlaceholder,
@@ -357,7 +355,7 @@ export function useChatTailRestore({
     let finished = false;
     let rafId = 0;
     let timeoutId = 0;
-    let stableFrameCount = 0;
+    let stableSinceAt = 0;
     let previousMetrics: ReturnType<typeof readTailLayoutMetrics> | null = null;
 
     const complete = () => {
@@ -422,13 +420,17 @@ export function useChatTailRestore({
         nextAnchorBottom: nextMetrics.anchorBottom,
         previousScrollHeight: previousMetrics.scrollHeight,
         nextScrollHeight: nextMetrics.scrollHeight,
+        previousViewportHeight: previousMetrics.viewportHeight,
+        nextViewportHeight: nextMetrics.viewportHeight,
       })) {
-        stableFrameCount += 1;
+        if (stableSinceAt === 0) {
+          stableSinceAt = window.performance.now();
+        }
       } else {
-        stableFrameCount = 0;
+        stableSinceAt = 0;
       }
       previousMetrics = nextMetrics;
-      if (stableFrameCount >= 2) {
+      if (stableSinceAt !== 0 && window.performance.now() - stableSinceAt >= TAIL_LAYOUT_SETTLE_IDLE_MS) {
         complete();
         return;
       }
@@ -443,7 +445,7 @@ export function useChatTailRestore({
     eventsForChatId,
     hasLoadedCurrentChat,
     isMobileLayout,
-    isMobileLayoutHydrated,
+    isTailRestoreLayoutReady,
     isTailRestoreHydrated,
     isNewChatPlaceholder,
     isWorkspaceHome,

--- a/services/aris-web/components/layout/ViewportHeightSync.tsx
+++ b/services/aris-web/components/layout/ViewportHeightSync.tsx
@@ -3,11 +3,19 @@
 import { useEffect } from 'react';
 import { dispatchSessionScrollPhaseEvent } from '@/app/sessions/[sessionId]/useSessionScrollOrchestrator';
 
+export const VIEWPORT_LAYOUT_CHANGE_EVENT = 'aris:viewport-layout-change';
+
 export function ViewportHeightSync() {
   useEffect(() => {
     const root = document.documentElement;
     let maxViewportHeight = window.visualViewport?.height ?? window.innerHeight;
     let lastInnerWidth = window.innerWidth;
+    let previousMetrics: {
+      appViewportHeight: number;
+      height: number;
+      keyboardInset: number;
+      viewportOffsetTop: number;
+    } | null = null;
 
     const updateViewportHeight = () => {
       // visualViewport.height는 iOS Safari 주소창 슬라이드 시 정확한 높이를 반환
@@ -33,7 +41,24 @@ export function ViewportHeightSync() {
       root.style.setProperty('--visual-viewport-offset-top', `${viewportOffsetTop}px`);
       root.style.setProperty('--keyboard-inset-height', `${keyboardInset}px`);
       root.dataset.keyboardOpen = keyboardOpen ? 'true' : 'false';
-      dispatchSessionScrollPhaseEvent('viewport-changed');
+      const nextMetrics = {
+        appViewportHeight,
+        height,
+        keyboardInset,
+        viewportOffsetTop,
+      };
+      const metricsChanged = previousMetrics === null
+        || previousMetrics.appViewportHeight !== nextMetrics.appViewportHeight
+        || previousMetrics.height !== nextMetrics.height
+        || previousMetrics.keyboardInset !== nextMetrics.keyboardInset
+        || previousMetrics.viewportOffsetTop !== nextMetrics.viewportOffsetTop;
+      if (metricsChanged) {
+        previousMetrics = nextMetrics;
+        dispatchSessionScrollPhaseEvent('viewport-changed');
+        window.dispatchEvent(new CustomEvent(VIEWPORT_LAYOUT_CHANGE_EVENT, {
+          detail: nextMetrics,
+        }));
+      }
     };
 
     updateViewportHeight();

--- a/services/aris-web/tests/chatComposerDockLayout.test.ts
+++ b/services/aris-web/tests/chatComposerDockLayout.test.ts
@@ -16,6 +16,13 @@ describe('chat composer dock desktop layout guards', () => {
     expect(chatInterfaceTsx).toMatch(/useLayoutEffect\(\(\) => \{\s*syncComposerDockMetrics\(\);/s);
   });
 
+  it('opens mobile tail restore only after composer layout metrics reach a quiet window', () => {
+    expect(chatInterfaceTsx).toContain('const isTailRestoreLayoutReady = resolveTailRestoreLayoutReady({');
+    expect(chatInterfaceTsx).toContain('isViewportLayoutReady');
+    expect(chatInterfaceTsx).toContain('haveComposerDockMetricsChanged(composerDockMetricsRef.current, nextMetrics)');
+    expect(chatInterfaceTsx).toMatch(/window\.setTimeout\(\(\) => \{\s*composerDockLayoutReadyTimeoutRef\.current = 0;\s*setIsComposerDockLayoutReady\(true\);/s);
+  });
+
   it('uses a desktop-safe default dock width instead of expanding across the full viewport', () => {
     expect(chatInterfaceCss).not.toContain('--composer-dock-width: calc(100vw - 1.5rem);');
   });

--- a/services/aris-web/tests/chatScroll.test.ts
+++ b/services/aris-web/tests/chatScroll.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  haveComposerDockMetricsChanged,
   hasResumePhaseSettled,
   hasTailRestoreRenderHydrated,
   hasTailLayoutSettled,
+  resolveTailRestoreLayoutReady,
   resolveSessionScrollPhase,
   resolveTailScrollAnchorId,
   resolveMobileWindowScrollTop,
@@ -39,6 +41,8 @@ describe('chatScroll', () => {
       nextAnchorBottom: 820.5,
       previousScrollHeight: 2400,
       nextScrollHeight: 2400.4,
+      previousViewportHeight: 712,
+      nextViewportHeight: 712.4,
     })).toBe(true);
 
     expect(hasTailLayoutSettled({
@@ -46,6 +50,8 @@ describe('chatScroll', () => {
       nextAnchorBottom: 820,
       previousScrollHeight: 2400,
       nextScrollHeight: 2400,
+      previousViewportHeight: 712,
+      nextViewportHeight: 712,
     })).toBe(false);
 
     expect(hasTailLayoutSettled({
@@ -53,6 +59,19 @@ describe('chatScroll', () => {
       nextAnchorBottom: 854,
       previousScrollHeight: 2400,
       nextScrollHeight: 2472,
+      previousViewportHeight: 712,
+      nextViewportHeight: 712,
+    })).toBe(false);
+  });
+
+  it('keeps the tail settle loop open while the mobile viewport height is still changing', () => {
+    expect(hasTailLayoutSettled({
+      previousAnchorBottom: 820,
+      nextAnchorBottom: 820,
+      previousScrollHeight: 2400,
+      nextScrollHeight: 2400,
+      previousViewportHeight: 712,
+      nextViewportHeight: 676,
     })).toBe(false);
   });
 
@@ -241,6 +260,60 @@ describe('chatScroll', () => {
       shouldStickToBottom: false,
       showScrollToBottom: true,
     });
+  });
+
+  it('waits for all mobile scroll-affecting layout inputs before marking tail restore layout ready', () => {
+    expect(resolveTailRestoreLayoutReady({
+      isMobileLayout: false,
+      isMobileLayoutHydrated: false,
+      isViewportLayoutReady: false,
+      isComposerDockLayoutReady: false,
+    })).toBe(true);
+
+    expect(resolveTailRestoreLayoutReady({
+      isMobileLayout: true,
+      isMobileLayoutHydrated: false,
+      isViewportLayoutReady: true,
+      isComposerDockLayoutReady: true,
+    })).toBe(false);
+
+    expect(resolveTailRestoreLayoutReady({
+      isMobileLayout: true,
+      isMobileLayoutHydrated: true,
+      isViewportLayoutReady: false,
+      isComposerDockLayoutReady: true,
+    })).toBe(false);
+
+    expect(resolveTailRestoreLayoutReady({
+      isMobileLayout: true,
+      isMobileLayoutHydrated: true,
+      isViewportLayoutReady: true,
+      isComposerDockLayoutReady: false,
+    })).toBe(false);
+
+    expect(resolveTailRestoreLayoutReady({
+      isMobileLayout: true,
+      isMobileLayoutHydrated: true,
+      isViewportLayoutReady: true,
+      isComposerDockLayoutReady: true,
+    })).toBe(true);
+  });
+
+  it('treats composer dock metrics as changed only when scroll-affecting geometry actually moves', () => {
+    expect(haveComposerDockMetricsChanged(
+      null,
+      { height: 98, left: 14, width: 402 },
+    )).toBe(true);
+
+    expect(haveComposerDockMetricsChanged(
+      { height: 98, left: 14, width: 402 },
+      { height: 98, left: 14, width: 402 },
+    )).toBe(false);
+
+    expect(haveComposerDockMetricsChanged(
+      { height: 98, left: 14, width: 402 },
+      { height: 112, left: 14, width: 402 },
+    )).toBe(true);
   });
 
   describe('shouldBlockLoadOlder', () => {

--- a/services/aris-web/tests/chatTailRestoreSettle.test.ts
+++ b/services/aris-web/tests/chatTailRestoreSettle.test.ts
@@ -12,24 +12,24 @@ const baseInput = {
 };
 
 describe('chat tail restore settle action', () => {
-  it('waits for the mobile layout decision before starting settle, then starts exactly once', () => {
+  it('waits for required layout measurements before starting settle, then starts exactly once', () => {
     expect(resolveTailRestoreSettleAction({
       ...baseInput,
-      isMobileLayoutHydrated: false,
+      isTailRestoreLayoutReady: false,
       isSettleInFlight: false,
       restoredForChatId: null,
     })).toBe('skip');
 
     expect(resolveTailRestoreSettleAction({
       ...baseInput,
-      isMobileLayoutHydrated: true,
+      isTailRestoreLayoutReady: true,
       isSettleInFlight: false,
       restoredForChatId: null,
     })).toBe('start');
 
     expect(resolveTailRestoreSettleAction({
       ...baseInput,
-      isMobileLayoutHydrated: true,
+      isTailRestoreLayoutReady: true,
       isSettleInFlight: false,
       restoredForChatId: 'chat-2',
     })).toBe('skip');
@@ -38,7 +38,16 @@ describe('chat tail restore settle action', () => {
   it('continues an in-flight settle for the same chat without qualifying as a new restore', () => {
     expect(resolveTailRestoreSettleAction({
       ...baseInput,
-      isMobileLayoutHydrated: true,
+      isTailRestoreLayoutReady: true,
+      isSettleInFlight: true,
+      restoredForChatId: 'chat-2',
+    })).toBe('continue');
+  });
+
+  it('continues an in-flight settle even when layout readiness temporarily drops again', () => {
+    expect(resolveTailRestoreSettleAction({
+      ...baseInput,
+      isTailRestoreLayoutReady: false,
       isSettleInFlight: true,
       restoredForChatId: 'chat-2',
     })).toBe('continue');


### PR DESCRIPTION
## Summary
- wait for viewport and composer dock layout inputs before opening chat entry tail restore on mobile
- keep tail restore settle running through temporary layout readiness drops and include viewport height in settle stability
- add regression tests for mobile layout readiness, composer dock geometry, and tail restore settle behavior

## Verification
- npm test -- chatScroll
- npm test -- chatTailRestoreSettle
- npm test -- mobileOverflowLayout
- npm run build
- npm test  # only the existing 6 failures tracked in #233 remain