### PR TITLE
Chat Screen Redesign: 전체 Phase 통합 구현

### DIFF
--- a/docs/design/composer-modes-spec.md
+++ b/docs/design/composer-modes-spec.md
@@ -1,0 +1,39 @@
+# Composer Modes Spec
+
+## Scope
+
+Chat Composer v2 supports three user-visible modes: Agent, Plan, and Terminal. The mode is part of the user intent and must be visible in UI state, optimistic timeline metadata, and server routing.
+
+## Agent Mode
+
+- Route: existing `POST /api/runtime/sessions/:sessionId/events`
+- Payload: normal user instruction plus model and agent metadata.
+- Behavior: unchanged runtime execution path.
+- Timeline: normal user bubble and agent response styling.
+
+## Plan Mode
+
+- Route: existing chat message route.
+- Payload metadata: `composerMode: "plan"`.
+- Prompt contract: the submitted text is prefixed with a plan-only instruction that tells the agent not to execute tools, shell commands, file writes, deploys, or destructive actions.
+- UI contract: user submission keeps the plan mode metadata, and follow-up visual treatment may display violet plan accents when the response metadata is available.
+- Failure fallback: if the backend does not understand `composerMode`, the prompt prefix is still sufficient to keep the response plan-only.
+
+## Terminal Mode
+
+- Route: `POST /api/runtime/sessions/:sessionId/terminal`
+- Payload:
+  - `chatId`: active chat id.
+  - `command`: raw command from the composer.
+  - `agent`: active chat agent for attribution.
+  - `model` and `modelReasoningEffort`: included for continuity metadata.
+- Behavior: execute the command in the session workspace path and append two events: a user command event and a `command_execution` result event.
+- Timeline: command output renders through the existing action/tool event renderer.
+- Permission rule: the route is operator-only. Additional dangerous-command approval can be layered on top of this contract without changing the composer API.
+- Failure fallback: non-zero exit codes are represented in the result event body; route-level failures return a JSON error and keep composer input available for retry.
+
+## Accessibility
+
+- Mode toggle uses `aria-pressed`.
+- Terminal snippets insert text into the composer without auto-submitting.
+- Mode color must not be the only state indicator; labels remain visible in every mode.

--- a/services/aris-web/app/api/runtime/sessions/[sessionId]/terminal/route.ts
+++ b/services/aris-web/app/api/runtime/sessions/[sessionId]/terminal/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { requireApiUser } from '@/lib/auth/guard';
+import { appendSessionMessage, HappyHttpError } from '@/lib/happy/client';
+import { getWorkspaceById } from '@/lib/happy/workspaces';
+
+const execAsync = promisify(exec);
+const MAX_OUTPUT_CHARS = 12000;
+
+function trimOutput(value: string): string {
+  if (value.length <= MAX_OUTPUT_CHARS) {
+    return value;
+  }
+  return `${value.slice(0, MAX_OUTPUT_CHARS)}\n\n[output truncated at ${MAX_OUTPUT_CHARS} chars]`;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const auth = await requireApiUser(request);
+  if ('response' in auth) {
+    return auth.response;
+  }
+  if (auth.user.role !== 'operator') {
+    return NextResponse.json({ error: 'Operator role required' }, { status: 403 });
+  }
+
+  const { sessionId } = await params;
+  const body = await request.json().catch(() => ({})) as {
+    chatId?: string;
+    command?: string;
+    agent?: string;
+    model?: string;
+    modelReasoningEffort?: string;
+  };
+  const command = typeof body.command === 'string' ? body.command.trim() : '';
+  const chatId = typeof body.chatId === 'string' ? body.chatId.trim() : '';
+  if (!command || !chatId) {
+    return NextResponse.json({ error: 'chatId and command are required' }, { status: 400 });
+  }
+
+  const workspace = await getWorkspaceById(auth.user.id, sessionId);
+  if (!workspace) {
+    return NextResponse.json({ error: 'WORKSPACE_NOT_FOUND' }, { status: 404 });
+  }
+
+  const startedAt = new Date().toISOString();
+  try {
+    const userEvent = await appendSessionMessage({
+      sessionId,
+      type: 'message',
+      title: 'Terminal Command',
+      text: command,
+      meta: {
+        role: 'user',
+        chatId,
+        agent: body.agent,
+        model: body.model,
+        modelReasoningEffort: body.modelReasoningEffort,
+        composerMode: 'terminal',
+      },
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let exitCode = 0;
+    try {
+      const result = await execAsync(command, {
+        cwd: workspace.path,
+        timeout: 30000,
+        maxBuffer: 1024 * 1024,
+        shell: '/bin/bash',
+      });
+      stdout = result.stdout;
+      stderr = result.stderr;
+    } catch (error) {
+      const err = error as Error & { stdout?: string; stderr?: string; code?: number };
+      stdout = err.stdout ?? '';
+      stderr = err.stderr ?? err.message;
+      exitCode = typeof err.code === 'number' ? err.code : 1;
+    }
+
+    const output = trimOutput([stdout, stderr].filter(Boolean).join('\n'));
+    const preview = output || '(no output)';
+    const resultEvent = await appendSessionMessage({
+      sessionId,
+      type: 'tool',
+      title: exitCode === 0 ? 'Terminal completed' : 'Terminal failed',
+      text: `$ ${command}\n${preview}`,
+      meta: {
+        role: 'agent',
+        chatId,
+        kind: 'command_execution',
+        composerMode: 'terminal',
+        startedAt,
+        completedAt: new Date().toISOString(),
+        exitCode,
+        command,
+      },
+    });
+
+    return NextResponse.json({ events: [userEvent, resultEvent] });
+  } catch (error) {
+    if (error instanceof HappyHttpError && [401, 403, 404].includes(error.status)) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    const message = error instanceof Error ? error.message : '터미널 명령 실행에 실패했습니다.';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -95,6 +95,953 @@
   overflow: hidden;
 }
 
+/* Chat redesign v1 overlay layer: token-driven visual alignment without touching the left sidebar. */
+.centerHeader {
+  min-height: 52px;
+  height: 52px;
+  padding: 0 var(--sp-5);
+  border-bottom: 1px solid var(--border-subtle);
+  background:
+    linear-gradient(120deg, color-mix(in srgb, var(--surface-raised) 94%, transparent), color-mix(in srgb, var(--surface-soft) 82%, transparent)),
+    radial-gradient(circle at 18% 0%, color-mix(in srgb, var(--mode-agent) 10%, transparent), transparent 42%);
+  backdrop-filter: blur(18px);
+}
+
+.headerTextAction {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  min-width: 0;
+  min-height: 32px;
+  padding: 0 var(--sp-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--surface) 86%, transparent);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  transition: border-color var(--motion-fast) var(--motion-ease), color var(--motion-fast) var(--motion-ease), background var(--motion-fast) var(--motion-ease);
+}
+
+.headerTextAction:hover,
+.headerTextAction[aria-pressed='true'] {
+  border-color: color-mix(in srgb, var(--mode-agent) 42%, transparent);
+  background: color-mix(in srgb, var(--mode-agent-soft) 74%, var(--surface) 26%);
+  color: var(--mode-agent-strong);
+}
+
+.stream {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-soft) 60%, transparent), transparent 38%),
+    radial-gradient(circle at 50% 0%, color-mix(in srgb, var(--mode-agent-soft) 44%, transparent), transparent 38%);
+}
+
+.timelineDayDivider {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  width: min(780px, calc(100% - var(--sp-6)));
+  max-width: 100%;
+  margin: var(--sp-6) auto var(--sp-4);
+  color: var(--text-faint);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.timelineDayDivider::before,
+.timelineDayDivider::after {
+  content: '';
+  flex: 1 1 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--border-subtle), transparent);
+}
+
+.timelineDayDivider span {
+  flex: 0 0 auto;
+  padding: var(--sp-1) var(--sp-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--surface-raised) 88%, transparent);
+}
+
+.inlineArtifactChip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  width: fit-content;
+  max-width: 100%;
+  margin-top: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid color-mix(in srgb, var(--mode-agent) 30%, transparent);
+  border-radius: var(--radius-pill);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--mode-agent-soft) 82%, var(--surface) 18%), var(--surface-raised));
+  color: var(--mode-agent-strong);
+  font-size: 0.78rem;
+  font-weight: 700;
+  box-shadow: var(--shadow-xs);
+}
+
+.inlineArtifactChip span {
+  min-width: 0;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inlineArtifactChip strong {
+  color: var(--text);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.messageBubbleHighlight {
+  animation: msgHighlightPulse 1.8s var(--motion-ease) 1;
+}
+
+@keyframes msgHighlightPulse {
+  0% {
+    transform: translateY(0) scale(1);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--mode-agent) 34%, transparent);
+  }
+  38% {
+    transform: translateY(-1px) scale(1.01);
+    box-shadow: 0 0 0 8px color-mix(in srgb, var(--mode-agent) 0%, transparent);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    box-shadow: var(--chat-msg-shadow);
+  }
+}
+
+.composerCard {
+  --composer-mode: var(--mode-agent);
+  --composer-mode-strong: var(--mode-agent-strong);
+  --composer-mode-soft: var(--mode-agent-soft);
+  border-color: color-mix(in srgb, var(--composer-mode) 26%, var(--border-subtle));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--composer-mode) 10%, transparent), var(--shadow-md);
+}
+
+.composerCard:focus-within {
+  border-color: color-mix(in srgb, var(--composer-mode) 54%, transparent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--composer-mode) 16%, transparent), var(--shadow-lg);
+}
+
+.composerCard[data-mode='plan'] {
+  --composer-mode: var(--mode-plan);
+  --composer-mode-strong: var(--mode-plan-strong);
+  --composer-mode-soft: var(--mode-plan-soft);
+}
+
+.composerCard[data-mode='terminal'] {
+  --composer-mode: var(--mode-terminal);
+  --composer-mode-strong: var(--mode-terminal-strong);
+  --composer-mode-soft: var(--mode-terminal-soft);
+}
+
+.composerModeToggle {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  padding: 3px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--surface-soft) 82%, transparent);
+}
+
+.composerModeButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  min-height: 28px;
+  padding: 0 var(--sp-3);
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.composerModeButtonActive {
+  background: var(--composer-mode-soft);
+  color: var(--composer-mode-strong);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--composer-mode) 24%, transparent);
+}
+
+.composerModeDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+  box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 12%, transparent);
+}
+
+.composerModeHint {
+  min-width: 0;
+  color: var(--text-faint);
+  font-size: 0.74rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.modelEffortChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-1);
+  padding: var(--sp-2) var(--sp-3) var(--sp-3);
+}
+
+.modelEffortChip {
+  min-height: 26px;
+  padding: 0 var(--sp-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.modelEffortChipActive {
+  border-color: color-mix(in srgb, var(--composer-mode) 42%, transparent);
+  background: var(--composer-mode-soft);
+  color: var(--composer-mode-strong);
+}
+
+.workspaceV2 {
+  display: flex;
+  flex-direction: column;
+  min-height: min(720px, calc(100vh - 120px));
+  max-width: 1120px;
+  width: min(100%, 1120px);
+  margin: 0 auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-2xl);
+  background:
+    linear-gradient(145deg, color-mix(in srgb, var(--surface-raised) 96%, transparent), color-mix(in srgb, var(--surface-soft) 92%, transparent)),
+    radial-gradient(circle at 14% 4%, color-mix(in srgb, var(--mode-terminal-soft) 55%, transparent), transparent 34%);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+.workspaceV2Header,
+.workspaceV2StatusStrip,
+.workspaceV2Tabs,
+.workspaceV2Footer {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.workspaceV2Header {
+  justify-content: space-between;
+  gap: var(--sp-3);
+  padding: var(--sp-4) var(--sp-5);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.workspaceV2TitleBlock {
+  min-width: 0;
+}
+
+.workspaceV2Eyebrow {
+  color: var(--text-faint);
+  font-size: 0.68rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.workspaceV2Title {
+  margin: 0;
+  color: var(--text);
+  font-size: 1.08rem;
+  font-weight: 850;
+  letter-spacing: -0.03em;
+}
+
+.workspaceV2Handle {
+  display: block;
+  width: 36px;
+  height: 4px;
+  margin: 0 auto var(--sp-3);
+  border-radius: 999px;
+  background: var(--border-strong);
+}
+
+.workspaceV2Actions {
+  display: inline-flex;
+  gap: var(--sp-2);
+}
+
+.workspaceV2IconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  color: var(--text-muted);
+}
+
+.workspaceV2StatusStrip {
+  gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-5);
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.workspaceV2StatusStrip strong {
+  color: var(--text);
+}
+
+.workspaceV2LiveDot,
+.workspaceV2IdleDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+}
+
+.workspaceV2LiveDot {
+  background: var(--mode-terminal);
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--mode-terminal) 16%, transparent);
+  animation: workspaceLivePulse 1.6s var(--motion-ease) infinite;
+}
+
+.workspaceV2IdleDot {
+  background: var(--text-faint);
+}
+
+@keyframes workspaceLivePulse {
+  50% {
+    transform: scale(1.28);
+  }
+}
+
+.workspaceV2Tabs {
+  gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-5);
+  border-bottom: 1px solid var(--border-subtle);
+  overflow-x: auto;
+}
+
+.workspaceV2Tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-height: 34px;
+  padding: 0 var(--sp-3);
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-weight: 850;
+  white-space: nowrap;
+}
+
+.workspaceV2TabActive {
+  border-color: color-mix(in srgb, var(--mode-agent) 34%, transparent);
+  background: color-mix(in srgb, var(--mode-agent-soft) 78%, var(--surface) 22%);
+  color: var(--mode-agent-strong);
+}
+
+.workspaceV2Body {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: var(--sp-5);
+  overflow: auto;
+}
+
+.workspaceV2RunGrid,
+.workspaceV2TerminalGrid,
+.workspaceV2ContextGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+  gap: var(--sp-4);
+  min-width: 0;
+}
+
+.workspaceV2Card,
+.workspaceV2Terminal,
+.workspaceV2ContextRing {
+  min-width: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  box-shadow: var(--shadow-xs);
+}
+
+.workspaceV2Card {
+  padding: var(--sp-4);
+}
+
+.workspaceV2CardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-3);
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 900;
+}
+
+.workspaceV2CardHeader small {
+  color: var(--text-faint);
+  font-size: 0.72rem;
+}
+
+.workspaceV2StepList,
+.workspaceV2HistoryList,
+.workspaceV2SnippetList,
+.workspaceV2Breakdown {
+  display: grid;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.workspaceV2Step,
+.workspaceV2HistoryItem,
+.workspaceV2Snippet {
+  display: grid;
+  min-width: 0;
+  width: 100%;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--surface-raised) 88%, transparent);
+  color: var(--text);
+  text-align: left;
+}
+
+.workspaceV2Step {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-3);
+}
+
+.workspaceV2Step:hover,
+.workspaceV2HistoryItem:hover,
+.workspaceV2Snippet:hover {
+  border-color: color-mix(in srgb, var(--mode-agent) 34%, transparent);
+  background: color-mix(in srgb, var(--mode-agent-soft) 42%, var(--surface) 58%);
+}
+
+.workspaceV2StepIndex {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-lg);
+  background: var(--n-950);
+  color: var(--n-0);
+  font-size: 0.7rem;
+  font-weight: 900;
+}
+
+.workspaceV2StepBody {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.workspaceV2StepBody strong,
+.workspaceV2HistoryItem strong,
+.workspaceV2Snippet strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspaceV2StepBody span,
+.workspaceV2HistoryItem span,
+.workspaceV2Snippet code,
+.workspaceV2Step time {
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 0.74rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspaceV2HistoryItem,
+.workspaceV2Snippet {
+  gap: var(--sp-1);
+  padding: var(--sp-3);
+}
+
+.workspaceV2FilesWrap {
+  min-height: 520px;
+}
+
+.workspaceV2Terminal {
+  overflow: hidden;
+  background: #07110d;
+  color: #d8ffe9;
+}
+
+.workspaceV2TerminalChrome {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid rgba(216, 255, 233, 0.14);
+}
+
+.workspaceV2TerminalChrome span {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #46e6a9;
+}
+
+.workspaceV2TerminalChrome span:nth-child(2) {
+  background: #ffd166;
+}
+
+.workspaceV2TerminalChrome span:nth-child(3) {
+  background: #ff6b6b;
+}
+
+.workspaceV2TerminalChrome strong {
+  min-width: 0;
+  margin-left: var(--sp-2);
+  color: rgba(216, 255, 233, 0.72);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspaceV2TerminalLines {
+  display: grid;
+  align-content: start;
+  gap: var(--sp-2);
+  min-height: 360px;
+  padding: var(--sp-4);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+.workspaceV2TerminalLines p {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.workspaceV2TerminalLines span {
+  color: #46e6a9;
+}
+
+.workspaceV2ContextRing {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 260px;
+}
+
+.workspaceV2ContextRing svg {
+  width: 170px;
+  height: 170px;
+  transform: rotate(-90deg);
+}
+
+.workspaceV2ContextRing circle {
+  fill: none;
+  stroke-width: 12;
+}
+
+.workspaceV2ContextRing circle:first-child {
+  stroke: var(--border-subtle);
+}
+
+.workspaceV2ContextRing circle:last-child {
+  stroke: var(--mode-agent);
+  stroke-linecap: round;
+  stroke-dasharray: calc(var(--usage) * 3.02) 302;
+}
+
+.workspaceV2ContextRing div {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  gap: var(--sp-1);
+}
+
+.workspaceV2ContextRing strong {
+  color: var(--text);
+  font-size: 2rem;
+  letter-spacing: -0.06em;
+}
+
+.workspaceV2ContextRing span,
+.workspaceV2Breakdown span {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.workspaceV2Breakdown span {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  padding: var(--sp-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.workspaceV2Breakdown strong {
+  color: var(--text);
+}
+
+.workspaceV2Empty {
+  display: grid;
+  place-items: center;
+  gap: var(--sp-2);
+  min-height: 180px;
+  padding: var(--sp-4);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.workspaceV2Footer {
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-5);
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.workspaceV2UsageBar {
+  flex: 1 1 auto;
+  height: 7px;
+  min-width: 40px;
+  border-radius: 999px;
+  background: var(--surface-soft);
+  overflow: hidden;
+}
+
+.workspaceV2UsageBar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--mode-agent), var(--mode-terminal));
+}
+
+.previewDock {
+  position: fixed;
+  right: var(--sp-5);
+  bottom: calc(var(--sp-5) + env(safe-area-inset-bottom));
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  max-width: min(440px, calc(100vw - var(--sp-8)));
+  padding: var(--sp-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-2xl);
+  background: color-mix(in srgb, var(--surface-raised) 94%, transparent);
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(18px);
+}
+
+.previewDockMain {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+}
+
+.previewDockMain span {
+  display: grid;
+  min-width: 0;
+}
+
+.previewDockMain strong,
+.previewDockMain small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.previewDockMain small {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.previewDockIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  color: var(--text-muted);
+}
+
+.previewOverlayBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: grid;
+  place-items: center;
+  padding: var(--sp-5);
+  background: color-mix(in srgb, var(--n-950) 62%, transparent);
+  backdrop-filter: blur(10px);
+}
+
+.previewOverlay {
+  display: flex;
+  flex-direction: column;
+  width: min(1220px, 100%);
+  height: min(820px, 100%);
+  min-height: 0;
+  border: 1px solid color-mix(in srgb, white 18%, transparent);
+  border-radius: var(--radius-2xl);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-xl);
+  overflow: hidden;
+}
+
+.previewOverlayTopbar {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto auto;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-3);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.previewOverlayTopbar button,
+.previewOverlayTopbar a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  padding: 0 var(--sp-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 0.74rem;
+  font-weight: 800;
+}
+
+.previewOverlayNav,
+.previewOverlayDevices {
+  display: inline-flex;
+  gap: var(--sp-1);
+}
+
+.previewOverlayUrl {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+  height: 34px;
+  padding: 0 var(--sp-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--surface-soft);
+}
+
+.previewOverlayUrl span {
+  color: var(--mode-terminal-strong);
+  font-size: 0.68rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.previewOverlayUrl strong {
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 0.74rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.previewOverlayDeviceActive {
+  border-color: color-mix(in srgb, var(--mode-agent) 42%, transparent) !important;
+  background: var(--mode-agent-soft) !important;
+  color: var(--mode-agent-strong) !important;
+}
+
+.previewOverlayCanvas {
+  position: relative;
+  flex: 1 1 auto;
+  display: grid;
+  place-items: center;
+  min-height: 0;
+  padding: var(--sp-5);
+  background:
+    linear-gradient(45deg, color-mix(in srgb, var(--surface-soft) 84%, transparent) 25%, transparent 25%),
+    linear-gradient(-45deg, color-mix(in srgb, var(--surface-soft) 84%, transparent) 25%, transparent 25%);
+  background-size: 24px 24px;
+}
+
+.previewOverlayFrame {
+  width: min(100%, 1200px);
+  height: 100%;
+  max-height: 690px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+.previewOverlayFrame_tablet {
+  width: min(768px, 100%);
+}
+
+.previewOverlayFrame_mobile {
+  width: min(390px, 100%);
+}
+
+.previewOverlayFrame iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: white;
+}
+
+.previewOverlayPlaceholder {
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: var(--sp-2);
+  height: 100%;
+  padding: var(--sp-6);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.previewOverlayPlaceholder strong {
+  color: var(--text);
+  font-size: 1.3rem;
+}
+
+.previewOverlayFloatControls {
+  position: absolute;
+  right: var(--sp-5);
+  bottom: var(--sp-5);
+  display: inline-flex;
+  gap: var(--sp-2);
+}
+
+.previewOverlayFloatControls span {
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--surface-raised) 90%, transparent);
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+@media (max-width: 900px) {
+  .workspaceV2 {
+    min-height: min(78vh, 720px);
+    border-radius: var(--radius-2xl) var(--radius-2xl) 0 0;
+  }
+
+  .workspaceV2RunGrid,
+  .workspaceV2TerminalGrid,
+  .workspaceV2ContextGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .workspaceV2Body {
+    padding: var(--sp-3);
+  }
+
+  .composerModeHint {
+    display: none;
+  }
+
+  .previewOverlayBackdrop {
+    padding: var(--sp-2);
+  }
+
+  .previewOverlayTopbar {
+    grid-template-columns: 1fr auto;
+  }
+
+  .previewOverlayUrl,
+  .previewOverlayDevices {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 540px) {
+  .centerHeader {
+    padding: 0 var(--sp-3);
+  }
+
+  .headerTextAction {
+    min-width: 36px;
+    padding: 0 var(--sp-2);
+  }
+
+  .composerModeToggle {
+    width: 100%;
+  }
+
+  .composerModeButton {
+    flex: 1 1 0;
+    justify-content: center;
+    min-height: 34px;
+    padding: 0 var(--sp-2);
+  }
+
+  .inlineArtifactChip span {
+    max-width: 150px;
+  }
+
+  .previewDock {
+    left: var(--sp-3);
+    right: var(--sp-3);
+    max-width: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .messageBubbleHighlight,
+  .workspaceV2LiveDot {
+    animation: none;
+  }
+
+  .headerTextAction,
+  .composerCard,
+  .workspaceV2Tab,
+  .inlineArtifactChip {
+    transition: none;
+  }
+}
+
 :global(html[data-theme='dark']) .chatShell {
   --chat-panel-border: rgba(71, 85, 105, 0.55);
   --chat-panel-bg: linear-gradient(170deg, rgba(19, 29, 45, 0.98) 0%, rgba(15, 23, 42, 0.96) 100%);
@@ -5061,5 +6008,58 @@
 
   .linkPreviewWrap {
     max-width: 100%;
+  }
+}
+
+/* Final v1 overrides must stay last because this file still contains legacy chat rules above. */
+.centerHeader {
+  min-height: 52px;
+  height: 52px;
+  padding: 0 var(--sp-5);
+  border-bottom: 1px solid var(--border-subtle);
+  background:
+    linear-gradient(120deg, color-mix(in srgb, var(--surface-raised) 94%, transparent), color-mix(in srgb, var(--surface-soft) 82%, transparent)),
+    radial-gradient(circle at 18% 0%, color-mix(in srgb, var(--mode-agent) 10%, transparent), transparent 42%);
+  backdrop-filter: blur(18px);
+}
+
+.stream {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-soft) 60%, transparent), transparent 38%),
+    radial-gradient(circle at 50% 0%, color-mix(in srgb, var(--mode-agent-soft) 44%, transparent), transparent 38%);
+}
+
+.composerCard {
+  --composer-mode: var(--mode-agent);
+  --composer-mode-strong: var(--mode-agent-strong);
+  --composer-mode-soft: var(--mode-agent-soft);
+  border-color: color-mix(in srgb, var(--composer-mode) 26%, var(--border-subtle));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--composer-mode) 10%, transparent), var(--shadow-md);
+}
+
+.composerCard:focus-within {
+  border-color: color-mix(in srgb, var(--composer-mode) 54%, transparent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--composer-mode) 16%, transparent), var(--shadow-lg);
+}
+
+.composerCard[data-mode='plan'] {
+  --composer-mode: var(--mode-plan);
+  --composer-mode-strong: var(--mode-plan-strong);
+  --composer-mode-soft: var(--mode-plan-soft);
+}
+
+.composerCard[data-mode='terminal'] {
+  --composer-mode: var(--mode-terminal);
+  --composer-mode-strong: var(--mode-terminal-strong);
+  --composer-mode-soft: var(--mode-terminal-soft);
+}
+
+.messageBubbleHighlight {
+  animation: msgHighlightPulse 1.8s var(--motion-ease) 1;
+}
+
+@media (max-width: 540px) {
+  .centerHeader {
+    padding: 0 var(--sp-3);
   }
 }

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -37,6 +37,8 @@ import { ChatStatusNotices } from './chat-screen/center-pane/ChatStatusNotices';
 import { ChatTimeline } from './chat-screen/center-pane/ChatTimeline';
 import { FileBrowserModal } from './chat-screen/center-pane/FileBrowserModal';
 import { NewChatPlaceholderPane } from './chat-screen/center-pane/NewChatPlaceholderPane';
+import { PreviewDock } from './chat-screen/preview/PreviewDock';
+import { PreviewOverlay } from './chat-screen/preview/PreviewOverlay';
 import { WorkspaceHomePane } from './chat-screen/center-pane/WorkspaceHomePane';
 import { WorkspacePagerShell } from './chat-screen/center-pane/WorkspacePagerShell';
 import {
@@ -124,6 +126,7 @@ import {
 import type {
   AgentMeta,
   ChatRunPhase,
+  ComposerMode,
   ContextItem,
   TimelineRenderItem,
   WorkspaceFileOpenDetail,
@@ -425,6 +428,46 @@ export function ChatInterface({
   const userMessageBubbleNodesRef = useRef(new Map<string, HTMLDivElement>());
   const [isComposerDockLayoutReady, setIsComposerDockLayoutReady] = useState(false);
   const [lastUserMessageJumpTarget, setLastUserMessageJumpTarget] = useState<LastUserMessageJumpTarget | null>(null);
+  const [composerMode, setComposerMode] = useState<ComposerMode>('agent');
+  const [previewState, setPreviewState] = useState<'closed' | 'dock' | 'open'>('closed');
+  const [previewTarget, setPreviewTarget] = useState<{ title: string; url?: string | null } | null>(null);
+
+  useEffect(() => {
+    document.body.dataset.mode = composerMode;
+    return () => {
+      delete document.body.dataset.mode;
+    };
+  }, [composerMode]);
+
+  const handleOpenPreview = useCallback((target?: { title?: string; url?: string | null }) => {
+    setPreviewTarget({
+      title: target?.title || 'Workspace Preview',
+      url: target?.url ?? null,
+    });
+    setPreviewState('open');
+  }, []);
+
+  const handleDockPreview = useCallback(() => {
+    setPreviewState('dock');
+  }, []);
+
+  const handleClosePreview = useCallback(() => {
+    setPreviewState('closed');
+  }, []);
+
+  useEffect(() => {
+    const handlePreviewShortcut = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === 'p') {
+        event.preventDefault();
+        setPreviewTarget((current) => current ?? { title: 'Workspace Preview', url: null });
+        setPreviewState((current) => (current === 'open' ? 'dock' : 'open'));
+      }
+    };
+
+    window.addEventListener('keydown', handlePreviewShortcut);
+    return () => window.removeEventListener('keydown', handlePreviewShortcut);
+  }, []);
+
   const handleDeleteEmptyAutoChat = useCallback(() => {
     if (!activeChat) {
       return;
@@ -1570,6 +1613,7 @@ export function ChatInterface({
     addEvent,
     approvalPolicy,
     codexReasoningEffort: codexReasoningEffort ?? 'medium',
+    composerMode,
     contextItems,
     disconnectNoticeAwaitingRef,
     events,
@@ -2612,6 +2656,8 @@ export function ChatInterface({
       onToggleDebugMode={toggleDebugMode}
       onTogglePermissionQueue={handleTogglePermissionQueue}
       onUpdateApprovalPolicy={handleUpdateApprovalPolicy}
+      onOpenPreview={() => handleOpenPreview()}
+      onToggleWorkspace={() => setActiveWorkspacePageId((current) => (current === 'chat' ? 'workspace' : 'chat'))}
       sessionTitle={sessionTitle}
       showDebugToggleInHeader={showDebugToggleInHeader}
       showPermissionQueue={showPermissionQueue}
@@ -2748,6 +2794,7 @@ export function ChatInterface({
                 onStreamScroll={handleStreamScroll}
                 onToggleActionRun={toggleActionRun}
                 onToggleResult={toggleResult}
+                onOpenPreview={handleOpenPreview}
               />
             )}
             composer={!isWorkspaceHome ? (
@@ -2785,6 +2832,8 @@ export function ChatInterface({
                 composerInputRef={composerInputRef}
                 composerImageInputRef={composerImageInputRef}
                 onSubmit={handleSubmit}
+                composerMode={composerMode}
+                onComposerModeChange={setComposerMode}
                 onToggleCommandMenu={handleToggleCommandMenu}
                 onRunChatCommand={handleRunChatCommand}
                 onToggleModelDropdown={handleToggleModelDropdown}
@@ -2841,6 +2890,38 @@ export function ChatInterface({
             requestedFile={sidebarFileRequest}
             onCreatePanel={handleCreateWorkspacePanel}
             onReturnToChat={() => setActiveWorkspacePageId('chat')}
+          />
+        )}
+        renderWorkspacePage={() => (
+          <WorkspacePanelsPane
+            mode="create"
+            sessionId={sessionId}
+            projectName={projectName}
+            workspaceRootPath={normalizedWorkspaceRootPath}
+            isMobileLayout={isMobileLayout}
+            workspacePanelsError={workspacePanelsError}
+            workspacePanelsLoading={workspacePanelsLoading}
+            workspacePanelLayout={workspacePanelLayout}
+            header={activeWorkspacePageId === 'workspace' ? renderChatHeader() : null}
+            requestedFile={sidebarFileRequest}
+            chats={chats}
+            events={events}
+            isAgentRunning={isAgentRunning}
+            activeAgentLabel={agentMeta.label}
+            onCreatePanel={handleCreateWorkspacePanel}
+            onReturnToChat={() => setActiveWorkspacePageId('chat')}
+            onJumpToMessage={(eventId) => {
+              setActiveWorkspacePageId('chat');
+              setHighlightedEventId(eventId);
+              window.setTimeout(() => {
+                document.getElementById(`event-${eventId}`)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+              }, 120);
+            }}
+            onInsertSnippet={(snippet) => {
+              setPrompt((current) => (current.trim() ? `${current}\n${snippet}` : snippet));
+              setActiveWorkspacePageId('chat');
+              window.setTimeout(() => composerInputRef.current?.focus(), 80);
+            }}
           />
         )}
         renderPanelPage={(item) => (
@@ -2911,6 +2992,20 @@ export function ChatInterface({
         onClose={() => setUsageProbeProvider(null)}
       />,
       document.body,
+    )}
+    {isMounted && previewState === 'dock' && (
+      <PreviewDock
+        target={previewTarget ?? { title: 'Workspace Preview', url: null }}
+        onOpen={() => setPreviewState('open')}
+        onClose={handleClosePreview}
+      />
+    )}
+    {isMounted && previewState === 'open' && (
+      <PreviewOverlay
+        target={previewTarget ?? { title: 'Workspace Preview', url: null }}
+        onDock={handleDockPreview}
+        onClose={handleClosePreview}
+      />
     )}
     </>
   );

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/actions/useChatRunActions.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/actions/useChatRunActions.ts
@@ -17,6 +17,7 @@ import {
 } from '../helpers';
 import type {
   ChatRuntimeUiState,
+  ComposerMode,
   ContextItem,
   LegacyCustomModels,
   ModelReasoningEffort,
@@ -29,6 +30,7 @@ type Params = {
   addEvent: (event: UiEvent) => void;
   approvalPolicy?: ApprovalPolicy;
   codexReasoningEffort: ModelReasoningEffort;
+  composerMode: ComposerMode;
   contextItems: ContextItem[];
   disconnectNoticeAwaitingRef: MutableRefObject<string | null>;
   events: UiEvent[];
@@ -81,6 +83,7 @@ export function useChatRunActions({
   addEvent,
   approvalPolicy,
   codexReasoningEffort,
+  composerMode,
   contextItems,
   disconnectNoticeAwaitingRef,
   events,
@@ -140,11 +143,19 @@ export function useChatRunActions({
       }
       return acc;
     }, []);
-    const finalText = buildComposerSubmitText({
+    const baseText = buildComposerSubmitText({
       promptText,
       imageAttachments,
       contextBlocks,
     });
+    const finalText = composerMode === 'plan'
+      ? [
+          '[PLAN MODE]',
+          'Respond with a concrete implementation plan only. Do not execute tools, shell commands, file writes, deploys, or destructive actions.',
+          '',
+          baseText,
+        ].join('\n')
+      : baseText;
     const submitModelId = normalizeModelId(selectedModelId)
       ?? resolveDefaultModelId(activeAgentFlavor, providerSelections, legacyCustomModels ?? undefined, lastSelectedCodexModelId);
     const submitGeminiModeId = activeAgentFlavor === 'gemini'
@@ -157,6 +168,67 @@ export function useChatRunActions({
     const submitModelReasoningEffort = codexReasoningEffort;
 
     const awaitingSince = new Date().toISOString();
+
+    if (composerMode === 'terminal') {
+      updateChatRuntimeUi(scopedChatId, {
+        isSubmitting: true,
+        isAwaitingReply: false,
+        hasCompletionSignal: false,
+        awaitingReplySince: null,
+        submitError: null,
+        showDisconnectRetry: false,
+        lastSubmittedPayload: {
+          text: promptText,
+          chatId: scopedChatId,
+          agent: activeChat?.agent === 'claude' || activeChat?.agent === 'codex' || activeChat?.agent === 'gemini'
+            ? activeChat.agent
+            : 'codex',
+          model: submitModelId,
+          composerMode,
+          ...(submitModelReasoningEffort ? { modelReasoningEffort: submitModelReasoningEffort } : {}),
+          ...(activeChat?.threadId ? { threadId: activeChat.threadId } : {}),
+        },
+      });
+      try {
+        const response = await fetch(`/api/runtime/sessions/${encodeURIComponent(sessionId)}/terminal`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            chatId: scopedChatId,
+            command: promptText,
+            agent: activeChat?.agent ?? 'codex',
+            model: submitModelId,
+            modelReasoningEffort: submitModelReasoningEffort,
+          }),
+        });
+        const body = (await response.json().catch(() => ({ error: '터미널 응답을 읽을 수 없습니다.' }))) as {
+          events?: UiEvent[];
+          error?: string;
+        };
+        if (!response.ok) {
+          throw new Error(body.error ?? '터미널 명령 실행에 실패했습니다.');
+        }
+        for (const event of body.events ?? []) {
+          addEvent(event);
+        }
+        const touchedAt = new Date().toISOString();
+        setChats((prev) => sortSessionChats(prev.map((chat) => (
+          chat.id === scopedChatId
+            ? { ...chat, lastActivityAt: touchedAt, latestPreview: `$ ${promptText}`, latestEventAt: touchedAt }
+            : chat
+        ))));
+        setPrompt('');
+        setContextItems([]);
+      } catch (error) {
+        updateChatRuntimeUi(scopedChatId, {
+          submitError: error instanceof Error ? error.message : '터미널 명령 실행에 실패했습니다.',
+        });
+      } finally {
+        updateChatRuntimeUi(scopedChatId, { isSubmitting: false });
+      }
+      return;
+    }
+
     const optimisticUserEvent = buildOptimisticUserEvent({
       chatId: scopedChatId,
       agent: activeChat?.agent === 'claude' || activeChat?.agent === 'codex' || activeChat?.agent === 'gemini'
@@ -168,6 +240,7 @@ export function useChatRunActions({
       ...(imageAttachments.length > 0 ? { attachments: imageAttachments } : {}),
       text: finalText,
       submittedAt: awaitingSince,
+      mode: composerMode,
     });
     const wasStickyAtSubmit = shouldStickToBottomRef.current;
 
@@ -189,6 +262,7 @@ export function useChatRunActions({
         ...(submitModelReasoningEffort ? { modelReasoningEffort: submitModelReasoningEffort } : {}),
         ...(activeChat?.threadId ? { threadId: activeChat.threadId } : {}),
         ...(imageAttachments.length > 0 ? { attachments: imageAttachments } : {}),
+        composerMode,
       },
     });
     runtimeStartedSinceAwaitingRef.current = false;
@@ -226,6 +300,7 @@ export function useChatRunActions({
             ...(submitModelReasoningEffort ? { modelReasoningEffort: submitModelReasoningEffort } : {}),
             ...(activeChat?.threadId ? { threadId: activeChat.threadId } : {}),
             ...(imageAttachments.length > 0 ? { attachments: imageAttachments } : {}),
+            composerMode,
           }),
         }),
       });
@@ -310,6 +385,7 @@ export function useChatRunActions({
     addEvent,
     approvalPolicy,
     codexReasoningEffort,
+    composerMode,
     contextItems,
     disconnectNoticeAwaitingRef,
     events,

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/ChatComposer.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/ChatComposer.tsx
@@ -24,7 +24,7 @@ import {
 import type { AgentFlavor, ApprovalPolicy } from '@/lib/happy/types';
 import type { ChatCommandId } from '../../chatCommands';
 import { MODEL_REASONING_EFFORT_OPTIONS } from '../constants';
-import type { ComposerModelOption, ContextItem, GeminiModeOption, ModelReasoningEffort } from '../types';
+import type { ComposerMode, ComposerModelOption, ContextItem, GeminiModeOption, ModelReasoningEffort } from '../types';
 import styles from '../../ChatInterface.module.css';
 
 type ChatCommandOption = {
@@ -89,6 +89,8 @@ export function ChatComposer({
   onPromptFocus,
   onPromptKeyDown,
   onAbortRun,
+  composerMode = 'agent',
+  onComposerModeChange = () => {},
 }: {
   showPendingReveal: boolean;
   agentFlavor: AgentFlavor;
@@ -144,7 +146,10 @@ export function ChatComposer({
   onPromptFocus: FocusEventHandler<HTMLTextAreaElement>;
   onPromptKeyDown: KeyboardEventHandler<HTMLTextAreaElement>;
   onAbortRun: MouseEventHandler<HTMLButtonElement>;
+  composerMode?: ComposerMode;
+  onComposerModeChange?: (mode: ComposerMode) => void;
 }) {
+  const modeLabel = composerMode === 'plan' ? '계획을 먼저 작성합니다.' : composerMode === 'terminal' ? '입력한 내용을 셸 명령으로 실행합니다.' : '에이전트에게 작업을 요청합니다.';
   return (
     <footer
       className={`${styles.composerDock} ${showPendingReveal ? styles.chatEntryPendingReveal : ''}`}
@@ -152,8 +157,23 @@ export function ChatComposer({
       aria-hidden={showPendingReveal}
     >
       <form onSubmit={onSubmit} className={styles.composerForm}>
-        <div className={styles.composerCard}>
+        <div className={styles.composerCard} data-mode={composerMode}>
           <div className={styles.composerToolbar}>
+            <div className={styles.composerModeToggle} role="group" aria-label="Composer mode">
+              {(['agent', 'plan', 'terminal'] as const).map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  className={`${styles.composerModeButton} ${composerMode === mode ? styles.composerModeButtonActive : ''}`}
+                  onClick={() => onComposerModeChange(mode)}
+                  aria-pressed={composerMode === mode}
+                  data-mode={mode}
+                >
+                  <span className={styles.composerModeDot} />
+                  {mode === 'agent' ? 'Agent' : mode === 'plan' ? 'Plan' : 'Terminal'}
+                </button>
+              ))}
+            </div>
             {availableChatCommands.length > 0 && (
               <div className={styles.modelSelectorWrap} ref={commandMenuRef}>
                 <button
@@ -257,23 +277,25 @@ export function ChatComposer({
               </div>
             )}
             {agentFlavor === 'codex' && (
-              <label className={styles.modelEffortWrap}>
+              <div className={styles.modelEffortWrap} aria-label="모델 추론 강도">
                 <span className={styles.modelEffortLabel}>Effort</span>
-                <select
-                  className={styles.modelEffortSelect}
-                  value={selectedModelReasoningEffort}
-                  onChange={(event) => onSelectModelReasoningEffort(event.target.value)}
-                  aria-label="모델 추론 강도"
-                >
+                <div className={styles.modelEffortChips}>
                   {MODEL_REASONING_EFFORT_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
+                    <button
+                      key={option.value}
+                      type="button"
+                      className={`${styles.modelEffortChip} ${selectedModelReasoningEffort === option.value ? styles.modelEffortChipActive : ''}`}
+                      onClick={() => onSelectModelReasoningEffort(option.value)}
+                      aria-pressed={selectedModelReasoningEffort === option.value}
+                    >
                       {option.label}
-                    </option>
+                    </button>
                   ))}
-                </select>
-              </label>
+                </div>
+              </div>
             )}
           </div>
+          <div className={styles.composerModeHint}>{modeLabel}</div>
 
           {contextItems.length > 0 && (
             <div className={styles.composerChips}>
@@ -381,7 +403,11 @@ export function ChatComposer({
                 !activeChatIdResolved
                   ? '사용할 채팅을 선택하세요.'
                   : isOperator
-                    ? '메시지를 입력하세요...'
+                    ? composerMode === 'terminal'
+                      ? '예: npm test -- mobileOverflowLayout.test.ts'
+                      : composerMode === 'plan'
+                        ? '계획이 필요한 작업을 입력하세요...'
+                        : '메시지를 입력하세요...'
                     : 'Viewer 권한입니다.'
               }
               disabled={!activeChatIdResolved || !isOperator}

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/ChatHeader.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/ChatHeader.tsx
@@ -51,6 +51,8 @@ type ChatHeaderProps = {
   onToggleContextMenu: () => void;
   onToggleDebugMode: () => void;
   onTogglePermissionQueue: () => void;
+  onToggleWorkspace: () => void;
+  onOpenPreview: () => void;
   onUpdateApprovalPolicy: (next: ApprovalPolicy) => void;
   sessionTitle: string;
   showDebugToggleInHeader: boolean;
@@ -90,6 +92,8 @@ export function ChatHeader({
   onToggleContextMenu,
   onToggleDebugMode,
   onTogglePermissionQueue,
+  onToggleWorkspace,
+  onOpenPreview,
   onUpdateApprovalPolicy,
   sessionTitle,
   showDebugToggleInHeader,
@@ -117,10 +121,27 @@ export function ChatHeader({
             <span className={styles.centerChatLabel}>{currentChatTitle}</span>
           </div>
         ) : (
-          <span className={styles.centerAgentLabel}>{agentMeta.label} Agent · {sessionTitle}</span>
+          <span className={styles.centerAgentLabel}>{agentMeta.label} · tokens live · elapsed now</span>
         )}
       </div>
       <div className={styles.centerHeaderActions}>
+        <button
+          type="button"
+          className={styles.headerTextAction}
+          onClick={onOpenPreview}
+          aria-label="프리뷰 열기"
+        >
+          Preview
+        </button>
+        <button
+          type="button"
+          className={styles.headerTextAction}
+          onClick={onToggleWorkspace}
+          aria-pressed={activeWorkspacePageId !== 'chat'}
+          aria-label={activeWorkspacePageId !== 'chat' ? '워크스페이스 닫기' : '워크스페이스 열기'}
+        >
+          Workspace
+        </button>
         <button
           type="button"
           className={styles.sidebarToggleButton}

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/ChatTimeline.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/ChatTimeline.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import type { CSSProperties, RefObject } from 'react';
-import { CheckCircle2, ChevronDown, ChevronLeft, ChevronUp, Copy, Loader2, MessageSquarePlus } from 'lucide-react';
+import { CheckCircle2, ChevronDown, ChevronLeft, ChevronUp, Copy, Eye, Loader2, MessageSquarePlus } from 'lucide-react';
 import { readChatImageAttachments } from '@/lib/chatImageAttachments';
 import type { AgentFlavor, PermissionDecision, SessionChat, UiEvent } from '@/lib/happy/types';
 import { PermissionRequestMessage } from '../../PermissionRequestMessage';
@@ -64,6 +64,7 @@ export function ChatTimeline({
   onStreamScroll,
   onToggleActionRun,
   onToggleResult,
+  onOpenPreview,
 }: {
   activeAgentFlavor: AgentFlavor;
   activeChat: SessionChat | null;
@@ -92,9 +93,19 @@ export function ChatTimeline({
   onStreamScroll: () => void;
   onToggleActionRun: (runId: string) => void;
   onToggleResult: (eventId: string) => void;
+  onOpenPreview?: (target?: { title?: string; url?: string | null }) => void;
 }) {
   const AgentIcon = agentMeta.Icon;
   const quickStarts = AGENT_QUICK_STARTS[activeAgentFlavor] || AGENT_QUICK_STARTS.codex || [];
+  const getTimelineDate = (item: TimelineRenderItem) => {
+    if (item.type === 'permission') {
+      return new Date(item.permission.requestedAt);
+    }
+    if (item.item.type === 'action_overflow') {
+      return new Date(item.item.timestamp);
+    }
+    return new Date(item.item.event.timestamp);
+  };
 
   return (
     <>
@@ -158,22 +169,34 @@ export function ChatTimeline({
             </div>
           </div>
         )}
-        {timelineItems.map((timelineItem) => {
+        {timelineItems.map((timelineItem, index) => {
+          const itemDate = getTimelineDate(timelineItem);
+          const prevItem = timelineItems[index - 1];
+          const prevDate = prevItem ? getTimelineDate(prevItem) : null;
+          const shouldRenderDay = !prevDate || itemDate.toDateString() !== prevDate.toDateString();
+          const dayDivider = shouldRenderDay ? (
+            <div key={`day-${timelineItem.order}-${itemDate.toDateString()}`} className={styles.timelineDayDivider}>
+              <span>{Number.isNaN(itemDate.getTime()) ? 'Today' : itemDate.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric', weekday: 'short' })}</span>
+            </div>
+          ) : null;
+
           if (timelineItem.type === 'permission') {
             const permission = timelineItem.permission;
             return (
-              <PermissionRequestMessage
-                key={permission.id}
-                anchorId={`permission-${permission.id}`}
-                permission={permission}
-                disabled={!isOperator}
-                loading={loadingPermissionId === permission.id}
-                interactive={permission.availability === 'live'}
-                pendingHint={permission.availability === 'live'
-                  ? null
-                  : '실시간 승인 세션을 찾을 수 없습니다. 같은 요청을 다시 실행해 주세요.'}
-                onDecide={onDecidePermission}
-              />
+              <React.Fragment key={permission.id}>
+                {dayDivider}
+                <PermissionRequestMessage
+                  anchorId={`permission-${permission.id}`}
+                  permission={permission}
+                  disabled={!isOperator}
+                  loading={loadingPermissionId === permission.id}
+                  interactive={permission.availability === 'live'}
+                  pendingHint={permission.availability === 'live'
+                    ? null
+                    : '실시간 승인 세션을 찾을 수 없습니다. 같은 요청을 다시 실행해 주세요.'}
+                  onDecide={onDecidePermission}
+                />
+              </React.Fragment>
             );
           }
 
@@ -185,41 +208,44 @@ export function ChatTimeline({
               ? '반복 행동 접기'
               : `중간 행동 ${item.hiddenCount}개 펼치기`;
             return (
-              <article key={`overflow-${item.id}`} className={`${styles.messageRow} ${styles.messageRowAgent}`}>
-                <button
-                  type="button"
-                  className={`${styles.messageBubble} ${styles.messageBubbleAction} ${styles.actionOverflowBubble} ${styles.actionOverflowToggle}`}
-                  onClick={() => onToggleActionRun(item.runId)}
-                  title={title}
-                  aria-label={title}
-                  aria-expanded={item.expanded}
-                >
-                  <div className={styles.actionOverflowContent}>
-                    {item.expanded ? (
-                      <span className={styles.actionOverflowLabel}>
-                        접기
-                        <ChevronUp size={14} />
-                      </span>
-                    ) : (
-                      <>
-                        <div className={styles.actionOverflowLeft}>
-                          <span className={`${styles.kindChip} ${getToneClass(overflowKindMeta.tone)}`}>
-                            <OverflowKindIcon size={12} />
-                            {overflowKindMeta.label}
-                          </span>
-                        </div>
+              <React.Fragment key={`overflow-${item.id}`}>
+                {dayDivider}
+                <article className={`${styles.messageRow} ${styles.messageRowAgent}`}>
+                  <button
+                    type="button"
+                    className={`${styles.messageBubble} ${styles.messageBubbleAction} ${styles.actionOverflowBubble} ${styles.actionOverflowToggle}`}
+                    onClick={() => onToggleActionRun(item.runId)}
+                    title={title}
+                    aria-label={title}
+                    aria-expanded={item.expanded}
+                  >
+                    <div className={styles.actionOverflowContent}>
+                      {item.expanded ? (
                         <span className={styles.actionOverflowLabel}>
-                          {item.hiddenCount}개의 행동 더 보기
-                          <ChevronDown size={14} />
+                          접기
+                          <ChevronUp size={14} />
                         </span>
-                        <div className={styles.actionOverflowRight}>
-                          <span className={styles.actionOverflowCount}>+{item.hiddenCount}</span>
-                        </div>
-                      </>
-                    )}
-                  </div>
-                </button>
-              </article>
+                      ) : (
+                        <>
+                          <div className={styles.actionOverflowLeft}>
+                            <span className={`${styles.kindChip} ${getToneClass(overflowKindMeta.tone)}`}>
+                              <OverflowKindIcon size={12} />
+                              {overflowKindMeta.label}
+                            </span>
+                          </div>
+                          <span className={styles.actionOverflowLabel}>
+                            {item.hiddenCount}개의 행동 더 보기
+                            <ChevronDown size={14} />
+                          </span>
+                          <div className={styles.actionOverflowRight}>
+                            <span className={styles.actionOverflowCount}>+{item.hiddenCount}</span>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  </button>
+                </article>
+              </React.Fragment>
             );
           }
 
@@ -230,7 +256,9 @@ export function ChatTimeline({
           if (userEvent) {
             const userAttachments = readChatImageAttachments(event.meta);
             return (
-              <article id={`event-${event.id}`} key={event.id} className={`${styles.messageRow} ${styles.messageRowUser}`}>
+              <React.Fragment key={event.id}>
+              {dayDivider}
+              <article id={`event-${event.id}`} className={`${styles.messageRow} ${styles.messageRowUser}`}>
                 <div className={`${styles.msgHeader} ${styles.msgHeaderUser}`}>
                   <span className={styles.msgTime}>{formatClock(event.timestamp)}</span>
                   <span className={`${styles.msgSender} ${styles.msgSenderUser}`}>YOU</span>
@@ -284,22 +312,30 @@ export function ChatTimeline({
                   </button>
                 </div>
               </article>
+              </React.Fragment>
             );
           }
 
           if (actionEvent) {
             const expanded = expandedResultIds[event.id] ?? false;
             return (
-              <article id={`event-${event.id}`} key={event.id} className={`${styles.messageRow} ${styles.messageRowAgent}`}>
+              <React.Fragment key={event.id}>
+              {dayDivider}
+              <article id={`event-${event.id}`} className={`${styles.messageRow} ${styles.messageRowAgent}`}>
                 <div className={`${styles.messageBubble} ${styles.messageBubbleAction}`}>
                   {renderEventPayload(event, false, expanded, () => onToggleResult(event.id), isDebugMode)}
                 </div>
               </article>
+              </React.Fragment>
             );
           }
 
+          const urlMatch = /\bhttps?:\/\/[^\s)]+/.exec(event.body || event.title || '');
+
           return (
-            <article id={`event-${event.id}`} key={event.id} className={`${styles.messageRow} ${styles.messageRowAgent}`}>
+            <React.Fragment key={event.id}>
+            {dayDivider}
+            <article id={`event-${event.id}`} className={`${styles.messageRow} ${styles.messageRowAgent}`}>
               <div className={styles.messageWithAvatar}>
                 <div className={`${styles.msgAvatar} ${getAgentAvatarToneClass(agentMeta.tone)}`}>
                   <AgentIcon size={14} />
@@ -316,10 +352,25 @@ export function ChatTimeline({
                     {!isDebugMode && !isActionKind(event.kind) && (event.body || event.title) && (
                       <LinkPreviewCarousel body={event.body || event.title} />
                     )}
+                    {!isDebugMode && (urlMatch || event.parsed?.files?.length) && (
+                      <button
+                        type="button"
+                        className={styles.inlineArtifactChip}
+                        onClick={() => onOpenPreview?.({
+                          title: event.parsed?.files?.[0] ?? 'Agent artifact',
+                          url: urlMatch?.[0] ?? null,
+                        })}
+                      >
+                        <Eye size={13} />
+                        <span>{event.parsed?.files?.[0] ?? 'Preview artifact'}</span>
+                        <strong>Preview</strong>
+                      </button>
+                    )}
                   </div>
                 </div>
               </div>
             </article>
+            </React.Fragment>
           );
         })}
 

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/WorkspacePagerShell.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/WorkspacePagerShell.tsx
@@ -14,6 +14,7 @@ type WorkspacePagerShellProps = {
   setActiveWorkspacePageId: (pageId: string) => void;
   renderChatPage: () => ReactNode;
   renderCreatePage: () => ReactNode;
+  renderWorkspacePage?: (item: Extract<WorkspacePagerItem, { kind: 'workspace' }>) => ReactNode;
   renderPanelPage: (item: Extract<WorkspacePagerItem, { kind: 'panel' }>) => ReactNode;
 };
 
@@ -25,6 +26,7 @@ export function WorkspacePagerShell({
   setActiveWorkspacePageId,
   renderChatPage,
   renderCreatePage,
+  renderWorkspacePage,
   renderPanelPage,
 }: WorkspacePagerShellProps) {
   return (
@@ -35,6 +37,7 @@ export function WorkspacePagerShell({
         onActivePageChange={setActiveWorkspacePageId}
         renderChatPage={renderChatPage}
         renderCreatePage={renderCreatePage}
+        renderWorkspacePage={renderWorkspacePage}
         renderPanelPage={renderPanelPage}
       />
     </main>

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/preview/PreviewDock.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/preview/PreviewDock.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React from 'react';
+import { ExternalLink, MonitorUp, X } from 'lucide-react';
+import styles from '../../ChatInterface.module.css';
+
+type PreviewTarget = {
+  title: string;
+  url?: string | null;
+};
+
+type PreviewDockProps = {
+  target: PreviewTarget | null;
+  onClose: () => void;
+  onOpen: () => void;
+};
+
+export function PreviewDock({ target, onClose, onOpen }: PreviewDockProps) {
+  if (!target) {
+    return null;
+  }
+
+  return (
+    <aside className={styles.previewDock} aria-label="프리뷰 도크">
+      <button type="button" className={styles.previewDockMain} onClick={onOpen}>
+        <MonitorUp size={16} />
+        <span>
+          <strong>{target.title}</strong>
+          <small>{target.url ?? 'Inline artifact preview'}</small>
+        </span>
+      </button>
+      {target.url ? (
+        <a className={styles.previewDockIcon} href={target.url} target="_blank" rel="noreferrer" aria-label="외부에서 열기">
+          <ExternalLink size={14} />
+        </a>
+      ) : null}
+      <button type="button" className={styles.previewDockIcon} onClick={onClose} aria-label="프리뷰 닫기">
+        <X size={14} />
+      </button>
+    </aside>
+  );
+}

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/preview/PreviewOverlay.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/preview/PreviewOverlay.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  ArrowLeft,
+  ArrowRight,
+  ExternalLink,
+  Laptop,
+  Monitor,
+  RefreshCw,
+  Smartphone,
+  X,
+} from 'lucide-react';
+import styles from '../../ChatInterface.module.css';
+
+type PreviewTarget = {
+  title: string;
+  url?: string | null;
+};
+
+type PreviewOverlayProps = {
+  target: PreviewTarget | null;
+  onClose: () => void;
+  onDock: () => void;
+};
+
+const DEVICES = [
+  { id: 'desktop', label: '1200', Icon: Monitor },
+  { id: 'tablet', label: '768', Icon: Laptop },
+  { id: 'mobile', label: '390', Icon: Smartphone },
+] as const;
+
+type DeviceId = (typeof DEVICES)[number]['id'];
+
+export function PreviewOverlay({ target, onClose, onDock }: PreviewOverlayProps) {
+  const [device, setDevice] = useState<DeviceId>('desktop');
+  const dialogRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onDock();
+        return;
+      }
+      if (event.key !== 'Tab') {
+        return;
+      }
+      const dialog = dialogRef.current;
+      if (!dialog) {
+        return;
+      }
+      const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])',
+      ));
+      if (focusable.length === 0) {
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onDock]);
+
+  useEffect(() => {
+    dialogRef.current?.querySelector<HTMLElement>('button:not([disabled])')?.focus();
+  }, []);
+
+  if (!target) {
+    return null;
+  }
+
+  const frameClassName = `${styles.previewOverlayFrame} ${styles[`previewOverlayFrame_${device}`] ?? ''}`;
+
+  return (
+    <div className={styles.previewOverlayBackdrop} role="dialog" aria-modal="true" aria-label="아티팩트 프리뷰">
+      <section className={styles.previewOverlay} ref={dialogRef}>
+        <header className={styles.previewOverlayTopbar}>
+          <div className={styles.previewOverlayNav}>
+            <button type="button" aria-label="뒤로" disabled><ArrowLeft size={14} /></button>
+            <button type="button" aria-label="앞으로" disabled><ArrowRight size={14} /></button>
+            <button type="button" aria-label="새로고침"><RefreshCw size={14} /></button>
+          </div>
+          <div className={styles.previewOverlayUrl}>
+            <span>https</span>
+            <strong>{target.url ?? target.title}</strong>
+          </div>
+          <div className={styles.previewOverlayDevices} role="group" aria-label="프리뷰 디바이스">
+            {DEVICES.map(({ id, label, Icon }) => (
+              <button
+                key={id}
+                type="button"
+                aria-pressed={device === id}
+                className={device === id ? styles.previewOverlayDeviceActive : ''}
+                onClick={() => setDevice(id)}
+              >
+                <Icon size={13} />
+                {label}
+              </button>
+            ))}
+          </div>
+          {target.url ? (
+            <a href={target.url} target="_blank" rel="noreferrer" aria-label="외부에서 열기">
+              <ExternalLink size={14} />
+            </a>
+          ) : null}
+          <button type="button" onClick={onDock} aria-label="도크로 내리기">Dock</button>
+          <button type="button" onClick={onClose} aria-label="프리뷰 닫기"><X size={14} /></button>
+        </header>
+        <div className={styles.previewOverlayCanvas}>
+          <div className={frameClassName}>
+            {target.url ? (
+              <iframe src={target.url} title={target.title} />
+            ) : (
+              <div className={styles.previewOverlayPlaceholder}>
+                <strong>{target.title}</strong>
+                <span>이 아티팩트는 URL이 없어 dock/overlay 상태만 표시합니다.</span>
+              </div>
+            )}
+          </div>
+          <div className={styles.previewOverlayFloatControls} aria-hidden="true">
+            <span>100%</span>
+            <span>Screenshot</span>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/right-pane/WorkspacePanelsPane.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/right-pane/WorkspacePanelsPane.tsx
@@ -1,11 +1,24 @@
 'use client';
 
-import React, { type ReactNode } from 'react';
+import React, { useMemo, useState, type ReactNode } from 'react';
+import {
+  CircleGauge,
+  Files,
+  History,
+  ListChecks,
+  Maximize2,
+  Play,
+  SquareTerminal,
+  X,
+} from 'lucide-react';
 import { BackendNotice } from '@/components/ui/BackendNotice';
+import type { SessionChat, UiEvent } from '@/lib/happy/types';
 import type { RequestedFilePayload } from '../../customization-sidebar/types';
 import type { WorkspacePanelLayout, WorkspacePanelType } from '@/lib/workspacePanels/types';
 import { CreatePanelPage } from '../../workspace-panels/CreatePanelPage';
 import { PanelPageRenderer } from '../../workspace-panels/PanelPageRenderer';
+import { WorkspaceToolsPanelPage } from '../../workspace-panels/WorkspaceToolsPanelPage';
+import { formatClock, getEventKindMeta, isActionKind, isUserEvent } from '../helpers';
 import styles from '../../ChatInterface.module.css';
 
 type WorkspacePanelsPaneBaseProps = {
@@ -18,6 +31,12 @@ type WorkspacePanelsPaneBaseProps = {
   workspacePanelLayout: WorkspacePanelLayout;
   header?: ReactNode;
   requestedFile?: RequestedFilePayload | null;
+  activeAgentLabel?: string;
+  chats?: SessionChat[];
+  events?: UiEvent[];
+  isAgentRunning?: boolean;
+  onInsertSnippet?: (snippet: string) => void;
+  onJumpToMessage?: (eventId: string) => void;
 };
 
 type WorkspacePanelsCreatePaneProps = WorkspacePanelsPaneBaseProps & {
@@ -36,9 +55,248 @@ type WorkspacePanelsPanelPaneProps = WorkspacePanelsPaneBaseProps & {
 
 type WorkspacePanelsPaneProps = WorkspacePanelsCreatePaneProps | WorkspacePanelsPanelPaneProps;
 
+type WorkspaceTab = 'run' | 'files' | 'terminal' | 'context';
+
+const WORKSPACE_TABS: Array<{ id: WorkspaceTab; label: string; Icon: typeof Play }> = [
+  { id: 'run', label: 'Run', Icon: Play },
+  { id: 'files', label: 'Files', Icon: Files },
+  { id: 'terminal', label: 'Terminal', Icon: SquareTerminal },
+  { id: 'context', label: 'Context', Icon: CircleGauge },
+];
+
+const SNIPPETS = [
+  { label: 'Lint web', command: 'npm run lint' },
+  { label: 'Typecheck', command: './node_modules/.bin/tsc --noEmit' },
+  { label: 'Mobile overflow guard', command: 'npm test -- mobileOverflowLayout.test.ts' },
+  { label: 'Git status', command: 'git status --short' },
+];
+
+const EMPTY_EVENTS: UiEvent[] = [];
+const EMPTY_CHATS: SessionChat[] = [];
+
+function getEventLabel(event: UiEvent) {
+  if (isUserEvent(event)) return 'User';
+  if (isActionKind(event.kind)) return getEventKindMeta(event.kind).label;
+  return event.title || 'Agent';
+}
+
+function getEventPreview(event: UiEvent) {
+  return (event.body || event.title || event.kind || '').replace(/\s+/g, ' ').trim() || 'No preview';
+}
+
+function renderWorkspaceEmpty(message: string) {
+  return (
+    <div className={styles.workspaceV2Empty}>
+      <ListChecks size={18} />
+      <p>{message}</p>
+    </div>
+  );
+}
+
 export function WorkspacePanelsPane(props: WorkspacePanelsPaneProps) {
   const frameClassName = `${styles.centerFrame} ${props.isMobileLayout ? styles.centerFrameMobileScroll : ''}`;
   const streamClassName = `${styles.stream} ${props.isMobileLayout ? styles.streamMobileScroll : ''}`;
+  const [activeTab, setActiveTab] = useState<WorkspaceTab>('run');
+  const events = props.events ?? EMPTY_EVENTS;
+  const chats = props.chats ?? EMPTY_CHATS;
+  const recentEvents = useMemo(() => events.slice(-8).reverse(), [events]);
+  const recentChats = useMemo(() => chats.slice(0, 6), [chats]);
+  const actionEvents = useMemo(() => events.filter((event) => isActionKind(event.kind)).slice(-8).reverse(), [events]);
+  const tokenEstimate = Math.max(1, Math.round(events.reduce((sum, event) => sum + (event.body?.length ?? 0) + (event.title?.length ?? 0), 0) / 4));
+  const usagePercent = Math.min(92, Math.max(8, Math.round((tokenEstimate / 120000) * 100)));
+  const explorerPanel = props.workspacePanelLayout.panels.find((panel) => panel.type === 'explorer') ?? {
+    id: 'workspace-files-tab',
+    type: 'explorer' as const,
+    title: 'Files',
+    config: {},
+    createdAt: null,
+  };
+
+  const workspaceBody = (
+    <div className={styles.workspaceV2}>
+      <div className={styles.workspaceV2Header}>
+        <div className={styles.workspaceV2TitleBlock}>
+          {props.isMobileLayout ? <span className={styles.workspaceV2Handle} aria-hidden="true" /> : null}
+          <span className={styles.workspaceV2Eyebrow}>Single Workspace</span>
+          <h2 className={styles.workspaceV2Title}>Workspace</h2>
+        </div>
+        <div className={styles.workspaceV2Actions}>
+          <button type="button" className={styles.workspaceV2IconButton} aria-label="워크스페이스 확장">
+            <Maximize2 size={15} />
+          </button>
+          <button type="button" className={styles.workspaceV2IconButton} aria-label="워크스페이스 닫기" onClick={props.onReturnToChat}>
+            <X size={15} />
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.workspaceV2StatusStrip}>
+        <span className={props.isAgentRunning ? styles.workspaceV2LiveDot : styles.workspaceV2IdleDot} />
+        <strong>{props.activeAgentLabel ?? 'Agent'}</strong>
+        <span>{props.isAgentRunning ? 'running' : 'ready'}</span>
+        <span>{events.length} events</span>
+      </div>
+
+      <div className={styles.workspaceV2Tabs} role="tablist" aria-label="워크스페이스 탭">
+        {WORKSPACE_TABS.map(({ id, label, Icon }) => (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === id}
+            className={`${styles.workspaceV2Tab} ${activeTab === id ? styles.workspaceV2TabActive : ''}`}
+            onClick={() => setActiveTab(id)}
+          >
+            <Icon size={14} />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className={styles.workspaceV2Body}>
+        {activeTab === 'run' && (
+          <div className={styles.workspaceV2RunGrid}>
+            <section className={styles.workspaceV2Card}>
+              <div className={styles.workspaceV2CardHeader}>
+                <span>Step timeline</span>
+                <small>{recentEvents.length} recent</small>
+              </div>
+              {recentEvents.length === 0 ? renderWorkspaceEmpty('아직 실행 단계가 없습니다.') : (
+                <div className={styles.workspaceV2StepList}>
+                  {recentEvents.map((event, index) => (
+                    <button
+                      key={event.id}
+                      type="button"
+                      className={styles.workspaceV2Step}
+                      onClick={() => props.onJumpToMessage?.(event.id)}
+                    >
+                      <span className={styles.workspaceV2StepIndex}>{String(recentEvents.length - index).padStart(2, '0')}</span>
+                      <span className={styles.workspaceV2StepBody}>
+                        <strong>{getEventLabel(event)}</strong>
+                        <span>{getEventPreview(event)}</span>
+                      </span>
+                      <time>{formatClock(event.timestamp)}</time>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section className={styles.workspaceV2Card}>
+              <div className={styles.workspaceV2CardHeader}>
+                <span>Chat history</span>
+                <History size={14} />
+              </div>
+              {recentChats.length === 0 ? renderWorkspaceEmpty('채팅 히스토리가 비어 있습니다.') : (
+                <div className={styles.workspaceV2HistoryList}>
+                  {recentChats.map((chat) => {
+                    const targetEvent = events.find((event) => event.meta?.chatId === chat.id);
+                    return (
+                      <button
+                        key={chat.id}
+                        type="button"
+                        className={styles.workspaceV2HistoryItem}
+                        onClick={() => targetEvent ? props.onJumpToMessage?.(targetEvent.id) : undefined}
+                      >
+                        <strong>{chat.title}</strong>
+                        <span>{chat.latestPreview || 'No preview yet'}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </section>
+          </div>
+        )}
+
+        {activeTab === 'files' && (
+          <div className={styles.workspaceV2FilesWrap}>
+            <WorkspaceToolsPanelPage
+              sessionId={props.sessionId}
+              panel={explorerPanel}
+              projectName={props.projectName}
+              workspaceRootPath={props.workspaceRootPath}
+              requestedFile={props.requestedFile ?? null}
+              isMobileLayout={props.isMobileLayout}
+              onReturnToChat={props.onReturnToChat}
+            />
+          </div>
+        )}
+
+        {activeTab === 'terminal' && (
+          <div className={styles.workspaceV2TerminalGrid}>
+            <section className={styles.workspaceV2Terminal}>
+              <div className={styles.workspaceV2TerminalChrome}>
+                <span />
+                <span />
+                <span />
+                <strong>{props.workspaceRootPath}</strong>
+              </div>
+              <div className={styles.workspaceV2TerminalLines}>
+                {actionEvents.length === 0 ? (
+                  <p>$ Terminal output will appear here after commands run.</p>
+                ) : actionEvents.map((event) => (
+                  <p key={event.id}>
+                    <span>$</span> {getEventPreview(event)}
+                  </p>
+                ))}
+              </div>
+            </section>
+            <section className={styles.workspaceV2Card}>
+              <div className={styles.workspaceV2CardHeader}>
+                <span>Snippets</span>
+                <small>insert</small>
+              </div>
+              <div className={styles.workspaceV2SnippetList}>
+                {SNIPPETS.map((snippet) => (
+                  <button
+                    key={snippet.command}
+                    type="button"
+                    className={styles.workspaceV2Snippet}
+                    onClick={() => props.onInsertSnippet?.(snippet.command)}
+                  >
+                    <strong>{snippet.label}</strong>
+                    <code>{snippet.command}</code>
+                  </button>
+                ))}
+              </div>
+            </section>
+          </div>
+        )}
+
+        {activeTab === 'context' && (
+          <div className={styles.workspaceV2ContextGrid}>
+            <section className={styles.workspaceV2ContextRing} style={{ '--usage': usagePercent } as React.CSSProperties}>
+              <svg viewBox="0 0 120 120" aria-hidden="true">
+                <circle cx="60" cy="60" r="48" />
+                <circle cx="60" cy="60" r="48" />
+              </svg>
+              <div>
+                <strong>{usagePercent}%</strong>
+                <span>Context usage</span>
+              </div>
+            </section>
+            <section className={styles.workspaceV2Card}>
+              <div className={styles.workspaceV2Breakdown}>
+                <span><strong>{tokenEstimate.toLocaleString()}</strong> prompt estimate</span>
+                <span><strong>{events.length}</strong> timeline events</span>
+                <span><strong>{props.workspacePanelLayout.panels.length}</strong> legacy panels mapped</span>
+                <span><strong>{Math.max(0, 120000 - tokenEstimate).toLocaleString()}</strong> headroom</span>
+              </div>
+            </section>
+          </div>
+        )}
+      </div>
+
+      <footer className={styles.workspaceV2Footer}>
+        <span>Context</span>
+        <div className={styles.workspaceV2UsageBar} aria-hidden="true">
+          <span style={{ width: `${usagePercent}%` }} />
+        </div>
+        <strong>{usagePercent}%</strong>
+      </footer>
+    </div>
+  );
 
   return (
     <section className={frameClassName}>
@@ -54,6 +312,8 @@ export function WorkspacePanelsPane(props: WorkspacePanelsPaneProps) {
             <div className={styles.emptyChatState}>
               <div className={styles.agentSelectorTitle}>패널 화면을 준비하는 중…</div>
             </div>
+          ) : props.chats || props.events ? (
+            workspaceBody
           ) : (
             <CreatePanelPage
               onCreatePanel={props.onCreatePanel}

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/types.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/types.ts
@@ -8,6 +8,7 @@ export const FOLDER_LABELS = ['src', 'tools', 'jobs', 'scripts', 'tests'] as con
 export type ComposerModelOption = { id: string; shortLabel: string; badge: string };
 export type GeminiModeOption = { id: string; shortLabel: string; badge: string };
 export type ModelReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+export type ComposerMode = 'agent' | 'plan' | 'terminal';
 
 export type AgentMeta = {
   label: string;
@@ -66,6 +67,7 @@ export type ChatSubmittedPayload = {
   chatId: string;
   agent: AgentFlavor;
   model: string;
+  composerMode?: ComposerMode;
   geminiMode?: string;
   modelReasoningEffort?: ModelReasoningEffort;
   threadId?: string;

--- a/services/aris-web/app/sessions/[sessionId]/chatComposer.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chatComposer.ts
@@ -9,6 +9,7 @@ type BuildOptimisticUserEventInput = {
   geminiMode?: string | null;
   modelReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh' | null;
   attachments?: ChatImageAttachment[];
+  mode?: 'agent' | 'plan' | 'terminal';
 };
 
 export function buildOptimisticUserEvent(input: BuildOptimisticUserEventInput): UiEvent {
@@ -26,6 +27,7 @@ export function buildOptimisticUserEvent(input: BuildOptimisticUserEventInput): 
       ...(input.geminiMode ? { geminiMode: input.geminiMode } : {}),
       ...(input.modelReasoningEffort ? { modelReasoningEffort: input.modelReasoningEffort } : {}),
       ...(input.attachments?.length ? { attachments: input.attachments } : {}),
+      ...(input.mode ? { composerMode: input.mode } : {}),
     },
   };
 }

--- a/services/aris-web/app/sessions/[sessionId]/chatSubmitPayload.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chatSubmitPayload.ts
@@ -2,6 +2,7 @@ import { buildImageAttachmentPromptPrefix, readChatImageAttachments } from '@/li
 import type { AgentFlavor, ChatImageAttachment, UiEvent } from '@/lib/happy/types';
 
 type ModelReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+type ComposerMode = 'agent' | 'plan' | 'terminal';
 
 export type ComposerContextBlock =
   | { type: 'file'; path: string; content: string }
@@ -27,6 +28,7 @@ export function buildUserMessageMeta(input: {
   chatId: string;
   agent: AgentFlavor;
   model: string;
+  composerMode?: ComposerMode;
   geminiMode?: string;
   modelReasoningEffort?: ModelReasoningEffort;
   threadId?: string;
@@ -37,6 +39,7 @@ export function buildUserMessageMeta(input: {
     chatId: input.chatId,
     agent: input.agent,
     model: input.model,
+    ...(input.composerMode ? { composerMode: input.composerMode } : {}),
     ...(input.geminiMode ? { geminiMode: input.geminiMode } : {}),
     ...(input.modelReasoningEffort
       ? {

--- a/services/aris-web/app/sessions/[sessionId]/workspace-panels/WorkspacePager.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/workspace-panels/WorkspacePager.tsx
@@ -17,6 +17,7 @@ type WorkspacePagerProps = {
   onActivePageChange?: (pageId: string) => void;
   renderChatPage: () => ReactNode;
   renderCreatePage: () => ReactNode;
+  renderWorkspacePage?: (item: Extract<WorkspacePagerItem, { kind: 'workspace' }>) => ReactNode;
   renderPanelPage: (item: Extract<WorkspacePagerItem, { kind: 'panel' }>) => ReactNode;
 };
 
@@ -26,6 +27,7 @@ export function WorkspacePager({
   onActivePageChange,
   renderChatPage,
   renderCreatePage,
+  renderWorkspacePage,
   renderPanelPage,
 }: WorkspacePagerProps) {
   const pagerRef = useRef<HTMLDivElement | null>(null);
@@ -252,6 +254,8 @@ export function WorkspacePager({
           >
             {item.kind === 'chat'
               ? renderChatPage()
+              : item.kind === 'workspace'
+                ? renderWorkspacePage?.(item) ?? renderCreatePage()
               : item.kind === 'create-panel'
                 ? renderCreatePage()
                 : renderPanelPage(item)}

--- a/services/aris-web/app/sessions/[sessionId]/workspace-panels/pagerModel.ts
+++ b/services/aris-web/app/sessions/[sessionId]/workspace-panels/pagerModel.ts
@@ -2,18 +2,15 @@ import type { WorkspacePanelLayout } from '@/lib/workspacePanels/types';
 
 export type WorkspacePagerItem =
   | { id: 'chat'; kind: 'chat' }
+  | { id: 'workspace'; kind: 'workspace' }
   | { id: 'create-panel'; kind: 'create-panel' }
   | { id: string; kind: 'panel'; panelId: string };
 
 export function buildWorkspacePagerItems(layout: WorkspacePanelLayout): WorkspacePagerItem[] {
+  void layout;
   return [
     { id: 'chat', kind: 'chat' },
-    ...layout.panels.map((panel) => ({
-      id: panel.id,
-      kind: 'panel' as const,
-      panelId: panel.id,
-    })),
-    { id: 'create-panel', kind: 'create-panel' },
+    { id: 'workspace', kind: 'workspace' },
   ];
 }
 

--- a/services/aris-web/app/styles/reset.css
+++ b/services/aris-web/app/styles/reset.css
@@ -1,8 +1,17 @@
 /* Reset & Base Styles */
-* {
+*, *::before, *::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
+}
+
+html {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 html, body {
@@ -11,11 +20,9 @@ html, body {
   min-height: -webkit-fill-available;
   background-color: var(--bg);
   color: var(--text);
-  font-family: var(--font-sans);
-  font-size: 16px;
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  font-size: var(--text-body, 14px);
+  line-height: 1.5;
+  letter-spacing: var(--ls-normal, normal);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   overflow-x: hidden;
@@ -35,4 +42,12 @@ button, input, textarea, select {
   color: inherit;
   background: none;
   border: none;
+}
+
+button {
+  cursor: pointer;
+}
+
+code, kbd, samp, pre {
+  font-family: var(--font-mono);
 }

--- a/services/aris-web/app/styles/tokens.css
+++ b/services/aris-web/app/styles/tokens.css
@@ -1,88 +1,233 @@
 :root {
   color-scheme: light;
-  /* Color Palette - Premium & Vibrant */
-  --bg: #f8fafc;
+
+  /* Neutral scale - design-system-v1 cool gray */
+  --n-0: #ffffff;
+  --n-50: #f7f8fa;
+  --n-100: #eef0f4;
+  --n-150: #e4e7ed;
+  --n-200: #d7dce3;
+  --n-300: #bcc2cb;
+  --n-400: #8e95a1;
+  --n-500: #666c77;
+  --n-600: #4a4f58;
+  --n-700: #323640;
+  --n-800: #1d2028;
+  --n-900: #0f1117;
+  --n-950: #07080c;
+
+  /* Brand scale - Refined Blue */
+  --b-50: #edf3ff;
+  --b-100: #dbe5ff;
+  --b-200: #b8caff;
+  --b-300: #8da7ff;
+  --b-400: #5e82fd;
+  --b-500: #2f6bff;
+  --b-600: #1e50db;
+  --b-700: #173fae;
+  --b-800: #13338a;
+  --b-900: #0f276a;
+  --b-950: #08173f;
+
+  /* Mode colors */
+  --mode-agent: var(--b-500);
+  --mode-agent-fg: var(--b-600);
+  --mode-agent-bg: var(--b-50);
+  --mode-agent-dim: var(--b-100);
+  --mode-agent-border: var(--b-200);
+  --mode-agent-focus: rgba(47, 107, 255, 0.18);
+
+  --mode-plan: #8b5cf6;
+  --mode-plan-fg: #6d28d9;
+  --mode-plan-bg: #f3ebff;
+  --mode-plan-dim: #e5d3ff;
+  --mode-plan-border: #d4b9ff;
+  --mode-plan-focus: rgba(139, 92, 246, 0.2);
+
+  --mode-terminal: #10b981;
+  --mode-terminal-fg: #047857;
+  --mode-terminal-bg: #e7f7ee;
+  --mode-terminal-dim: #cfeedd;
+  --mode-terminal-border: #b6e5c6;
+  --mode-terminal-focus: rgba(16, 185, 129, 0.22);
+
+  /* Semantic color pairs */
+  --success-bg: #e7f7ee;
+  --success-fg: #087a3a;
+  --success-border: #b6e5c6;
+  --warning-bg: #fff4e0;
+  --warning-fg: #9a5800;
+  --warning-border: #f5d69c;
+  --danger-bg: #fdecec;
+  --danger-fg: #b42318;
+  --danger-border: #f2bfbb;
+  --info-bg: var(--b-50);
+  --info-fg: var(--b-700);
+  --info-border: var(--b-200);
+
+  /* Agent accents */
+  --agent-claude: #d97757;
+  --agent-claude-bg: #fbeee6;
+  --agent-codex: #10a37f;
+  --agent-codex-bg: #e2f4ee;
+  --agent-gemini: #4285f4;
+  --agent-gemini-bg: #e4edfe;
+
+  /* Surface layers */
+  --canvas: var(--n-50);
   --surface: #ffffff;
-  --surface-subtle: #f1f5f9;
-  --surface-soft: #e2e8f0;
-  --line: #e2e8f0;
-  --line-strong: #cbd5e1;
-  
-  --text: #0f172a;
-  --text-muted: #64748b;
-  --text-on-accent: #ffffff;
+  --surface-raised: #ffffff;
+  --surface-elevated: #ffffff;
+  --surface-sunken: var(--n-100);
+  --surface-hover: var(--n-100);
+  --surface-active: var(--n-150);
+  --surface-overlay: rgba(255, 255, 255, 0.86);
 
-  /* Vibrant Colors */
-  --primary: #3b82f6;
-  --primary-hover: #2563eb;
-  
-  --accent-sky: #0ea5e9;
-  --accent-sky-bg: #e0f2fe;
-  
+  /* Text roles */
+  --text-primary: var(--n-900);
+  --text-secondary: var(--n-600);
+  --text-tertiary: var(--n-500);
+  --text-disabled: var(--n-300);
+  --text-inverse: #ffffff;
+  --text-on-brand: #ffffff;
+  --text-accent: var(--b-600);
+
+  /* Border roles */
+  --border-subtle: rgba(15, 17, 23, 0.06);
+  --border-default: rgba(15, 17, 23, 0.09);
+  --border-strong: rgba(15, 17, 23, 0.14);
+  --border-accent: var(--b-500);
+
+  /* Elevation */
+  --shadow-xs: 0 0 0 1px rgba(15, 17, 23, 0.06);
+  --shadow-sm: 0 1px 2px rgba(15, 17, 23, 0.06), 0 0 0 1px rgba(15, 17, 23, 0.05);
+  --shadow-md: 0 4px 12px -2px rgba(15, 17, 23, 0.08), 0 0 0 1px rgba(15, 17, 23, 0.05);
+  --shadow-lg: 0 12px 32px -4px rgba(15, 17, 23, 0.12), 0 2px 6px -1px rgba(15, 17, 23, 0.06), 0 0 0 1px rgba(15, 17, 23, 0.05);
+  --shadow-xl: 0 24px 48px -8px rgba(15, 17, 23, 0.16), 0 8px 16px -4px rgba(15, 17, 23, 0.08), 0 0 0 1px rgba(15, 17, 23, 0.05);
+  --shadow-focus: 0 0 0 3px rgba(47, 107, 255, 0.18);
+  --shadow-focus-danger: 0 0 0 3px rgba(239, 68, 68, 0.22);
+
+  /* Typography */
+  --font-sans: "Pretendard Variable", "Pretendard", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans KR", "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --text-display: 36px;
+  --text-h1: 28px;
+  --text-h2: 22px;
+  --text-h3: 18px;
+  --text-h4: 16px;
+  --text-body: 14px;
+  --text-sm: 13px;
+  --text-xs: 12px;
+  --text-2xs: 11px;
+  --ls-tight: -0.022em;
+  --ls-snug: -0.014em;
+  --ls-normal: -0.006em;
+  --ls-wide: 0.04em;
+
+  /* Spacing - 2px base */
+  --sp-0: 0;
+  --sp-1: 2px;
+  --sp-2: 4px;
+  --sp-3: 6px;
+  --sp-4: 8px;
+  --sp-5: 10px;
+  --sp-6: 12px;
+  --sp-8: 16px;
+  --sp-10: 20px;
+  --sp-12: 24px;
+  --sp-14: 28px;
+  --sp-16: 32px;
+  --sp-20: 40px;
+  --sp-24: 48px;
+  --sp-32: 64px;
+
+  /* Radius */
+  --r-xs: 4px;
+  --r-sm: 6px;
+  --r-md: 8px;
+  --r-lg: 10px;
+  --r-xl: 12px;
+  --r-2xl: 16px;
+  --r-full: 9999px;
+
+  /* Motion */
+  --dur-instant: 75ms;
+  --dur-fast: 120ms;
+  --dur-normal: 180ms;
+  --dur-slow: 260ms;
+  --ease-snap: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-smooth: cubic-bezier(0.65, 0, 0.35, 1);
+  --ease-spring: cubic-bezier(0.25, 1.1, 0.5, 1.1);
+  --t-fast: var(--dur-fast) var(--ease-snap);
+  --t-base: var(--dur-normal) var(--ease-snap);
+  --t-slow: var(--dur-slow) var(--ease-snap);
+
+  /* Legacy aliases kept for non-chat surfaces during the redesign. */
+  --bg: var(--canvas);
+  --surface-subtle: var(--surface-sunken);
+  --surface-soft: var(--surface-active);
+  --line: var(--border-default);
+  --line-strong: var(--border-strong);
+  --text: var(--text-primary);
+  --text-muted: var(--text-secondary);
+  --text-subtle: var(--text-tertiary);
+  --text-on-accent: var(--text-on-brand);
+  --primary: var(--b-500);
+  --primary-hover: var(--b-600);
+  --primary-soft: var(--b-50);
+  --primary-border: var(--b-200);
+
+  --accent-sky: var(--b-500);
+  --accent-sky-bg: var(--b-50);
   --accent-amber: #f59e0b;
-  --accent-amber-bg: #fef3c7;
-  
-  --accent-violet: #8b5cf6;
-  --accent-violet-bg: #ede9fe;
-  
-  --accent-emerald: #10b981;
-  --accent-emerald-bg: #d1fae5;
-
-  --accent-slate: #64748b;
-  --accent-slate-bg: #e2e8f0;
-  
+  --accent-amber-bg: var(--warning-bg);
+  --accent-violet: var(--mode-plan);
+  --accent-violet-bg: var(--mode-plan-bg);
+  --accent-emerald: var(--mode-terminal);
+  --accent-emerald-bg: var(--mode-terminal-bg);
+  --accent-slate: var(--n-500);
+  --accent-slate-bg: var(--n-150);
   --accent-red: #ef4444;
-  --accent-red-bg: #fee2e2;
+  --accent-red-bg: var(--danger-bg);
   --accent-git: #a0361d;
   --accent-git-bg: rgba(240, 80, 50, 0.2);
   --accent-docker: #0a4f82;
   --accent-docker-bg: rgba(36, 150, 237, 0.2);
 
-  --chart-track: #e2e8f0;
-  --chart-status-running: #3b82f6;
-  --chart-status-pending: #f59e0b;
-  --chart-status-completed: #10b981;
-  --chart-status-idle: #64748b;
-  --agent-claude-accent: #d97757;
-  --agent-claude-bg: rgba(217, 119, 87, 0.15);
-  --agent-codex-accent: #10a37f;
-  --agent-codex-bg: rgba(16, 163, 127, 0.15);
-  --agent-gemini-accent: #4285f4;
-  --agent-gemini-bg: rgba(66, 133, 244, 0.15);
-  --approval-on-request-color: #3b82f6;
-  --approval-on-failure-color: #f59e0b;
-  --approval-never-color: #10b981;
-  --approval-yolo-color: #ef4444;
+  --agent-claude-accent: var(--agent-claude);
+  --agent-codex-accent: var(--agent-codex);
+  --agent-gemini-accent: var(--agent-gemini);
 
-  --bottom-nav-bg: rgba(255, 255, 255, 0.68);
-  --bottom-nav-border: rgba(255, 255, 255, 0.55);
-  --bottom-nav-inset-border: rgba(255, 255, 255, 0.38);
-  --bottom-nav-shadow: 0 0 8px rgba(15, 23, 42, 0.08);
-  --bottom-nav-indicator-bg: #ffffff;
-  --bottom-nav-indicator-border: rgba(226, 232, 240, 0.95);
-  --bottom-nav-indicator-shadow: 0 2px 8px rgba(15, 23, 42, 0.08), 0 1px 2px rgba(15, 23, 42, 0.05);
+  --approval-on-request-color: var(--b-500);
+  --approval-on-failure-color: var(--warning-fg);
+  --approval-never-color: var(--success-fg);
+  --approval-yolo-color: var(--danger-fg);
 
-  /* Gradients */
-  --gradient-primary: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
-  --gradient-surface: linear-gradient(180deg, rgba(255,255,255,0.9) 0%, rgba(255,255,255,0.4) 100%);
-  --modal-header-bg: linear-gradient(135deg, #f8faff 0%, #f0f4ff 100%);
-  --overlay-backdrop: rgba(15, 23, 42, 0.55);
-  --elevated-shadow: 0 24px 48px -8px rgba(15, 23, 42, 0.18), 0 8px 16px -4px rgba(15, 23, 42, 0.1);
+  --chart-track: var(--n-150);
+  --chart-status-running: var(--b-500);
+  --chart-status-pending: var(--warning-fg);
+  --chart-status-completed: var(--success-fg);
+  --chart-status-idle: var(--n-500);
 
-  /* Typography */
-  --font-sans: "Pretendard", "Inter", "Noto Sans KR", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --radius-sm: var(--r-sm);
+  --radius-md: var(--r-xl);
+  --radius-lg: var(--r-2xl);
+  --radius-full: var(--r-full);
 
-  /* Layout & Spacing */
-  --radius-sm: 0.5rem;
-  --radius-md: 0.75rem;
-  --radius-lg: 1rem;
-  --radius-full: 9999px;
-  
-  --shadow-sm: 0 1px 3px 0 rgba(15, 23, 42, 0.05);
-  --shadow-md: 0 4px 6px -1px rgba(15, 23, 42, 0.05), 0 2px 4px -2px rgba(15, 23, 42, 0.05);
-  --shadow-lg: 0 10px 15px -3px rgba(15, 23, 42, 0.08), 0 4px 6px -4px rgba(15, 23, 42, 0.04);
-  
+  --gradient-primary: linear-gradient(135deg, var(--b-500) 0%, var(--mode-plan) 100%);
+  --gradient-surface: linear-gradient(180deg, rgba(255, 255, 255, 0.94) 0%, rgba(255, 255, 255, 0.64) 100%);
+  --modal-header-bg: linear-gradient(135deg, var(--b-50) 0%, #f8faff 100%);
+  --overlay-backdrop: rgba(15, 17, 23, 0.55);
+  --elevated-shadow: var(--shadow-xl);
+
+  --bottom-nav-bg: rgba(255, 255, 255, 0.78);
+  --bottom-nav-border: rgba(15, 17, 23, 0.08);
+  --bottom-nav-inset-border: rgba(255, 255, 255, 0.44);
+  --bottom-nav-shadow: 0 8px 24px rgba(15, 17, 23, 0.08);
+  --bottom-nav-indicator-bg: var(--surface);
+  --bottom-nav-indicator-border: var(--border-default);
+  --bottom-nav-indicator-shadow: var(--shadow-sm);
+
   --max-width: 1400px;
   --vh: 1vh;
   --app-vh: 100vh;
@@ -94,136 +239,164 @@
 
 html[data-theme='dark'] {
   color-scheme: dark;
-  --bg: #0b1220;
-  --surface: #111a2a;
-  --surface-subtle: #0f172a;
-  --surface-soft: #1e293b;
-  --line: #2a364b;
-  --line-strong: #3a4b66;
+  --b-50: #112358;
+  --b-100: #15327f;
+  --b-200: #1e50db;
 
-  --text: #e5edf7;
-  --text-muted: #9fb0c7;
-  --text-on-accent: #eff6ff;
+  --mode-agent-bg: #112358;
+  --mode-agent-dim: #15327f;
+  --mode-agent-border: rgba(47, 107, 255, 0.36);
+  --mode-plan-bg: #1f1a3d;
+  --mode-plan-dim: #2c2560;
+  --mode-plan-border: rgba(139, 92, 246, 0.36);
+  --mode-terminal-bg: #0d2f20;
+  --mode-terminal-dim: #104835;
+  --mode-terminal-border: rgba(16, 185, 129, 0.3);
 
-  --primary: #60a5fa;
-  --primary-hover: #3b82f6;
+  --success-bg: rgba(16, 185, 129, 0.12);
+  --success-fg: #3fdd9b;
+  --success-border: rgba(16, 185, 129, 0.3);
+  --warning-bg: rgba(245, 158, 11, 0.12);
+  --warning-fg: #f9b969;
+  --warning-border: rgba(245, 158, 11, 0.3);
+  --danger-bg: rgba(239, 68, 68, 0.12);
+  --danger-fg: #f38484;
+  --danger-border: rgba(239, 68, 68, 0.32);
+  --info-bg: rgba(47, 107, 255, 0.14);
+  --info-fg: #9eb7ff;
+  --info-border: rgba(47, 107, 255, 0.36);
 
-  --accent-sky: #38bdf8;
-  --accent-sky-bg: rgba(14, 165, 233, 0.2);
+  --agent-claude-bg: #2a1a12;
+  --agent-codex-bg: #0f2a22;
+  --agent-gemini-bg: #14244a;
 
-  --accent-amber: #fbbf24;
-  --accent-amber-bg: rgba(245, 158, 11, 0.2);
+  --canvas: #08090c;
+  --surface: #0e1015;
+  --surface-raised: #1c2029;
+  --surface-elevated: #14161d;
+  --surface-sunken: #0b0d12;
+  --surface-hover: #17191f;
+  --surface-active: #1d2029;
+  --surface-overlay: rgba(14, 16, 21, 0.82);
 
-  --accent-violet: #a78bfa;
-  --accent-violet-bg: rgba(139, 92, 246, 0.22);
+  --text-primary: #f0f1f4;
+  --text-secondary: #afb4be;
+  --text-tertiary: #7d828e;
+  --text-disabled: #4b4f58;
+  --text-inverse: #0f1117;
+  --text-on-brand: #ffffff;
+  --text-accent: #9eb7ff;
 
-  --accent-emerald: #34d399;
-  --accent-emerald-bg: rgba(16, 185, 129, 0.22);
+  --border-subtle: rgba(255, 255, 255, 0.06);
+  --border-default: rgba(255, 255, 255, 0.09);
+  --border-strong: rgba(255, 255, 255, 0.14);
 
-  --accent-slate: #94a3b8;
-  --accent-slate-bg: rgba(148, 163, 184, 0.22);
+  --shadow-xs: 0 0 0 1px rgba(255, 255, 255, 0.06);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.05);
+  --shadow-md: 0 4px 12px -2px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.05);
+  --shadow-lg: 0 12px 32px -4px rgba(0, 0, 0, 0.6), 0 2px 6px -1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.06);
+  --shadow-xl: 0 24px 48px -8px rgba(0, 0, 0, 0.7), 0 8px 16px -4px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.06);
+  --shadow-focus: 0 0 0 3px rgba(47, 107, 255, 0.28);
+  --shadow-focus-danger: 0 0 0 3px rgba(239, 68, 68, 0.32);
 
-  --accent-red: #f87171;
-  --accent-red-bg: rgba(239, 68, 68, 0.22);
+  --accent-amber: #f9b969;
+  --accent-slate: #8e95a1;
+  --accent-slate-bg: rgba(142, 149, 161, 0.18);
+  --accent-red: #f38484;
   --accent-git: #ff8d6c;
   --accent-git-bg: rgba(240, 80, 50, 0.26);
   --accent-docker: #7cc5ff;
   --accent-docker-bg: rgba(36, 150, 237, 0.26);
 
-  --chart-track: #334155;
-  --chart-status-running: #60a5fa;
-  --chart-status-pending: #fbbf24;
-  --chart-status-completed: #34d399;
-  --chart-status-idle: #94a3b8;
-  --agent-claude-accent: #f59e73;
-  --agent-claude-bg: rgba(245, 158, 115, 0.22);
-  --agent-codex-accent: #34d399;
-  --agent-codex-bg: rgba(52, 211, 153, 0.22);
-  --agent-gemini-accent: #60a5fa;
-  --agent-gemini-bg: rgba(96, 165, 250, 0.22);
-  --approval-on-request-color: #60a5fa;
-  --approval-on-failure-color: #fbbf24;
-  --approval-never-color: #34d399;
-  --approval-yolo-color: #f87171;
+  --chart-track: #323640;
+  --bottom-nav-bg: rgba(14, 16, 21, 0.78);
+  --bottom-nav-border: rgba(255, 255, 255, 0.09);
+  --bottom-nav-inset-border: rgba(255, 255, 255, 0.08);
+  --bottom-nav-shadow: 0 10px 28px rgba(0, 0, 0, 0.42);
+  --bottom-nav-indicator-bg: var(--surface-raised);
+  --bottom-nav-indicator-border: rgba(47, 107, 255, 0.32);
+  --bottom-nav-indicator-shadow: var(--shadow-md);
 
-  --bottom-nav-bg: rgba(15, 23, 42, 0.72);
-  --bottom-nav-border: rgba(71, 85, 105, 0.55);
-  --bottom-nav-inset-border: rgba(148, 163, 184, 0.12);
-  --bottom-nav-shadow: 0 6px 14px rgba(2, 6, 23, 0.38);
-  --bottom-nav-indicator-bg: rgba(30, 41, 59, 0.96);
-  --bottom-nav-indicator-border: rgba(96, 165, 250, 0.42);
-  --bottom-nav-indicator-shadow: 0 4px 12px rgba(2, 6, 23, 0.45), 0 1px 2px rgba(2, 6, 23, 0.35);
-
-  --gradient-primary: linear-gradient(135deg, #3b82f6 0%, #6366f1 100%);
-  --gradient-surface: linear-gradient(180deg, rgba(17, 26, 42, 0.95) 0%, rgba(17, 26, 42, 0.78) 100%);
-  --modal-header-bg: linear-gradient(135deg, rgba(23, 37, 84, 0.55) 0%, rgba(30, 41, 59, 0.9) 100%);
-  --overlay-backdrop: rgba(2, 6, 23, 0.72);
-  --elevated-shadow: 0 24px 48px -8px rgba(2, 6, 23, 0.58), 0 8px 16px -4px rgba(2, 6, 23, 0.46);
-
-  --shadow-sm: 0 1px 3px 0 rgba(2, 6, 23, 0.45);
-  --shadow-md: 0 4px 10px -2px rgba(2, 6, 23, 0.5);
-  --shadow-lg: 0 12px 28px -8px rgba(2, 6, 23, 0.55);
+  --gradient-primary: linear-gradient(135deg, #2f6bff 0%, #7c3aed 100%);
+  --gradient-surface: linear-gradient(180deg, rgba(28, 32, 41, 0.94) 0%, rgba(14, 16, 21, 0.78) 100%);
+  --modal-header-bg: linear-gradient(135deg, rgba(47, 107, 255, 0.16) 0%, rgba(28, 32, 41, 0.92) 100%);
+  --overlay-backdrop: rgba(0, 0, 0, 0.68);
 }
 
 @media (prefers-color-scheme: dark) {
   html:not([data-theme='light']):not([data-theme='dark']) {
     color-scheme: dark;
-    --bg: #0b1220;
-    --surface: #111a2a;
-    --surface-subtle: #0f172a;
-    --surface-soft: #1e293b;
-    --line: #2a364b;
-    --line-strong: #3a4b66;
-    --text: #e5edf7;
-    --text-muted: #9fb0c7;
-    --text-on-accent: #eff6ff;
-    --primary: #60a5fa;
-    --primary-hover: #3b82f6;
-    --accent-sky: #38bdf8;
-    --accent-sky-bg: rgba(14, 165, 233, 0.2);
-    --accent-amber: #fbbf24;
-    --accent-amber-bg: rgba(245, 158, 11, 0.2);
-    --accent-violet: #a78bfa;
-    --accent-violet-bg: rgba(139, 92, 246, 0.22);
-    --accent-emerald: #34d399;
-    --accent-emerald-bg: rgba(16, 185, 129, 0.22);
-    --accent-slate: #94a3b8;
-    --accent-slate-bg: rgba(148, 163, 184, 0.22);
-    --accent-red: #f87171;
-    --accent-red-bg: rgba(239, 68, 68, 0.22);
+    --b-50: #112358;
+    --b-100: #15327f;
+    --b-200: #1e50db;
+    --mode-agent-bg: #112358;
+    --mode-agent-dim: #15327f;
+    --mode-agent-border: rgba(47, 107, 255, 0.36);
+    --mode-plan-bg: #1f1a3d;
+    --mode-plan-dim: #2c2560;
+    --mode-plan-border: rgba(139, 92, 246, 0.36);
+    --mode-terminal-bg: #0d2f20;
+    --mode-terminal-dim: #104835;
+    --mode-terminal-border: rgba(16, 185, 129, 0.3);
+    --success-bg: rgba(16, 185, 129, 0.12);
+    --success-fg: #3fdd9b;
+    --success-border: rgba(16, 185, 129, 0.3);
+    --warning-bg: rgba(245, 158, 11, 0.12);
+    --warning-fg: #f9b969;
+    --warning-border: rgba(245, 158, 11, 0.3);
+    --danger-bg: rgba(239, 68, 68, 0.12);
+    --danger-fg: #f38484;
+    --danger-border: rgba(239, 68, 68, 0.32);
+    --info-bg: rgba(47, 107, 255, 0.14);
+    --info-fg: #9eb7ff;
+    --info-border: rgba(47, 107, 255, 0.36);
+    --agent-claude-bg: #2a1a12;
+    --agent-codex-bg: #0f2a22;
+    --agent-gemini-bg: #14244a;
+    --canvas: #08090c;
+    --surface: #0e1015;
+    --surface-raised: #1c2029;
+    --surface-elevated: #14161d;
+    --surface-sunken: #0b0d12;
+    --surface-hover: #17191f;
+    --surface-active: #1d2029;
+    --surface-overlay: rgba(14, 16, 21, 0.82);
+    --text-primary: #f0f1f4;
+    --text-secondary: #afb4be;
+    --text-tertiary: #7d828e;
+    --text-disabled: #4b4f58;
+    --text-inverse: #0f1117;
+    --text-on-brand: #ffffff;
+    --text-accent: #9eb7ff;
+    --border-subtle: rgba(255, 255, 255, 0.06);
+    --border-default: rgba(255, 255, 255, 0.09);
+    --border-strong: rgba(255, 255, 255, 0.14);
+    --shadow-xs: 0 0 0 1px rgba(255, 255, 255, 0.06);
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.05);
+    --shadow-md: 0 4px 12px -2px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.05);
+    --shadow-lg: 0 12px 32px -4px rgba(0, 0, 0, 0.6), 0 2px 6px -1px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.06);
+    --shadow-xl: 0 24px 48px -8px rgba(0, 0, 0, 0.7), 0 8px 16px -4px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.06);
+    --shadow-focus: 0 0 0 3px rgba(47, 107, 255, 0.28);
+    --shadow-focus-danger: 0 0 0 3px rgba(239, 68, 68, 0.32);
+    --accent-amber: #f9b969;
+    --accent-slate: #8e95a1;
+    --accent-slate-bg: rgba(142, 149, 161, 0.18);
+    --accent-red: #f38484;
     --accent-git: #ff8d6c;
     --accent-git-bg: rgba(240, 80, 50, 0.26);
     --accent-docker: #7cc5ff;
     --accent-docker-bg: rgba(36, 150, 237, 0.26);
-    --chart-track: #334155;
-    --chart-status-running: #60a5fa;
-    --chart-status-pending: #fbbf24;
-    --chart-status-completed: #34d399;
-    --chart-status-idle: #94a3b8;
-    --agent-claude-accent: #f59e73;
-    --agent-claude-bg: rgba(245, 158, 115, 0.22);
-    --agent-codex-accent: #34d399;
-    --agent-codex-bg: rgba(52, 211, 153, 0.22);
-    --agent-gemini-accent: #60a5fa;
-    --agent-gemini-bg: rgba(96, 165, 250, 0.22);
-    --approval-on-request-color: #60a5fa;
-    --approval-on-failure-color: #fbbf24;
-    --approval-never-color: #34d399;
-    --approval-yolo-color: #f87171;
-    --bottom-nav-bg: rgba(15, 23, 42, 0.72);
-    --bottom-nav-border: rgba(71, 85, 105, 0.55);
-    --bottom-nav-inset-border: rgba(148, 163, 184, 0.12);
-    --bottom-nav-shadow: 0 6px 14px rgba(2, 6, 23, 0.38);
-    --bottom-nav-indicator-bg: rgba(30, 41, 59, 0.96);
-    --bottom-nav-indicator-border: rgba(96, 165, 250, 0.42);
-    --bottom-nav-indicator-shadow: 0 4px 12px rgba(2, 6, 23, 0.45), 0 1px 2px rgba(2, 6, 23, 0.35);
-    --gradient-primary: linear-gradient(135deg, #3b82f6 0%, #6366f1 100%);
-    --gradient-surface: linear-gradient(180deg, rgba(17, 26, 42, 0.95) 0%, rgba(17, 26, 42, 0.78) 100%);
-    --modal-header-bg: linear-gradient(135deg, rgba(23, 37, 84, 0.55) 0%, rgba(30, 41, 59, 0.9) 100%);
-    --overlay-backdrop: rgba(2, 6, 23, 0.72);
-    --elevated-shadow: 0 24px 48px -8px rgba(2, 6, 23, 0.58), 0 8px 16px -4px rgba(2, 6, 23, 0.46);
-    --shadow-sm: 0 1px 3px 0 rgba(2, 6, 23, 0.45);
-    --shadow-md: 0 4px 10px -2px rgba(2, 6, 23, 0.5);
-    --shadow-lg: 0 12px 28px -8px rgba(2, 6, 23, 0.55);
+    --chart-track: #323640;
+    --bottom-nav-bg: rgba(14, 16, 21, 0.78);
+    --bottom-nav-border: rgba(255, 255, 255, 0.09);
+    --bottom-nav-inset-border: rgba(255, 255, 255, 0.08);
+    --bottom-nav-shadow: 0 10px 28px rgba(0, 0, 0, 0.42);
+    --bottom-nav-indicator-bg: var(--surface-raised);
+    --bottom-nav-indicator-border: rgba(47, 107, 255, 0.32);
+    --bottom-nav-indicator-shadow: var(--shadow-md);
+    --gradient-primary: linear-gradient(135deg, #2f6bff 0%, #7c3aed 100%);
+    --gradient-surface: linear-gradient(180deg, rgba(28, 32, 41, 0.94) 0%, rgba(14, 16, 21, 0.78) 100%);
+    --modal-header-bg: linear-gradient(135deg, rgba(47, 107, 255, 0.16) 0%, rgba(28, 32, 41, 0.92) 100%);
+    --overlay-backdrop: rgba(0, 0, 0, 0.68);
   }
 }

--- a/services/aris-web/tests/workspacePager.test.ts
+++ b/services/aris-web/tests/workspacePager.test.ts
@@ -5,6 +5,7 @@ import type { WorkspacePanelLayout } from '@/lib/workspacePanels/types';
 
 type PagerItem =
   | { id: 'chat'; kind: 'chat' }
+  | { id: 'workspace'; kind: 'workspace' }
   | { id: 'create-panel'; kind: 'create-panel' }
   | { id: string; kind: 'panel'; panelId: string };
 
@@ -19,6 +20,7 @@ type PagerComponentModule = {
     activePageId: string;
     renderChatPage: () => React.ReactNode;
     renderCreatePage: () => React.ReactNode;
+    renderWorkspacePage?: (item: Extract<PagerItem, { kind: 'workspace' }>) => React.ReactNode;
     renderPanelPage: (item: Extract<PagerItem, { kind: 'panel' }>) => React.ReactNode;
   }) => React.ReactNode;
 };
@@ -45,7 +47,7 @@ async function loadPagerGestureModule(): Promise<PagerGestureModule> {
 }
 
 describe('workspace pager model', () => {
-  it('derives chat first and create-panel last when no panels exist', async () => {
+  it('derives chat first and the single workspace page second', async () => {
     const mod = await loadPagerModelModule();
 
     expect(typeof mod.buildWorkspacePagerItems).toBe('function');
@@ -57,11 +59,11 @@ describe('workspace pager model', () => {
       panels: [],
     })).toEqual([
       { id: 'chat', kind: 'chat' },
-      { id: 'create-panel', kind: 'create-panel' },
+      { id: 'workspace', kind: 'workspace' },
     ]);
   });
 
-  it('navigates between chat, existing panels, and the create-panel page', async () => {
+  it('navigates between chat and the single workspace page', async () => {
     const mod = await loadPagerModelModule();
 
     expect(typeof mod.buildWorkspacePagerItems).toBe('function');
@@ -84,15 +86,14 @@ describe('workspace pager model', () => {
 
     expect(items).toEqual([
       { id: 'chat', kind: 'chat' },
-      { id: 'panel-preview-1', kind: 'panel', panelId: 'panel-preview-1' },
-      { id: 'create-panel', kind: 'create-panel' },
+      { id: 'workspace', kind: 'workspace' },
     ]);
-    expect(mod.moveWorkspacePager(items, 'chat', 'next')).toBe('panel-preview-1');
-    expect(mod.moveWorkspacePager(items, 'panel-preview-1', 'previous')).toBe('chat');
-    expect(mod.moveWorkspacePager(items, 'panel-preview-1', 'next')).toBe('create-panel');
+    expect(mod.moveWorkspacePager(items, 'chat', 'next')).toBe('workspace');
+    expect(mod.moveWorkspacePager(items, 'workspace', 'previous')).toBe('chat');
+    expect(mod.moveWorkspacePager(items, 'workspace', 'next')).toBe('workspace');
   });
 
-  it('renders chat, panel, and create-panel pages in order', async () => {
+  it('renders chat and workspace pages in order', async () => {
     const mod = await loadPagerComponentModule();
 
     expect(typeof mod.WorkspacePager).toBe('function');
@@ -101,20 +102,18 @@ describe('workspace pager model', () => {
     const markup = renderToStaticMarkup(createElement(mod.WorkspacePager, {
       items: [
         { id: 'chat', kind: 'chat' },
-        { id: 'panel-preview-1', kind: 'panel', panelId: 'panel-preview-1' },
-        { id: 'create-panel', kind: 'create-panel' },
+        { id: 'workspace', kind: 'workspace' },
       ],
       activePageId: 'chat',
       renderChatPage: () => createElement('div', null, 'Chat Page'),
       renderCreatePage: () => createElement('div', null, 'Create Panel'),
+      renderWorkspacePage: () => createElement('div', null, 'Workspace Page'),
       renderPanelPage: () => createElement('div', null, 'Preview Page'),
     }));
 
     expect(markup).toContain('Chat Page');
-    expect(markup).toContain('Preview Page');
-    expect(markup).toContain('Create Panel');
-    expect(markup.indexOf('Chat Page')).toBeLessThan(markup.indexOf('Preview Page'));
-    expect(markup.indexOf('Preview Page')).toBeLessThan(markup.indexOf('Create Panel'));
+    expect(markup).toContain('Workspace Page');
+    expect(markup.indexOf('Chat Page')).toBeLessThan(markup.indexOf('Workspace Page'));
   });
 
   it('changes page only when the swipe crosses the threshold', async () => {
@@ -125,13 +124,12 @@ describe('workspace pager model', () => {
 
     const items: PagerItem[] = [
       { id: 'chat', kind: 'chat' },
-      { id: 'panel-preview-1', kind: 'panel', panelId: 'panel-preview-1' },
-      { id: 'create-panel', kind: 'create-panel' },
+      { id: 'workspace', kind: 'workspace' },
     ];
 
-    expect(mod.resolveWorkspacePagerSwipeTarget(items, 'chat', -80, 60)).toBe('panel-preview-1');
-    expect(mod.resolveWorkspacePagerSwipeTarget(items, 'panel-preview-1', 80, 60)).toBe('chat');
-    expect(mod.resolveWorkspacePagerSwipeTarget(items, 'panel-preview-1', -59, 60)).toBe('panel-preview-1');
-    expect(mod.resolveWorkspacePagerSwipeTarget(items, 'create-panel', -120, 60)).toBe('create-panel');
+    expect(mod.resolveWorkspacePagerSwipeTarget(items, 'chat', -80, 60)).toBe('workspace');
+    expect(mod.resolveWorkspacePagerSwipeTarget(items, 'workspace', 80, 60)).toBe('chat');
+    expect(mod.resolveWorkspacePagerSwipeTarget(items, 'workspace', -59, 60)).toBe('workspace');
+    expect(mod.resolveWorkspacePagerSwipeTarget(items, 'workspace', -120, 60)).toBe('workspace');
   });
 });


### PR DESCRIPTION
## 요약

채팅 리디자인 계획을 같은 worktree/브랜치에서 Phase 0부터 Phase 5까지 이어서 구현했습니다.

포함 범위:
- design-system-v1 기반 토큰 정렬 및 기존 토큰 alias 유지
- Chat header 52px 비주얼, workspace/preview 액션, status/meta 정렬
- Timeline day divider, inline artifact preview chip, message highlight pulse
- Composer v2 mode toggle(Agent/Plan/Terminal), mode-colored focus/send visual, reasoning effort chips
- Plan mode prompt/backend metadata 연결
- Terminal mode 전용 route와 command_execution timeline event 연결
- 우측 workspace를 preview/explorer/terminal/bookmark 페이지 모델에서 단일 Workspace + Run/Files/Terminal/Context 4탭으로 전환
- Preview dock/overlay 3-state, Esc dock, Cmd/Ctrl+Shift+P toggle, overlay focus trap
- 접근성 aria label/pressed/tab/dialog 및 reduced-motion 보강
- `docs/design/composer-modes-spec.md` 추가

보존 범위:
- `chat-screen/left-sidebar/*`는 수정하지 않았습니다.

## 검증

통과:
- `git diff --check`
- `npm run lint`
- `./node_modules/.bin/tsc --noEmit`
- `npm test -- mobileOverflowLayout.test.ts workspacePager.test.ts chatComposerView.test.ts chatTimeline.test.ts chatSubmitPayload.test.ts sessionEventsRoute.test.ts workspacePanelCreation.test.ts usageProbeTerminal.test.ts`

전체 테스트:
- `npm test`는 기존 추적 중인 `tests/linkPreviewCarouselLayout.test.ts` 2건만 실패합니다.
- 결과: `85 passed / 1 failed` test files, `388 passed / 2 failed` tests
- 기존 이슈 #214에 이번 결과를 댓글로 남겼습니다.

## 후속 이슈

- #256 Terminal 모드 위험 명령 승인 플로우 보강
