### PR TITLE
Project 모바일 폭과 모델 provider 로고 개선

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type CSSProperties, type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import {
   Activity,
@@ -168,6 +168,12 @@ const PROVIDER_LABELS: Record<ModelProvider, string> = {
   claude: 'Claude',
   codex: 'Codex',
   gemini: 'Gemini',
+};
+
+const PROVIDER_ICON_PATHS: Record<ModelProvider, string> = {
+  claude: '/icons/claude.svg',
+  codex: '/icons/codex.svg',
+  gemini: '/icons/gemini.svg',
 };
 
 const PROVIDER_EFFORTS: Record<ModelProvider, ReasoningEffort[]> = {
@@ -1694,6 +1700,16 @@ function agentInitial(agent: SessionSummary['agent'] | SessionChat['agent']): st
   return 'A';
 }
 
+function ProviderLogo({ provider }: { provider: ModelProvider }) {
+  return (
+    <span
+      className={`provider-logo provider-logo--${provider}`}
+      aria-hidden="true"
+      style={{ '--provider-logo-url': `url(${PROVIDER_ICON_PATHS[provider]})` } as CSSProperties}
+    />
+  );
+}
+
 function isProjectActionEvent(event: UiEvent): boolean {
   if (readEventRole(event) === 'user') return false;
   if (event.action?.command || event.action?.path || event.parsed?.commands?.length) return true;
@@ -2487,7 +2503,9 @@ function ProjectChatSurface({
                   ))}
                 </div>
                 <button type="button" className="cmp-ctx" aria-label="Current model" aria-expanded={modelSelectorOpen} onClick={() => setModelSelectorOpen((current) => !current)}>
-                  <span className={`cmp-ctx__logo cmp-ctx__logo--${selectedProvider}`}>{agentInitial(activeAgent).slice(0, 1)}</span>
+                  <span className={`cmp-ctx__logo cmp-ctx__logo--${selectedProvider}`}>
+                    <ProviderLogo provider={selectedProvider} />
+                  </span>
                   <span className="cmp-ctx__name">{activeModelLabel}</span>
                   <span className="cmp-ctx__effort">{selectedEffort}</span>
                   <ChevronRight size={12} />
@@ -2517,7 +2535,7 @@ function ProjectChatSurface({
                         }
                       }}
                     >
-                      <span>{agentInitial(provider).slice(0, 1)}</span>
+                      <ProviderLogo provider={provider} />
                       <span className="ms__provider-label">{PROVIDER_LABELS[provider]}</span>
                     </button>
                   ))}

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -3419,6 +3419,27 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
   font-weight: 800;
 }
 
+.provider-logo {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+  background: currentColor;
+  -webkit-mask-image: var(--provider-logo-url);
+  mask-image: var(--provider-logo-url);
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}
+
+.pc-proto .cmp-ctx__logo .provider-logo {
+  width: 13px;
+  height: 13px;
+}
+
 .pc-proto .cmp-ctx__logo--codex,
 .pc-proto .ws__model--codex .ws__model-dot {
   background: var(--agent-codex);
@@ -3527,6 +3548,11 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 .pc-proto .ms__provider[data-provider="claude"] { background: var(--agent-claude); }
 .pc-proto .ms__provider[data-provider="codex"] { background: var(--agent-codex); }
 .pc-proto .ms__provider[data-provider="gemini"] { background: var(--agent-gemini); }
+
+.pc-proto .ms__provider .provider-logo {
+  width: 22px;
+  height: 22px;
+}
 
 .pc-proto .ms__provider:hover {
   transform: translateY(-1px);
@@ -5524,10 +5550,10 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
 
   .aris-ia-shell {
     grid-template-columns: minmax(0, 1fr);
-    width: calc(100% - var(--sp-12));
+    width: 100%;
     max-width: 100%;
     min-height: calc(var(--app-vh, 100dvh) - 96px - var(--safe-area-inset-bottom));
-    margin-inline: auto;
+    margin-inline: 0;
     overflow: hidden;
   }
 
@@ -5589,6 +5615,10 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
     padding: var(--sp-8);
   }
 
+  .m-main-scroll--project-detail {
+    padding: 0;
+  }
+
   .m-main-scroll--project-chat-detail {
     overflow: hidden;
     padding: 0;
@@ -5646,6 +5676,7 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
 
   .proj-tabs {
     max-width: 100%;
+    width: 100%;
     padding: 0 var(--sp-8);
     scrollbar-width: none;
   }

--- a/services/aris-web/tests/projectLayoutProviderLogos.test.ts
+++ b/services/aris-web/tests/projectLayoutProviderLogos.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const homeClient = readFileSync(resolve(__dirname, '../app/HomePageClient.tsx'), 'utf8');
+const uiCss = readFileSync(resolve(__dirname, '../app/styles/ui.css'), 'utf8');
+
+describe('project layout and provider logo guards', () => {
+  it('lets the mobile project shell and project tabs fill the browser width', () => {
+    expect(uiCss).toMatch(/@media \(max-width:\s*767px\)[\s\S]*?\.aris-ia-shell\s*\{[^}]*width:\s*100%;/);
+    expect(uiCss).toMatch(/@media \(max-width:\s*767px\)[\s\S]*?\.aris-ia-shell\s*\{[^}]*margin-inline:\s*0;/);
+    expect(uiCss).toMatch(/@media \(max-width:\s*767px\)[\s\S]*?\.m-main-scroll--project-detail\s*\{[^}]*padding:\s*0;/);
+    expect(uiCss).toMatch(/@media \(max-width:\s*767px\)[\s\S]*?\.proj-tabs\s*\{[^}]*width:\s*100%;/);
+  });
+
+  it('uses the real provider logo assets in the model picker', () => {
+    expect(homeClient).toContain("claude: '/icons/claude.svg'");
+    expect(homeClient).toContain("codex: '/icons/codex.svg'");
+    expect(homeClient).toContain("gemini: '/icons/gemini.svg'");
+    expect(homeClient).toContain('function ProviderLogo({');
+    expect(homeClient).toContain('<ProviderLogo provider={selectedProvider} />');
+    expect(homeClient).toContain('<ProviderLogo provider={provider} />');
+    expect(homeClient).not.toContain('<span>{agentInitial(provider).slice(0, 1)}</span>');
+
+    expect(uiCss).toContain('.provider-logo');
+    expect(uiCss).toContain('mask-image: var(--provider-logo-url);');
+  });
+});


### PR DESCRIPTION
## 변경 사항
- 모바일 Project 화면에서 IA shell을 브라우저 전체 폭으로 확장했습니다.
- Project detail scroll wrapper의 모바일 padding을 제거해 상단 탭 바가 좌우 전체 폭을 사용하도록 했습니다.
- 모델 선택기와 현재 모델 버튼의 provider 이니셜을 Claude/Codex/Gemini SVG 로고 마스크로 교체했습니다.
- 회귀 테스트를 추가했습니다.

## 검증
- npm test -- projectLayoutProviderLogos.test.ts
- npm test -- projectListSurface.test.ts projectLayoutProviderLogos.test.ts chatComposerLayout.test.ts chatComposerView.test.ts
- npm exec -- tsc --noEmit
- npm run build
- git diff --check