### PR TITLE
dev proxy 기본 포트와 자동 포트 탐색 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - 디자인 수정이나 기능 변경이 끝나면 production 배포 대신 dev proxy 서버를 먼저 열어 사용자가 직접 확인할 수 있게 한다. 외부 확인 URL은 `https://lawdigest.cloud/proxy/<WEB_DEV_PORT>/` 형식을 사용하며, trailing slash(`/`)를 포함한다.
 - production 배포는 사용자가 명시적으로 배포를 지시한 시점에만 수행한다. main 머지, PR 병합, dev proxy 확인만으로 production 배포를 진행하지 않는다.
 - 소규모 UI/카피/CSS 수정은 fast path로 처리한다. 동일 화면의 연속 diff comment는 가능한 한 하나의 worktree, 하나의 PR, 하나의 dev proxy 확인으로 묶고, 검증은 `git diff --check`, 관련 targeted test, `tsc --noEmit` 중심으로 제한한다.
-- fast path에서도 사용자가 직접 볼 수 있도록 변경 worktree 기준 dev hot reload 서버를 띄우고, 최종 보고에는 정확한 dev proxy URL(예: `https://lawdigest.cloud/proxy/2233/`)과 확인 범위를 포함한다.
+- fast path에서도 사용자가 직접 볼 수 있도록 변경 worktree 기준 dev hot reload 서버를 띄운다. 기본 dev port는 `2233`으로 하고, 포트 충돌 시 `WEB_DEV_AUTO_PORT=1`로 다음 가용 포트를 자동 탐색한다. 최종 보고에는 정확한 dev proxy URL(예: `https://lawdigest.cloud/proxy/2233/`), commit, worktree 경로, 확인 범위를 포함한다.
 - 머지 과정에서 충돌이 발생한 경우 어떤 내용이 서로 충돌하는지 파악한 후 사용자에게 설명하고, 처리 방안 3가지를 제안한다.
 - 작업이 마무리되고 나면 후속 작업 5가지를 제안한다.
 - 사용자의 지침 중 확실하지 않은 부분이 있으면 작업을 진행하기 전에 사용자에게 분명히 물어본다. 이때 사용자의 의도일 가능성이 있는 최대 3가지 경우를 제시하며 사용자에게 의도를 명확히 해 달라고 요청한다.
@@ -44,7 +44,7 @@
 | aris-backend 포트 | `4080` (PM2 cluster) |
 | Happy Server 포트 | `3005` |
 | 웹 Blue/Green 포트 | `3301` / `3302` |
-| dev hot reload 포트 | `3305` (기본값) |
+| dev hot reload 포트 | `2233` (기본값) |
 | 인증 토큰 출처 | prod.env의 `RUNTIME_API_TOKEN` |
 
 ### 공식 디버깅 스크립트
@@ -69,7 +69,7 @@ pm2 logs aris-backend --lines 120 --nostream
 docker compose --env-file /home/ubuntu/.config/aris/prod.env logs --tail=120 aris-web-blue aris-web-green
 
 # 7) dev 서버 띄우기 (디버그 로그 확인용)
-DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env SKIP_DB_PREPARE=1 WEB_DEV_PORT=3305 \
+DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env SKIP_DB_PREPARE=1 WEB_DEV_AUTO_PORT=1 \
   ./deploy/dev/run_web_dev_hot_reload.sh
 ```
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -195,14 +195,16 @@ Daily cron example:
 Use hot reload without touching production routing:
 
 ```bash
-DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env ./deploy/dev/run_web_dev_hot_reload.sh
+DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env WEB_DEV_AUTO_PORT=1 ./deploy/dev/run_web_dev_hot_reload.sh
 ```
 
 Optional fast restart:
 
 ```bash
-DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env SKIP_DB_PREPARE=1 ./deploy/dev/run_web_dev_hot_reload.sh
+DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env SKIP_DB_PREPARE=1 WEB_DEV_AUTO_PORT=1 ./deploy/dev/run_web_dev_hot_reload.sh
 ```
+
+The default dev proxy port is `2233`; with `WEB_DEV_AUTO_PORT=1`, the script increments to the next free port and prints the external URL as `https://lawdigest.cloud/proxy/<port>/`.
 
 ## Legacy fallback
 

--- a/deploy/dev/run_web_dev_hot_reload.sh
+++ b/deploy/dev/run_web_dev_hot_reload.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${ROOT_DIR}/deploy/lib/env.sh"
 ENV_FILE="$(require_deploy_env_file "web-dev")"
-WEB_DEV_PORT="${WEB_DEV_PORT:-3305}"
+WEB_DEV_PORT="${WEB_DEV_PORT:-2233}"
 WEB_DEV_HOST="${WEB_DEV_HOST:-0.0.0.0}"
+WEB_DEV_AUTO_PORT="${WEB_DEV_AUTO_PORT:-0}"
+WEB_DEV_PORT_SCAN_LIMIT="${WEB_DEV_PORT_SCAN_LIMIT:-20}"
 SKIP_DB_PREPARE="${SKIP_DB_PREPARE:-0}"
 
 require_env_keys "web-dev" "${ENV_FILE}" \
@@ -37,6 +39,76 @@ while IFS= read -r line || [[ -n "$line" ]]; do
   export "${key}=${value}"
 done < "${ENV_FILE}"
 
+probe_dev_port() {
+  local host="$1"
+  local port="$2"
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 0
+  fi
+
+  python3 - "${host}" "${port}" <<'PY'
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+try:
+    sock.bind((host, port))
+except OSError:
+    sys.exit(1)
+finally:
+    sock.close()
+PY
+}
+
+describe_port_conflict() {
+  if command -v lsof >/dev/null 2>&1; then
+    mapfile -t listening_pids < <(lsof -tiTCP:"${WEB_DEV_PORT}" -sTCP:LISTEN -n -P 2>/dev/null || true)
+    if (( ${#listening_pids[@]} > 0 )); then
+      for pid in "${listening_pids[@]}"; do
+        cwd="$(readlink -f "/proc/${pid}/cwd" 2>/dev/null || echo "unknown")"
+        cmd="$(ps -p "${pid}" -o cmd= 2>/dev/null || echo "unknown")"
+        echo "[web-dev] existing pid=${pid} cwd=${cwd}" >&2
+        echo "[web-dev] existing cmd=${cmd}" >&2
+      done
+    else
+      echo "[web-dev] no listener pid was visible to lsof; the port may be held by docker-proxy or another privileged process" >&2
+    fi
+  fi
+}
+
+port_probe_status=0
+port_scan_attempts=0
+while true; do
+  port_probe_status=0
+  probe_dev_port "${WEB_DEV_HOST}" "${WEB_DEV_PORT}" || port_probe_status=$?
+  if (( port_probe_status == 0 )); then
+    break
+  fi
+
+  echo "[web-dev] port ${WEB_DEV_PORT} is already in use" >&2
+  echo "[web-dev] requested bind=${WEB_DEV_HOST}:${WEB_DEV_PORT}" >&2
+
+  if [[ "${WEB_DEV_AUTO_PORT}" != "1" ]]; then
+    describe_port_conflict
+    echo "[web-dev] stop the old process, choose WEB_DEV_PORT=<free-port>, or set WEB_DEV_AUTO_PORT=1" >&2
+    exit 1
+  fi
+
+  if (( port_scan_attempts >= WEB_DEV_PORT_SCAN_LIMIT )); then
+    describe_port_conflict
+    echo "[web-dev] no free port found after ${WEB_DEV_PORT_SCAN_LIMIT} attempts from ${WEB_DEV_PORT}" >&2
+    exit 1
+  fi
+
+  WEB_DEV_PORT="$((WEB_DEV_PORT + 1))"
+  port_scan_attempts="$((port_scan_attempts + 1))"
+  echo "[web-dev] trying next port ${WEB_DEV_PORT}" >&2
+done
+
 export NODE_ENV=development
 export HOST="${WEB_DEV_HOST}"
 export PORT="${WEB_DEV_PORT}"
@@ -63,46 +135,6 @@ fi
 git_ref="$(git -C "${ROOT_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")"
 git_sha="$(git -C "${ROOT_DIR}" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
 proxy_url="https://lawdigest.cloud/proxy/${WEB_DEV_PORT}/"
-
-port_probe_status=0
-if command -v python3 >/dev/null 2>&1; then
-  python3 - "${WEB_DEV_HOST}" "${WEB_DEV_PORT}" <<'PY' || port_probe_status=$?
-import socket
-import sys
-
-host = sys.argv[1]
-port = int(sys.argv[2])
-
-sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-try:
-    sock.bind((host, port))
-except OSError:
-    sys.exit(1)
-finally:
-    sock.close()
-PY
-fi
-
-if (( port_probe_status != 0 )); then
-  echo "[web-dev] port ${WEB_DEV_PORT} is already in use; refusing to start a second dev server" >&2
-  echo "[web-dev] requested bind=${WEB_DEV_HOST}:${WEB_DEV_PORT}" >&2
-  if command -v lsof >/dev/null 2>&1; then
-    mapfile -t listening_pids < <(lsof -tiTCP:"${WEB_DEV_PORT}" -sTCP:LISTEN -n -P 2>/dev/null || true)
-    if (( ${#listening_pids[@]} > 0 )); then
-      for pid in "${listening_pids[@]}"; do
-        cwd="$(readlink -f "/proc/${pid}/cwd" 2>/dev/null || echo "unknown")"
-        cmd="$(ps -p "${pid}" -o cmd= 2>/dev/null || echo "unknown")"
-        echo "[web-dev] existing pid=${pid} cwd=${cwd}" >&2
-        echo "[web-dev] existing cmd=${cmd}" >&2
-      done
-    else
-      echo "[web-dev] no listener pid was visible to lsof; the port may be held by docker-proxy or another privileged process" >&2
-    fi
-  fi
-  echo "[web-dev] stop the old process or choose WEB_DEV_PORT=<free-port>" >&2
-  exit 1
-fi
 
 # Host dev mode does not receive Docker Compose's DATABASE_URL injection.
 # Build it from deploy env and point to the running postgres container IP.

--- a/deploy/ops/debug-runbook.md
+++ b/deploy/ops/debug-runbook.md
@@ -83,11 +83,11 @@ docker compose --env-file /home/ubuntu/.config/aris/prod.env \
 # worktree에서 실행
 DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env \
   SKIP_DB_PREPARE=1 \
-  WEB_DEV_PORT=3305 \
+  WEB_DEV_AUTO_PORT=1 \
   ./deploy/dev/run_web_dev_hot_reload.sh
 ```
 
-→ `http://localhost:3305` 로 접속 후 브라우저 DevTools > Console 탭 확인.
+→ 스크립트가 출력하는 `https://lawdigest.cloud/proxy/<port>/` URL로 접속 후 브라우저 DevTools > Console 탭 확인.
 
 ---
 

--- a/services/aris-web/tests/devProxyAssetPrefix.test.ts
+++ b/services/aris-web/tests/devProxyAssetPrefix.test.ts
@@ -102,7 +102,10 @@ describe('dev proxy asset prefix resolution', () => {
   it('makes dev proxy target identity explicit before starting hot reload', () => {
     const script = readFileSync(resolve(__dirname, '../../../deploy/dev/run_web_dev_hot_reload.sh'), 'utf8');
 
+    expect(script).toContain('WEB_DEV_PORT="${WEB_DEV_PORT:-2233}"');
+    expect(script).toContain('WEB_DEV_AUTO_PORT="${WEB_DEV_AUTO_PORT:-0}"');
     expect(script).toContain('port ${WEB_DEV_PORT} is already in use');
+    expect(script).toContain('trying next port');
     expect(script).toContain('readlink -f "/proc/${pid}/cwd"');
     expect(script).toContain('proxy URL=${proxy_url}');
     expect(script).toContain('this dev proxy is not production deploy');


### PR DESCRIPTION
## 요약
- fast path dev proxy 기본 포트를 2233으로 고정했습니다.
- WEB_DEV_AUTO_PORT=1 설정 시 포트 충돌에서 다음 가용 포트를 자동 탐색하도록 했습니다.
- 관련 runbook과 fast path 보고 규칙을 갱신했습니다.

## 검증
- npm test -- devProxyAssetPrefix.test.ts
- bash -n deploy/dev/run_web_dev_hot_reload.sh
- git diff --check
- npm exec -- tsc --noEmit

## 배포
- production 배포는 수행하지 않았습니다.