### PR TITLE
작업 fast path와 dev proxy 확인 정책 문서화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@
 - GitHub 이슈 본문에 백틱, `$()`, 따옴표가 포함될 수 있는 경우 전송 후 반드시 `gh issue view` 등으로 본문이 깨지지 않았는지 확인한다.
 - main 브랜치에 머지되더라도 배포 기준은 GitHub Actions 자동 배포가 아니라 공식 배포 스크립트다. 배포가 필요하면 `deploy/README.md` 기준으로 스크립트를 직접 실행하고, 그 결과를 사용자에게 최종 보고한다.
 - 직접 배포를 수행할 때는 반드시 deploy/README.md 문서를 참고한다.
+- 디자인 수정이나 기능 변경이 끝나면 production 배포 대신 dev proxy 서버를 먼저 열어 사용자가 직접 확인할 수 있게 한다. 외부 확인 URL은 `https://lawdigest.cloud/proxy/<WEB_DEV_PORT>/` 형식을 사용하며, trailing slash(`/`)를 포함한다.
+- production 배포는 사용자가 명시적으로 배포를 지시한 시점에만 수행한다. main 머지, PR 병합, dev proxy 확인만으로 production 배포를 진행하지 않는다.
+- 소규모 UI/카피/CSS 수정은 fast path로 처리한다. 동일 화면의 연속 diff comment는 가능한 한 하나의 worktree, 하나의 PR, 하나의 dev proxy 확인으로 묶고, 검증은 `git diff --check`, 관련 targeted test, `tsc --noEmit` 중심으로 제한한다.
+- fast path에서도 사용자가 직접 볼 수 있도록 변경 worktree 기준 dev hot reload 서버를 띄우고, 최종 보고에는 정확한 dev proxy URL(예: `https://lawdigest.cloud/proxy/2233/`)과 확인 범위를 포함한다.
 - 머지 과정에서 충돌이 발생한 경우 어떤 내용이 서로 충돌하는지 파악한 후 사용자에게 설명하고, 처리 방안 3가지를 제안한다.
 - 작업이 마무리되고 나면 후속 작업 5가지를 제안한다.
 - 사용자의 지침 중 확실하지 않은 부분이 있으면 작업을 진행하기 전에 사용자에게 분명히 물어본다. 이때 사용자의 의도일 가능성이 있는 최대 3가지 경우를 제시하며 사용자에게 의도를 명확히 해 달라고 요청한다.


### PR DESCRIPTION
## 변경 사항
- 디자인 수정/기능 변경 후 production 배포 대신 dev proxy 서버로 사용자 확인을 우선하도록 문서화했습니다.
- production 배포는 사용자가 명시적으로 지시한 시점에만 수행하도록 명문화했습니다.
- 소규모 UI/카피/CSS 변경은 fast path로 묶어 처리하고 targeted 검증 중심으로 제한하도록 추가했습니다.

## 검증
- git diff --check
- AGENTS.md diff 확인

## 배포
- 문서/작업 정책 변경이므로 production 배포하지 않았습니다.