### PR TITLE
fix: reserve jump bar layout during chat entry reveal

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -1597,7 +1597,7 @@ export function ChatInterface({
     runtimeStartedSinceAwaitingRef,
   });
   const syncLastUserMessageJumpTarget = useCallback(() => {
-    if (isWorkspaceHome || isNewChatPlaceholder || showChatTransitionLoading || userMessageJumpTargets.length === 0) {
+    if (isWorkspaceHome || isNewChatPlaceholder || userMessageJumpTargets.length === 0) {
       setLastUserMessageJumpTarget(null);
       return;
     }
@@ -1621,7 +1621,6 @@ export function ChatInterface({
     isNewChatPlaceholder,
     isWorkspaceHome,
     scrollRef,
-    showChatTransitionLoading,
     userMessageJumpTargets,
   ]);
 
@@ -2601,6 +2600,7 @@ export function ChatInterface({
             jumpBar={showLastUserMessageJumpBar ? (
               <LastUserMessageJumpBar
                 preview={lastUserMessageJumpTarget?.preview ?? ''}
+                showPendingReveal={showChatTransitionLoading}
                 onJump={handleLastUserMessageJump}
               />
             ) : null}

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/LastUserMessageJumpBar.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/LastUserMessageJumpBar.tsx
@@ -7,12 +7,14 @@ import styles from '../../ChatInterface.module.css';
 export function LastUserMessageJumpBar({
   preview,
   onJump,
+  showPendingReveal = false,
 }: {
   preview: string;
   onJump: () => void;
+  showPendingReveal?: boolean;
 }) {
   return (
-    <div className={styles.lastUserJumpBar}>
+    <div className={`${styles.lastUserJumpBar} ${showPendingReveal ? styles.chatEntryPendingReveal : ''}`}>
       <button type="button" className={styles.lastUserJumpButton} onClick={onJump}>
         <span className={styles.lastUserJumpLabel}>지난 사용자 메시지</span>
         <span className={styles.lastUserJumpPreview}>{preview}</span>

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/lastUserMessageBar.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/lastUserMessageBar.ts
@@ -61,7 +61,7 @@ export function shouldShowLastUserMessageJumpBar(input: ShouldShowLastUserMessag
   if (!input.targetEventId) {
     return false;
   }
-  if (input.isWorkspaceHome || input.isNewChatPlaceholder || input.showChatTransitionLoading) {
+  if (input.isWorkspaceHome || input.isNewChatPlaceholder) {
     return false;
   }
   return true;

--- a/services/aris-web/tests/chatEntryLoadingVisibility.test.ts
+++ b/services/aris-web/tests/chatEntryLoadingVisibility.test.ts
@@ -25,6 +25,11 @@ describe('chat entry loading visibility guards', () => {
     expect(chatInterfaceTsx).toContain('showPendingReveal={showChatTransitionLoading}');
   });
 
+  it('keeps last-user jump-bar layout reserved during entry loading', () => {
+    expect(chatInterfaceTsx).not.toContain('isWorkspaceHome || isNewChatPlaceholder || showChatTransitionLoading || userMessageJumpTargets.length === 0');
+    expect(chatInterfaceTsx).toMatch(/<LastUserMessageJumpBar[\s\S]*showPendingReveal=\{showChatTransitionLoading\}/);
+  });
+
   it('shows the scroll-to-bottom affordance only on the active chat timeline', () => {
     expect(chatCenterPaneTsx).toContain('!showChatTransitionLoading && activeChatIdResolved && !isWorkspaceHome && !isNewChatPlaceholder && showScrollToBottom');
   });

--- a/services/aris-web/tests/chatScroll.test.ts
+++ b/services/aris-web/tests/chatScroll.test.ts
@@ -268,6 +268,13 @@ describe('chatScroll', () => {
       isMobileLayoutHydrated: false,
       isViewportLayoutReady: false,
       isComposerDockLayoutReady: false,
+    })).toBe(false);
+
+    expect(resolveTailRestoreLayoutReady({
+      isMobileLayout: false,
+      isMobileLayoutHydrated: true,
+      isViewportLayoutReady: false,
+      isComposerDockLayoutReady: false,
     })).toBe(true);
 
     expect(resolveTailRestoreLayoutReady({

--- a/services/aris-web/tests/lastUserMessageBar.test.ts
+++ b/services/aris-web/tests/lastUserMessageBar.test.ts
@@ -151,12 +151,19 @@ describe('last user message jump bar', () => {
     })).toBeNull();
   });
 
-  it('shows the jump bar only while a passed target exists and the chat view is active', () => {
+  it('shows the jump bar whenever a passed target exists on the active chat view, even during entry loading', () => {
     expect(shouldShowLastUserMessageJumpBar({
       targetEventId: 'user-1',
       isWorkspaceHome: false,
       isNewChatPlaceholder: false,
       showChatTransitionLoading: false,
+    })).toBe(true);
+
+    expect(shouldShowLastUserMessageJumpBar({
+      targetEventId: 'user-1',
+      isWorkspaceHome: false,
+      isNewChatPlaceholder: false,
+      showChatTransitionLoading: true,
     })).toBe(true);
 
     expect(shouldShowLastUserMessageJumpBar({


### PR DESCRIPTION
## Summary
- reserve the last-user jump bar layout during chat entry loading so reveal does not add late vertical height
- keep the jump target computed during pending reveal, but render the bar hidden until the chat is revealed
- cover the behavior with loading visibility and jump-bar tests

## Verification
- npm test -- lastUserMessageBar
- npm test -- chatEntryLoadingVisibility
- npm test -- chatScroll
- npm test -- chatTailRestoreSettle
- npm test -- chatComposerDockLayout
- npm test -- mobileOverflowLayout
- npm test (same 6 pre-existing failures tracked in #233)
- npm run build
