### PR TITLE
Project overview에 Recent chats 표시

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -373,25 +373,44 @@ function createChatPreview(session: SessionSummary): string {
 function ProjectRecentChatRows({
   className = '',
   emptyCopy = '아직 채팅 내역이 없습니다.',
+  onChatOpen,
   session,
 }: {
   className?: string;
   emptyCopy?: string;
+  onChatOpen?: (chatId: string) => void;
   session: SessionSummary;
 }) {
   const chats = (session.recentChats ?? []).slice(0, 2);
 
   return (
     <div className={`home-proj__chats${className ? ` ${className}` : ''}`}>
-      {chats.length > 0 ? chats.map((chat) => (
-        <div key={chat.id} className="home-proj__chat">
-          <span className={`home-proj__chat-dot home-proj__chat-dot--${chatDotStatusClass(chat)}`} />
-          <div className="home-proj__chat-body">
-            <div className="home-proj__chat-title">{chatTitle(chat)}</div>
-            <div className="home-proj__chat-last">{chatPreviewText(chat)}</div>
+      {chats.length > 0 ? chats.map((chat) => {
+        const content = (
+          <>
+            <span className={`home-proj__chat-dot home-proj__chat-dot--${chatDotStatusClass(chat)}`} />
+            <div className="home-proj__chat-body">
+              <div className="home-proj__chat-title">{chatTitle(chat)}</div>
+              <div className="home-proj__chat-last">{chatPreviewText(chat)}</div>
+            </div>
+          </>
+        );
+
+        return onChatOpen ? (
+          <button
+            key={chat.id}
+            type="button"
+            className="home-proj__chat home-proj__chat--button"
+            onClick={() => onChatOpen(chat.id)}
+          >
+            {content}
+          </button>
+        ) : (
+          <div key={chat.id} className="home-proj__chat">
+            {content}
           </div>
-        </div>
-      )) : (
+        );
+      }) : (
         <div className="home-proj__chat home-proj__chat--empty">
           <span className="home-proj__chat-dot home-proj__chat-dot--idle" />
           <div className="home-proj__chat-body">
@@ -1574,32 +1593,17 @@ function ProjectDetailSurface({
                 <span>{tokenLabel} · project scope</span>
               </div>
             </button>
-            <article className="proj-card">
+            <article className="proj-card proj-card--recent-chats">
               <div className="proj-card__title">
-                <Clock3 size={14} />
-                Recent decisions
+                <MessageSquareText size={14} />
+                Recent chats
               </div>
-              <div className="proj-item">
-                <span className="proj-item__ico proj-item__ico--done">✓</span>
-                <div className="proj-item__body">
-                  <div className="proj-item__title">최근 작업 범위를 프로젝트 단위로 고정</div>
-                  <div className="proj-item__meta">Project context · workspace scope</div>
-                </div>
-              </div>
-              <div className="proj-item">
-                <span className="proj-item__ico proj-item__ico--done">✓</span>
-                <div className="proj-item__body">
-                  <div className="proj-item__title">배포 전 런타임 헬스 체크 유지</div>
-                  <div className="proj-item__meta">deploy · health · runtime token</div>
-                </div>
-              </div>
-              <div className="proj-item">
-                <span className="proj-item__ico proj-item__ico--idle">·</span>
-                <div className="proj-item__body">
-                  <div className="proj-item__title">{projectPath}</div>
-                  <div className="proj-item__meta">workspace path</div>
-                </div>
-              </div>
+              <ProjectRecentChatRows
+                className="home-proj__chats--project-overview"
+                emptyCopy="프로젝트에서 채팅을 시작하면 최신 내역이 여기에 표시됩니다."
+                onChatOpen={onProjectChatOpen}
+                session={session}
+              />
             </article>
           </div>
 

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -1359,6 +1359,17 @@ html[data-theme='dark'] .home-proj:focus-visible {
   min-width: 0;
 }
 
+.home-proj__chat--button {
+  width: 100%;
+  text-align: left;
+  border-radius: var(--r-sm);
+  padding: 0;
+}
+
+.home-proj__chat--button:hover .home-proj__chat-title {
+  color: var(--b-500);
+}
+
 .home-proj__chat-dot {
   width: 7px;
   height: 7px;
@@ -1979,6 +1990,13 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 
 .home-proj__chats--project-list {
   margin-bottom: 0;
+}
+
+.home-proj__chats--project-overview {
+  padding-top: var(--sp-5);
+  padding-bottom: 0;
+  margin-bottom: 0;
+  border-bottom: 0;
 }
 
 .proj-list-card__foot {

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -103,6 +103,21 @@ describe('project list surface', () => {
     expect(detailSource).not.toContain('className="btn btn--primary btn--sm" onClick={() => onProjectViewChange(\'chats\')}');
   });
 
+  it('renders the project overview secondary card as real recent chats', () => {
+    const detailStart = homeClient.indexOf('function ProjectDetailSurface({');
+    const chatSurfaceStart = homeClient.indexOf('function ProjectChatSurface({');
+    const detailSource = homeClient.slice(detailStart, chatSurfaceStart);
+
+    expect(detailSource).toContain('Recent chats');
+    expect(detailSource).toContain('className="proj-card proj-card--recent-chats"');
+    expect(detailSource).toContain('<ProjectRecentChatRows');
+    expect(detailSource).toContain('onChatOpen={onProjectChatOpen}');
+    expect(detailSource).not.toContain('Recent decisions');
+    expect(detailSource).not.toContain('최근 작업 범위를 프로젝트 단위로 고정');
+    expect(detailSource).not.toContain('배포 전 런타임 헬스 체크 유지');
+    expect(detailSource).not.toContain('workspace path');
+  });
+
   it('wires the prototype chat controls to real project-chat state', () => {
     expect(homeClient).toContain("type ComposerMode = 'agent' | 'plan' | 'terminal';");
     expect(homeClient).toContain("type WorkspaceTab = 'run' | 'files' | 'terminal' | 'context';");


### PR DESCRIPTION
## 변경 사항
- Project Overview의 Recent decisions 더미 카드를 Recent chats 카드로 교체했습니다.
- 실제 session.recentChats 데이터를 재사용하고, 항목 클릭 시 해당 채팅을 열도록 연결했습니다.
- 회귀 테스트를 추가했습니다.

## 검증
- npm test -- projectListSurface.test.ts
- npm test -- homeProjects.test.ts homeSurfaceCopy.test.ts projectListSurface.test.ts
- npm exec -- tsc --noEmit
- npm run build
- git diff --check