### PR TITLE
채팅 provider 로고와 실행 상태 UI 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - production 배포는 사용자가 명시적으로 배포를 지시한 시점에만 수행한다. main 머지, PR 병합, dev proxy 확인만으로 production 배포를 진행하지 않는다.
 - 소규모 UI/카피/CSS 수정은 fast path로 처리한다. 동일 화면의 연속 diff comment는 가능한 한 하나의 worktree, 하나의 PR, 하나의 dev proxy 확인으로 묶고, 검증은 `git diff --check`, 관련 targeted test, `tsc --noEmit` 중심으로 제한한다.
 - fast path에서도 사용자가 직접 볼 수 있도록 변경 worktree 기준 dev hot reload 서버를 띄운다. 기본 dev port는 `2233`으로 하고, 포트 충돌 시 `WEB_DEV_AUTO_PORT=1`로 다음 가용 포트를 자동 탐색한다. 최종 보고에는 정확한 dev proxy URL(예: `https://lawdigest.cloud/proxy/2233/`), commit, worktree 경로, 확인 범위를 포함한다.
+- fast path 최종 보고 템플릿은 아래 항목을 유지한다: `변경 요약`, `검증`, `dev proxy URL`, `commit`, `worktree`, `배포 여부`. production 배포를 하지 않은 경우 `배포 여부: production 배포 안 함`으로 명시한다.
 - 머지 과정에서 충돌이 발생한 경우 어떤 내용이 서로 충돌하는지 파악한 후 사용자에게 설명하고, 처리 방안 3가지를 제안한다.
 - 작업이 마무리되고 나면 후속 작업 5가지를 제안한다.
 - 사용자의 지침 중 확실하지 않은 부분이 있으면 작업을 진행하기 전에 사용자에게 분명히 물어본다. 이때 사용자의 의도일 가능성이 있는 최대 3가지 경우를 제시하며 사용자에게 의도를 명확히 해 달라고 요청한다.

--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -1790,30 +1790,30 @@ function projectActionPreview(event: UiEvent): string {
 function projectRunStatusMeta(runStatus: string) {
   const normalized = runStatus.trim().toLowerCase();
   if (normalized === 'run_started' || normalized === 'turn_started' || normalized === 'model_normalized') {
-    return { label: '실행 시작', tone: 'run' };
+    return { Icon: Terminal, label: '실행 시작', tone: 'run' };
   }
   if (normalized === 'completed' || normalized === 'run_completed') {
-    return { label: '실행 종료', tone: 'done' };
+    return { Icon: Check, label: '실행 종료', tone: 'done' };
   }
   if (normalized === 'waiting_for_approval') {
-    return { label: '승인 대기', tone: 'wait' };
+    return { Icon: Clock3, label: '승인 대기', tone: 'wait' };
   }
   if (normalized === 'aborted' || normalized === 'run_aborted' || normalized === 'cancelled' || normalized === 'canceled') {
-    return { label: 'aborted', tone: 'alert' };
+    return { Icon: AlertCircle, label: 'aborted', tone: 'alert' };
   }
-  return { label: normalized ? normalized.replace(/_/g, ' ') : '실행 상태', tone: 'alert' };
+  return { Icon: AlertCircle, label: normalized ? normalized.replace(/_/g, ' ') : '실행 상태', tone: 'alert' };
 }
 
-function ProjectRunStatusLine({ event }: { event: UiEvent }) {
+function ProjectRunStatusChip({ event }: { event: UiEvent }) {
   const runStatus = readUiEventRunStatus(event);
-  const { label, tone } = projectRunStatusMeta(runStatus);
+  const { Icon, label, tone } = projectRunStatusMeta(runStatus);
   const relativeTime = formatRelativeTime(event.timestamp);
 
   return (
     <div className="pc-run-status" data-tone={tone} title={`${label} · ${relativeTime}`} aria-label={`${label} · ${relativeTime}`}>
-      <span className="pc-run-status__dash" aria-hidden="true">-</span>
+      <span className="pc-run-status__icon" aria-hidden="true"><Icon size={12} /></span>
       <span className="pc-run-status__label">{label}</span>
-      <span className="pc-run-status__dash" aria-hidden="true">-</span>
+      <time className="pc-run-status__time" dateTime={event.timestamp}>{relativeTime}</time>
     </div>
   );
 }
@@ -2541,7 +2541,7 @@ function ProjectChatSurface({
                 if (runStatusEvent) {
                   return (
                     <div key={item.id} className={`msg msg--run-status${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
-                      <ProjectRunStatusLine event={event} />
+                      <ProjectRunStatusChip event={event} />
                     </div>
                   );
                 }

--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -7,6 +7,7 @@ import {
   AlertCircle,
   ArrowDown,
   AtSign,
+  Brain,
   ChevronLeft,
   Check,
   ChevronRight,
@@ -17,9 +18,12 @@ import {
   Database,
   ExternalLink,
   File as FileIcon,
+  FilePenLine,
+  FileSearch,
   FileText,
   Folder,
   FolderOpen,
+  FolderTree,
   HardDrive,
   Home,
   Maximize2,
@@ -40,12 +44,15 @@ import {
   Square,
   Sun,
   Terminal,
+  TerminalSquare,
   Wifi,
   X,
 } from 'lucide-react';
 import { BottomNav, TabType } from '@/components/layout/BottomNav';
 import { BackendNotice } from '@/components/ui/BackendNotice';
+import { ProviderLogo, type ProviderLogoProvider } from '@/components/ui/ProviderLogo';
 import { selectRecentChats, selectRecentProjects, type HomeRecentChat } from './homeProjects';
+import { readUiEventRunStatus } from '@/lib/happy/chatRuntime';
 import { withAppBasePath } from '@/lib/routing/appPath';
 import { applyTheme, readThemeMode, type ThemeMode } from '@/lib/theme/clientTheme';
 import type { AuthenticatedUser } from '@/lib/auth/types';
@@ -55,7 +62,7 @@ type ProjectView = 'overview' | 'chats' | 'chat' | 'files' | 'context';
 type ComposerMode = 'agent' | 'plan' | 'terminal';
 type WorkspaceTab = 'run' | 'files' | 'terminal' | 'context';
 type PreviewState = 'closed' | 'open' | 'dock';
-type ModelProvider = 'claude' | 'codex' | 'gemini';
+type ModelProvider = ProviderLogoProvider;
 type ReasoningEffort = 'Low' | 'Medium' | 'High' | 'XHigh' | 'Max';
 type ExpandedTurnState = string | null | '__none__';
 
@@ -168,12 +175,6 @@ const PROVIDER_LABELS: Record<ModelProvider, string> = {
   claude: 'Claude',
   codex: 'Codex',
   gemini: 'Gemini',
-};
-
-const PROVIDER_ICON_PATHS: Record<ModelProvider, string> = {
-  claude: '/icons/claude.svg',
-  codex: '/icons/codex.svg',
-  gemini: '/icons/gemini.svg',
 };
 
 const PROVIDER_EFFORTS: Record<ModelProvider, ReasoningEffort[]> = {
@@ -1693,23 +1694,6 @@ function agentAvatarClass(agent: SessionSummary['agent'] | SessionChat['agent'])
   return 'msg__avatar--sys';
 }
 
-function agentInitial(agent: SessionSummary['agent'] | SessionChat['agent']): string {
-  if (agent === 'claude') return 'C';
-  if (agent === 'gemini') return 'G';
-  if (agent === 'codex') return 'GPT';
-  return 'A';
-}
-
-function ProviderLogo({ provider }: { provider: ModelProvider }) {
-  return (
-    <span
-      className={`provider-logo provider-logo--${provider}`}
-      aria-hidden="true"
-      style={{ '--provider-logo-url': `url(${PROVIDER_ICON_PATHS[provider]})` } as CSSProperties}
-    />
-  );
-}
-
 function isProjectActionEvent(event: UiEvent): boolean {
   if (readEventRole(event) === 'user') return false;
   if (event.action?.command || event.action?.path || event.parsed?.commands?.length) return true;
@@ -1724,6 +1708,14 @@ function isProjectActionEvent(event: UiEvent): boolean {
     || event.kind === 'think';
 }
 
+function isProjectRunStatusEvent(event: UiEvent): boolean {
+  if (readEventRole(event) === 'user') return false;
+  const runStatus = readUiEventRunStatus(event);
+  if (!runStatus) return false;
+  const streamEvent = typeof event.meta?.streamEvent === 'string' ? event.meta.streamEvent.trim().toLowerCase() : '';
+  return streamEvent === 'run_status' || /^run status:/i.test(event.body || event.title);
+}
+
 function eventCommand(event: UiEvent): string {
   return event.action?.command
     || event.parsed?.commands?.[0]
@@ -1733,14 +1725,59 @@ function eventCommand(event: UiEvent): string {
     || event.title;
 }
 
+function commandTokenClass(token: string, tokenIndex: number): string {
+  if (tokenIndex === 0) return 'pc-action-token--bin';
+  if (/^[A-Z_][A-Z0-9_]*=/.test(token)) return 'pc-action-token--env';
+  if (/^-{1,2}[\w-]+/.test(token)) return 'pc-action-token--flag';
+  if (/^https?:\/\//.test(token)) return 'pc-action-token--url';
+  if (/^(?:\/|~\/|\.{1,2}\/)/.test(token)) return 'pc-action-token--path';
+  if (/^(?:&&|\|\||[|;])$/.test(token)) return 'pc-action-token--op';
+  if (/^\d+(?:\.\d+)?(?::\d+)?$/.test(token) || /:\d+/.test(token)) return 'pc-action-token--number';
+  return 'pc-action-token--arg';
+}
+
+function renderCommandTokens(command: string) {
+  let tokenIndex = 0;
+  return (command.match(/\s+|[^\s]+/g) ?? []).map((token, index) => {
+    if (/^\s+$/.test(token)) {
+      return <span key={`space-${index}`}>{token}</span>;
+    }
+    const className = commandTokenClass(token, tokenIndex);
+    tokenIndex += 1;
+    return <span key={`${className}-${index}`} className={`pc-action-token ${className}`}>{token}</span>;
+  });
+}
+
+function GitActionMark({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" role="img" aria-label="Git">
+      <path
+        d="M22.1 10.9 13.1 1.9a1.55 1.55 0 0 0-2.2 0L8.98 3.82l2.38 2.38a1.92 1.92 0 0 1 2.43 2.45l2.28 2.28a1.92 1.92 0 1 1-1.15 1.15l-2.13-2.13v5.6a1.92 1.92 0 1 1-1.58-.02V9.82a1.92 1.92 0 0 1-.9-2.55L7.85 4.81 1.9 10.76a1.55 1.55 0 0 0 0 2.2l9.14 9.14a1.55 1.55 0 0 0 2.2 0l8.86-8.86a1.65 1.65 0 0 0 0-2.34Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function DockerActionMark({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" role="img" aria-label="Docker">
+      <path
+        d="M4.9 11.8h2.2V9.7H4.9v2.1Zm2.7 0h2.2V9.7H7.6v2.1Zm2.7 0h2.2V9.7h-2.2v2.1Zm2.7 0h2.2V9.7H13v2.1Zm-5.4-2.6h2.2V7.1H7.6v2.1Zm2.7 0h2.2V7.1h-2.2v2.1Zm2.7 0h2.2V7.1H13v2.1Zm0-2.6h2.2V4.5H13v2.1Zm9.1 5.1c-.5-.3-1.5-.4-2.3-.2-.1-.8-.6-1.5-1.3-2l-.5-.3-.3.5c-.4.7-.5 1.7-.1 2.4.2.4.5.8.9 1-1.2.7-3.2.7-3.5.7H2.2l-.1.5c-.2 1.4.1 2.6.8 3.5.8 1.1 2.1 1.7 3.8 1.7 3.7 0 6.5-1.7 8-4.8 1 .1 3.1.1 4.5-1.3.6 0 1.9-.1 2.8-1l.4-.4-.3-.3Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
 function projectActionMeta(kind: UiEvent['kind']) {
-  if (kind === 'file_read') return { Icon: FileText, label: 'Read', tone: 'read' };
-  if (kind === 'file_write') return { Icon: FileIcon, label: 'Write', tone: 'write' };
-  if (kind === 'file_list') return { Icon: FolderOpen, label: 'List', tone: 'list' };
-  if (kind === 'think') return { Icon: Clock3, label: 'Thinking', tone: 'think' };
-  if (kind === 'git_execution') return { Icon: Check, label: 'Git', tone: 'run' };
-  if (kind === 'docker_execution') return { Icon: HardDrive, label: 'Docker', tone: 'run' };
-  return { Icon: Terminal, label: 'Run', tone: 'run' };
+  if (kind === 'file_read') return { Icon: FileSearch, label: 'Read', tone: 'read' };
+  if (kind === 'file_write') return { Icon: FilePenLine, label: 'Write', tone: 'write' };
+  if (kind === 'file_list') return { Icon: FolderTree, label: 'List', tone: 'list' };
+  if (kind === 'think') return { Icon: Brain, label: 'Thinking', tone: 'think' };
+  if (kind === 'git_execution') return { Icon: GitActionMark, label: 'Git', tone: 'git' };
+  if (kind === 'docker_execution') return { Icon: DockerActionMark, label: 'Docker', tone: 'docker' };
+  return { Icon: TerminalSquare, label: 'Run', tone: 'run' };
 }
 
 function projectActionPreview(event: UiEvent): string {
@@ -1748,6 +1785,33 @@ function projectActionPreview(event: UiEvent): string {
   const preview = event.result?.preview || event.body || event.title || '';
   if (!preview || preview === command) return '';
   return preview.trim();
+}
+
+function projectRunStatusMeta(runStatus: string) {
+  const normalized = runStatus.trim().toLowerCase();
+  if (normalized === 'run_started' || normalized === 'turn_started' || normalized === 'model_normalized') {
+    return { Icon: Terminal, label: '실행 시작', tone: 'run' };
+  }
+  if (normalized === 'completed' || normalized === 'run_completed') {
+    return { Icon: Check, label: '실행 종료', tone: 'done' };
+  }
+  if (normalized === 'waiting_for_approval') {
+    return { Icon: Clock3, label: '승인 대기', tone: 'wait' };
+  }
+  return { Icon: AlertCircle, label: normalized ? normalized.replace(/_/g, ' ') : '실행 상태', tone: 'alert' };
+}
+
+function ProjectRunStatusChip({ event }: { event: UiEvent }) {
+  const runStatus = readUiEventRunStatus(event);
+  const { Icon, label, tone } = projectRunStatusMeta(runStatus);
+
+  return (
+    <div className="pc-run-status" data-tone={tone} title={`${label} · ${formatRelativeTime(event.timestamp)}`}>
+      <span className="pc-run-status__icon" aria-hidden="true"><Icon size={12} /></span>
+      <span className="pc-run-status__label">{label}</span>
+      <time className="pc-run-status__time" dateTime={event.timestamp}>{formatRelativeTime(event.timestamp)}</time>
+    </div>
+  );
 }
 
 function ProjectActionCard({
@@ -1763,32 +1827,97 @@ function ProjectActionCard({
   const primary = eventCommand(event);
   const preview = projectActionPreview(event);
   const filePath = event.parsed?.files?.[0] || event.action?.path || '';
+  const stackRef = useRef<HTMLDivElement | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const resultRef = useRef<HTMLDivElement | null>(null);
+  const [connectorMetrics, setConnectorMetrics] = useState<{
+    cardCenter: number;
+    resultCenter: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const stack = stackRef.current;
+    const card = cardRef.current;
+    const result = resultRef.current;
+    if (!preview || !stack || !card || !result) {
+      setConnectorMetrics(null);
+      return undefined;
+    }
+
+    let frame = 0;
+    const measure = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const stackRect = stack.getBoundingClientRect();
+        const cardRect = card.getBoundingClientRect();
+        const resultRect = result.getBoundingClientRect();
+        const nextMetrics = {
+          cardCenter: Math.round(cardRect.top - stackRect.top + cardRect.height / 2),
+          resultCenter: Math.round(resultRect.top - stackRect.top + resultRect.height / 2),
+        };
+        setConnectorMetrics((current) => {
+          if (
+            current &&
+            current.cardCenter === nextMetrics.cardCenter &&
+            current.resultCenter === nextMetrics.resultCenter
+          ) {
+            return current;
+          }
+          return nextMetrics;
+        });
+      });
+    };
+
+    measure();
+    const observer = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measure) : null;
+    observer?.observe(card);
+    observer?.observe(result);
+    window.addEventListener('resize', measure);
+    return () => {
+      cancelAnimationFrame(frame);
+      observer?.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, [preview]);
+
+  const connectorStyle = connectorMetrics
+    ? ({
+        '--pc-action-card-center': `${connectorMetrics.cardCenter}px`,
+        '--pc-action-result-center': `${connectorMetrics.resultCenter}px`,
+      } as CSSProperties)
+    : undefined;
 
   return (
-    <div className="pc-action-card" data-project-action-card data-kind={tone}>
-      <div className="pc-action-card__main">
-        <div className="pc-action-card__top">
-          <span className="pc-action-card__kind"><Icon size={12} />{label}</span>
-          <span className="pc-action-card__time">{formatRelativeTime(event.timestamp)}</span>
+    <div ref={stackRef} className="pc-action-stack" data-kind={tone} style={connectorStyle}>
+      <div ref={cardRef} className="pc-action-card" data-project-action-card data-kind={tone}>
+        <span className="pc-action-card__kind" aria-hidden="true"><Icon size={12} /></span>
+        <div className="pc-action-card__main">
+          <span className="pc-action-card__primary">{label}</span>
+          <span className="pc-action-card__cmd" aria-label={primary}>{renderCommandTokens(primary)}</span>
+          {filePath && filePath !== primary && (
+            <div className="pc-action-card__path">{filePath}</div>
+          )}
         </div>
-        <div className="pc-action-card__primary">{primary}</div>
-        {filePath && filePath !== primary && (
-          <div className="pc-action-card__path">{filePath}</div>
-        )}
-        {preview && (
-          <pre className="pc-action-card__preview">{preview}</pre>
-        )}
-      </div>
-      <div className="pc-action-card__actions">
-        {onPreview && (
-          <button type="button" className="pc-action-card__preview-btn" onClick={onPreview} title="Preview referenced file">
-            <Maximize2 size={13} />
+        <span className="pc-action-card__time">{formatRelativeTime(event.timestamp)}</span>
+        <div className="pc-action-card__actions">
+          {onPreview && (
+            <button type="button" className="pc-action-card__preview-btn" onClick={onPreview} title="Preview referenced file">
+              <Maximize2 size={13} />
+            </button>
+          )}
+          <button type="button" className="pc-action-card__copy" onClick={onCopy} title="Copy action command">
+            <Copy size={13} />
           </button>
-        )}
-        <button type="button" className="pc-action-card__copy" onClick={onCopy} title="Copy action command">
-          <Copy size={13} />
-        </button>
+        </div>
       </div>
+      {preview && (
+        <span className="pc-action-connector" aria-hidden="true" />
+      )}
+      {preview && (
+        <div ref={resultRef} className="pc-action-result">
+          <pre className="pc-action-result__body">{preview}</pre>
+        </div>
+      )}
     </div>
   );
 }
@@ -2404,6 +2533,14 @@ function ProjectChatSurface({
                 const isUser = role === 'user';
                 const snippet = item.parsed?.snippets?.[0];
                 const actionEvent = !isUser && isProjectActionEvent(item);
+                const runStatusEvent = !isUser && isProjectRunStatusEvent(item);
+                if (runStatusEvent) {
+                  return (
+                    <div key={item.id} className={`msg msg--run-status${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
+                      <ProjectRunStatusChip event={event} />
+                    </div>
+                  );
+                }
                 if (actionEvent) {
                   return (
                     <div key={item.id} className={`msg msg--action${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
@@ -2417,7 +2554,9 @@ function ProjectChatSurface({
                 }
                 return (
                   <div key={item.id} className={`msg${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
-                    <span className={`msg__avatar ${isUser ? 'msg__avatar--user' : agentAvatarClass(activeAgent)}`}>{isUser ? 'U' : agentInitial(activeAgent)}</span>
+                    <span className={`msg__avatar ${isUser ? 'msg__avatar--user' : agentAvatarClass(activeAgent)}`}>
+                      {isUser ? 'U' : <ProviderLogo provider={selectedProvider} />}
+                    </span>
                     <div className="msg__body">
                       <div className="msg__header">
                         <span className="msg__name">{isUser ? 'You' : agentLabel(activeAgent, activeModelLabel)}</span>
@@ -2728,7 +2867,9 @@ function ProjectChatSurface({
                         </button>
                         <div className="chturn__expanded">
                           <div className="chturn__agent-head">
-                            <span className={`chturn__agent-avatar ${agentAvatarClass(activeAgent)}`}>{agentInitial(activeAgent).slice(0, 1)}</span>
+                            <span className={`chturn__agent-avatar ${agentAvatarClass(activeAgent)}`}>
+                              <ProviderLogo provider={selectedProvider} />
+                            </span>
                             <span className="chturn__agent-label"><strong>{agentLabel(activeAgent, activeModelLabel)}</strong></span>
                             <span className="chturn__agent-final">{item.state === 'running' ? 'In progress' : 'Final'}</span>
                           </div>

--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -1790,26 +1790,30 @@ function projectActionPreview(event: UiEvent): string {
 function projectRunStatusMeta(runStatus: string) {
   const normalized = runStatus.trim().toLowerCase();
   if (normalized === 'run_started' || normalized === 'turn_started' || normalized === 'model_normalized') {
-    return { Icon: Terminal, label: '실행 시작', tone: 'run' };
+    return { label: '실행 시작', tone: 'run' };
   }
   if (normalized === 'completed' || normalized === 'run_completed') {
-    return { Icon: Check, label: '실행 종료', tone: 'done' };
+    return { label: '실행 종료', tone: 'done' };
   }
   if (normalized === 'waiting_for_approval') {
-    return { Icon: Clock3, label: '승인 대기', tone: 'wait' };
+    return { label: '승인 대기', tone: 'wait' };
   }
-  return { Icon: AlertCircle, label: normalized ? normalized.replace(/_/g, ' ') : '실행 상태', tone: 'alert' };
+  if (normalized === 'aborted' || normalized === 'run_aborted' || normalized === 'cancelled' || normalized === 'canceled') {
+    return { label: 'aborted', tone: 'alert' };
+  }
+  return { label: normalized ? normalized.replace(/_/g, ' ') : '실행 상태', tone: 'alert' };
 }
 
-function ProjectRunStatusChip({ event }: { event: UiEvent }) {
+function ProjectRunStatusLine({ event }: { event: UiEvent }) {
   const runStatus = readUiEventRunStatus(event);
-  const { Icon, label, tone } = projectRunStatusMeta(runStatus);
+  const { label, tone } = projectRunStatusMeta(runStatus);
+  const relativeTime = formatRelativeTime(event.timestamp);
 
   return (
-    <div className="pc-run-status" data-tone={tone} title={`${label} · ${formatRelativeTime(event.timestamp)}`}>
-      <span className="pc-run-status__icon" aria-hidden="true"><Icon size={12} /></span>
+    <div className="pc-run-status" data-tone={tone} title={`${label} · ${relativeTime}`} aria-label={`${label} · ${relativeTime}`}>
+      <span className="pc-run-status__dash" aria-hidden="true">-</span>
       <span className="pc-run-status__label">{label}</span>
-      <time className="pc-run-status__time" dateTime={event.timestamp}>{formatRelativeTime(event.timestamp)}</time>
+      <span className="pc-run-status__dash" aria-hidden="true">-</span>
     </div>
   );
 }
@@ -2537,7 +2541,7 @@ function ProjectChatSurface({
                 if (runStatusEvent) {
                   return (
                     <div key={item.id} className={`msg msg--run-status${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
-                      <ProjectRunStatusChip event={event} />
+                      <ProjectRunStatusLine event={event} />
                     </div>
                   );
                 }

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -3182,6 +3182,11 @@
   align-self: flex-start;
 }
 
+.msgAvatar :global(.provider-logo) {
+  width: 15px;
+  height: 15px;
+}
+
 .msgBody {
   min-width: 0;
   flex: 1;

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/ChatTimeline.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/ChatTimeline.tsx
@@ -5,6 +5,7 @@ import type { CSSProperties, RefObject } from 'react';
 import { CheckCircle2, ChevronDown, ChevronLeft, ChevronUp, Copy, Eye, Loader2, MessageSquarePlus } from 'lucide-react';
 import { readChatImageAttachments } from '@/lib/chatImageAttachments';
 import { isRunLifecycleEvent } from '@/lib/happy/chatRuntime';
+import { ProviderLogo } from '@/components/ui/ProviderLogo';
 import type { AgentFlavor, PermissionDecision, SessionChat, UiEvent } from '@/lib/happy/types';
 import { PermissionRequestMessage } from '../../PermissionRequestMessage';
 import styles from '../../ChatInterface.module.css';
@@ -353,7 +354,7 @@ export function ChatTimeline({
             <article id={`event-${event.id}`} className={`${styles.messageRow} ${styles.messageRowAgent} ${styles.csMsg} ${styles.csMsgAgent}`}>
               <div className={styles.messageWithAvatar}>
                 <div className={`${styles.msgAvatar} ${getAgentAvatarToneClass(agentMeta.tone)}`}>
-                  <AgentIcon size={14} />
+                  <ProviderLogo provider={activeAgentFlavor} />
                 </div>
                 <div className={styles.msgBody}>
                   <div className={styles.msgHeader}>
@@ -393,7 +394,7 @@ export function ChatTimeline({
           <article className={`${styles.messageRow} ${styles.messageRowAgent} ${styles.csMsg} ${styles.csMsgAgent}`}>
             <div className={styles.messageWithAvatar}>
               <div className={`${styles.msgAvatar} ${getAgentAvatarToneClass(agentMeta.tone)}`}>
-                <AgentIcon size={14} />
+                <ProviderLogo provider={activeAgentFlavor} />
               </div>
               <div className={styles.msgBody}>
                 <div className={styles.msgHeader}>

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -2981,57 +2981,46 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 }
 
 .pc-proto .msg--run-status {
-  display: block;
+  display: flex;
+  justify-content: center;
   width: 100%;
   box-sizing: border-box;
-  padding-left: calc(28px + var(--sp-4));
+  padding: var(--sp-1) 0;
 }
 
 .pc-proto .pc-run-status {
+  --pc-run-status-color: var(--text-tertiary);
   display: inline-flex;
   align-items: center;
-  gap: var(--sp-3);
+  justify-content: center;
+  gap: 0.42em;
   max-width: 100%;
-  min-height: 26px;
-  padding: 4px 10px 4px 5px;
-  border: 1px solid color-mix(in srgb, var(--pc-run-status-accent, var(--b-600)) 28%, var(--border-subtle));
-  border-radius: var(--r-full);
-  background: color-mix(in srgb, var(--pc-run-status-bg, var(--b-50)) 58%, var(--surface));
-  color: var(--pc-run-status-accent, var(--b-700));
+  min-height: 20px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--pc-run-status-color);
+  font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 700;
+  letter-spacing: 0;
   box-shadow: none;
 }
 
 .pc-proto .pc-run-status[data-tone="run"] {
-  --pc-run-status-accent: var(--info-fg);
-  --pc-run-status-bg: var(--info-bg);
+  --pc-run-status-color: color-mix(in srgb, var(--info-fg) 62%, var(--text-tertiary));
 }
 
 .pc-proto .pc-run-status[data-tone="done"] {
-  --pc-run-status-accent: var(--success-fg);
-  --pc-run-status-bg: var(--success-bg);
+  --pc-run-status-color: color-mix(in srgb, var(--success-fg) 62%, var(--text-tertiary));
 }
 
 .pc-proto .pc-run-status[data-tone="wait"] {
-  --pc-run-status-accent: var(--warning-fg);
-  --pc-run-status-bg: var(--warning-bg);
+  --pc-run-status-color: color-mix(in srgb, var(--warning-fg) 66%, var(--text-tertiary));
 }
 
 .pc-proto .pc-run-status[data-tone="alert"] {
-  --pc-run-status-accent: var(--danger-fg);
-  --pc-run-status-bg: var(--danger-bg);
-}
-
-.pc-proto .pc-run-status__icon {
-  width: 18px;
-  height: 18px;
-  display: grid;
-  place-items: center;
-  flex-shrink: 0;
-  border-radius: var(--r-full);
-  background: var(--pc-run-status-accent, var(--b-600));
-  color: #fff;
+  --pc-run-status-color: color-mix(in srgb, var(--danger-fg) 68%, var(--text-tertiary));
 }
 
 .pc-proto .pc-run-status__label {
@@ -3041,11 +3030,8 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
   white-space: nowrap;
 }
 
-.pc-proto .pc-run-status__time {
-  color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 600;
+.pc-proto .pc-run-status__dash {
+  color: color-mix(in srgb, var(--pc-run-status-color) 70%, transparent);
   white-space: nowrap;
 }
 

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -2989,38 +2989,50 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 }
 
 .pc-proto .pc-run-status {
-  --pc-run-status-color: var(--text-tertiary);
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.42em;
+  gap: var(--sp-3);
   max-width: 100%;
-  min-height: 20px;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  color: var(--pc-run-status-color);
-  font-family: var(--font-mono);
+  min-height: 26px;
+  padding: 4px 10px 4px 5px;
+  border: 1px solid color-mix(in srgb, var(--pc-run-status-accent, var(--b-600)) 28%, var(--border-subtle));
+  border-radius: var(--r-full);
+  background: color-mix(in srgb, var(--pc-run-status-bg, var(--b-50)) 58%, var(--surface));
+  color: var(--pc-run-status-accent, var(--b-700));
   font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0;
   box-shadow: none;
 }
 
 .pc-proto .pc-run-status[data-tone="run"] {
-  --pc-run-status-color: color-mix(in srgb, var(--info-fg) 62%, var(--text-tertiary));
+  --pc-run-status-accent: var(--info-fg);
+  --pc-run-status-bg: var(--info-bg);
 }
 
 .pc-proto .pc-run-status[data-tone="done"] {
-  --pc-run-status-color: color-mix(in srgb, var(--success-fg) 62%, var(--text-tertiary));
+  --pc-run-status-accent: var(--success-fg);
+  --pc-run-status-bg: var(--success-bg);
 }
 
 .pc-proto .pc-run-status[data-tone="wait"] {
-  --pc-run-status-color: color-mix(in srgb, var(--warning-fg) 66%, var(--text-tertiary));
+  --pc-run-status-accent: var(--warning-fg);
+  --pc-run-status-bg: var(--warning-bg);
 }
 
 .pc-proto .pc-run-status[data-tone="alert"] {
-  --pc-run-status-color: color-mix(in srgb, var(--danger-fg) 68%, var(--text-tertiary));
+  --pc-run-status-accent: var(--danger-fg);
+  --pc-run-status-bg: var(--danger-bg);
+}
+
+.pc-proto .pc-run-status__icon {
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  border-radius: var(--r-full);
+  background: var(--pc-run-status-accent, var(--b-600));
+  color: #fff;
 }
 
 .pc-proto .pc-run-status__label {
@@ -3030,8 +3042,11 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
   white-space: nowrap;
 }
 
-.pc-proto .pc-run-status__dash {
-  color: color-mix(in srgb, var(--pc-run-status-color) 70%, transparent);
+.pc-proto .pc-run-status__time {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
   white-space: nowrap;
 }
 
@@ -5942,7 +5957,7 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
   }
 
   .pc-proto .msg--run-status {
-    padding-left: calc(28px + var(--sp-3));
+    padding: var(--sp-1) 0;
   }
 
   .pc-proto .pc-action-card {

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -2988,7 +2988,7 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
   width: 100%;
   min-width: 0;
   box-sizing: border-box;
-  padding: var(--sp-1) 0;
+  padding: var(--sp-1) var(--sp-8);
 }
 
 .pc-proto .msg--run-status::before,

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -2869,6 +2869,11 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 .pc-proto .msg__avatar--gemini { background: var(--agent-gemini); }
 .pc-proto .msg__avatar--sys { background: var(--n-400); }
 
+.pc-proto .msg__avatar .provider-logo {
+  width: 15px;
+  height: 15px;
+}
+
 .pc-proto .msg__body {
   flex: 1;
   min-width: 0;
@@ -2970,54 +2975,156 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 
 .pc-proto .msg--action {
   display: block;
-  padding-left: 42px;
+  width: 100%;
+  box-sizing: border-box;
+  padding-left: calc(28px + var(--sp-4));
+}
+
+.pc-proto .msg--run-status {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  padding-left: calc(28px + var(--sp-4));
+}
+
+.pc-proto .pc-run-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-3);
+  max-width: 100%;
+  min-height: 26px;
+  padding: 4px 10px 4px 5px;
+  border: 1px solid color-mix(in srgb, var(--pc-run-status-accent, var(--b-600)) 28%, var(--border-subtle));
+  border-radius: var(--r-full);
+  background: color-mix(in srgb, var(--pc-run-status-bg, var(--b-50)) 58%, var(--surface));
+  color: var(--pc-run-status-accent, var(--b-700));
+  font-size: 11px;
+  font-weight: 700;
+  box-shadow: none;
+}
+
+.pc-proto .pc-run-status[data-tone="run"] {
+  --pc-run-status-accent: var(--info-fg);
+  --pc-run-status-bg: var(--info-bg);
+}
+
+.pc-proto .pc-run-status[data-tone="done"] {
+  --pc-run-status-accent: var(--success-fg);
+  --pc-run-status-bg: var(--success-bg);
+}
+
+.pc-proto .pc-run-status[data-tone="wait"] {
+  --pc-run-status-accent: var(--warning-fg);
+  --pc-run-status-bg: var(--warning-bg);
+}
+
+.pc-proto .pc-run-status[data-tone="alert"] {
+  --pc-run-status-accent: var(--danger-fg);
+  --pc-run-status-bg: var(--danger-bg);
+}
+
+.pc-proto .pc-run-status__icon {
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  border-radius: var(--r-full);
+  background: var(--pc-run-status-accent, var(--b-600));
+  color: #fff;
+}
+
+.pc-proto .pc-run-status__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pc-proto .pc-run-status__time {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.pc-proto .pc-action-stack {
+  --pc-action-accent: var(--b-600);
+  --pc-action-bg: color-mix(in srgb, var(--b-50) 42%, var(--surface));
+  --pc-action-connector-opacity: 0.42;
+  display: grid;
+  gap: var(--sp-2);
+  justify-items: stretch;
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+html[data-theme='dark'] .pc-proto .pc-action-stack {
+  --pc-action-connector-opacity: 0.34;
 }
 
 .pc-proto .pc-action-card {
-  --pc-action-accent: var(--b-600);
-  --pc-action-bg: color-mix(in srgb, var(--b-50) 42%, var(--surface));
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--sp-5);
-  align-items: start;
-  max-width: 680px;
-  padding: 10px 10px 10px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-4);
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 7px 10px 7px 6px;
   background: var(--surface);
-  border: 1px solid var(--border-default);
-  border-left: 3px solid var(--pc-action-accent);
-  border-radius: 8px;
-  box-shadow: var(--shadow-xs);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  box-shadow: none;
+  font-size: 12px;
+  overflow: hidden;
 }
 
-.pc-proto .pc-action-card[data-kind="run"] {
+.pc-proto .pc-action-stack[data-kind="run"] {
   --pc-action-accent: var(--warning-fg);
   --pc-action-bg: color-mix(in srgb, var(--warning-bg) 54%, var(--surface));
 }
 
-.pc-proto .pc-action-card[data-kind="read"] {
+.pc-proto .pc-action-stack[data-kind="git"] {
+  --pc-action-accent: #f05033;
+  --pc-action-bg: color-mix(in srgb, #f05033 12%, var(--surface));
+}
+
+.pc-proto .pc-action-stack[data-kind="docker"] {
+  --pc-action-accent: #2496ed;
+  --pc-action-bg: color-mix(in srgb, #2496ed 12%, var(--surface));
+}
+
+.pc-proto .pc-action-stack[data-kind="read"] {
   --pc-action-accent: var(--info-fg);
   --pc-action-bg: color-mix(in srgb, var(--info-bg) 58%, var(--surface));
 }
 
-.pc-proto .pc-action-card[data-kind="write"] {
+.pc-proto .pc-action-stack[data-kind="write"] {
   --pc-action-accent: var(--success-fg);
   --pc-action-bg: color-mix(in srgb, var(--success-bg) 54%, var(--surface));
 }
 
-.pc-proto .pc-action-card[data-kind="list"] {
+.pc-proto .pc-action-stack[data-kind="list"] {
   --pc-action-accent: var(--b-600);
   --pc-action-bg: color-mix(in srgb, var(--b-50) 60%, var(--surface));
 }
 
-.pc-proto .pc-action-card[data-kind="think"] {
+.pc-proto .pc-action-stack[data-kind="think"] {
   --pc-action-accent: var(--text-tertiary);
   --pc-action-bg: var(--surface-sunken);
 }
 
 .pc-proto .pc-action-card__main {
   min-width: 0;
-  display: grid;
-  gap: var(--sp-3);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  overflow: hidden;
 }
 
 .pc-proto .pc-action-card__top {
@@ -3028,85 +3135,162 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 }
 
 .pc-proto .pc-action-card__kind {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  min-height: 22px;
-  padding: 2px 7px;
-  background: var(--pc-action-bg);
-  color: var(--pc-action-accent);
-  border: 1px solid color-mix(in srgb, var(--pc-action-accent) 22%, transparent);
-  border-radius: var(--r-full);
-  font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0;
-  line-height: 1;
-  text-transform: uppercase;
-  white-space: nowrap;
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  background: var(--pc-action-accent);
+  color: #fff;
+  border-radius: var(--r-md);
 }
 
 .pc-proto .pc-action-card__time {
   color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
+  flex-shrink: 0;
   white-space: nowrap;
 }
 
 .pc-proto .pc-action-card__primary {
   color: var(--text-primary);
-  font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 700;
-  line-height: 1.55;
-  overflow-wrap: anywhere;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.pc-proto .pc-action-card__cmd {
+  display: block;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.pc-proto .pc-action-token--bin {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.pc-proto .pc-action-token--env {
+  color: var(--warning-fg);
+  font-weight: 700;
+}
+
+.pc-proto .pc-action-token--flag {
+  color: var(--info-fg);
+}
+
+.pc-proto .pc-action-token--url,
+.pc-proto .pc-action-token--path {
+  color: var(--b-700);
+}
+
+.pc-proto .pc-action-token--number {
+  color: var(--success-fg);
+}
+
+.pc-proto .pc-action-token--op {
+  color: var(--text-primary);
+  font-weight: 700;
 }
 
 .pc-proto .pc-action-card__path {
+  display: block;
   color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.45;
-  overflow-wrap: anywhere;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.pc-proto .pc-action-card__preview {
-  max-height: 132px;
+.pc-proto .pc-action-result {
+  position: relative;
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.pc-proto .pc-action-connector {
+  position: absolute;
+  left: calc(-1 * (var(--sp-4) + 18px));
+  top: var(--pc-action-card-center, 22px);
+  width: 18px;
+  height: max(38px, calc(var(--pc-action-result-center, 82px) - var(--pc-action-card-center, 22px)));
+  color: var(--pc-action-accent);
+  opacity: var(--pc-action-connector-opacity);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.pc-proto .pc-action-connector::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 15px;
+  height: 100%;
+  border-top: 2px solid currentColor;
+  border-left: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  border-top-left-radius: 7px;
+  border-bottom-left-radius: 7px;
+}
+
+.pc-proto .pc-action-result__body {
   margin: 0;
+  width: 100%;
+  max-height: 132px;
+  box-sizing: border-box;
   padding: var(--sp-4);
   overflow: auto;
+  color: var(--text-secondary);
   background: var(--surface-sunken);
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-md);
-  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.55;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
+  min-width: 0;
 }
 
 .pc-proto .pc-action-card__actions {
   display: flex;
   align-items: center;
-  gap: var(--sp-2);
+  gap: 2px;
+  flex-shrink: 0;
 }
 
 .pc-proto .pc-action-card__copy,
 .pc-proto .pc-action-card__preview-btn {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   display: grid;
   place-items: center;
-  border-radius: var(--r-md);
+  border-radius: var(--r-sm);
   color: var(--text-tertiary);
-  background: var(--surface-sunken);
-  border: 1px solid var(--border-subtle);
+  background: transparent;
+  border: 1px solid transparent;
 }
 
 .pc-proto .pc-action-card__copy:hover,
 .pc-proto .pc-action-card__preview-btn:hover {
   color: var(--text-primary);
   border-color: var(--border-default);
+  background: var(--surface-sunken);
 }
 
 .pc-proto .thinking,
@@ -4627,6 +4811,11 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
   font-weight: 700;
 }
 
+.pc-proto .chturn__agent-avatar .provider-logo {
+  width: 10px;
+  height: 10px;
+}
+
 .pc-proto .chturn__agent-label {
   font-size: 10px;
   font-weight: 700;
@@ -5763,11 +5952,15 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
   }
 
   .pc-proto .msg--action {
-    padding-left: 0;
+    padding-left: calc(28px + var(--sp-3));
+  }
+
+  .pc-proto .msg--run-status {
+    padding-left: calc(28px + var(--sp-3));
   }
 
   .pc-proto .pc-action-card {
-    grid-template-columns: minmax(0, 1fr);
+    width: 100%;
     gap: var(--sp-4);
   }
 

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -2982,15 +2982,28 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 
 .pc-proto .msg--run-status {
   display: flex;
+  align-items: center;
   justify-content: center;
+  gap: var(--sp-4);
   width: 100%;
+  min-width: 0;
   box-sizing: border-box;
   padding: var(--sp-1) 0;
+}
+
+.pc-proto .msg--run-status::before,
+.pc-proto .msg--run-status::after {
+  content: "";
+  flex: 1 1 0;
+  min-width: var(--sp-8);
+  height: 1px;
+  background: color-mix(in srgb, var(--border-default) 58%, transparent);
 }
 
 .pc-proto .pc-run-status {
   display: inline-flex;
   align-items: center;
+  flex: 0 0 auto;
   gap: var(--sp-3);
   max-width: 100%;
   min-height: 26px;

--- a/services/aris-web/components/ui/ProviderLogo.tsx
+++ b/services/aris-web/components/ui/ProviderLogo.tsx
@@ -1,0 +1,40 @@
+import React, { type CSSProperties, type ReactNode } from 'react';
+
+export const PROVIDER_ICON_SVGS = {
+  claude: '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z" fill="currentColor"/></svg>',
+  codex: '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" fill="currentColor"/></svg>',
+  gemini: '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81" fill="currentColor"/></svg>',
+} as const;
+
+export type ProviderLogoProvider = keyof typeof PROVIDER_ICON_SVGS;
+
+function svgToMaskDataUrl(svg: string): string {
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+export function resolveProviderLogoProvider(provider: string | null | undefined): ProviderLogoProvider | null {
+  if (provider === 'claude' || provider === 'codex' || provider === 'gemini') return provider;
+  return null;
+}
+
+export function ProviderLogo({
+  className = '',
+  fallback = null,
+  provider,
+}: {
+  className?: string;
+  fallback?: ReactNode;
+  provider: string | null | undefined;
+}) {
+  const resolvedProvider = resolveProviderLogoProvider(provider);
+  if (!resolvedProvider) return fallback;
+
+  return (
+    <span
+      className={`provider-logo provider-logo--${resolvedProvider}${className ? ` ${className}` : ''}`}
+      aria-hidden="true"
+      data-provider={resolvedProvider}
+      style={{ '--provider-logo-url': `url("${svgToMaskDataUrl(PROVIDER_ICON_SVGS[resolvedProvider])}")` } as CSSProperties}
+    />
+  );
+}

--- a/services/aris-web/middleware.ts
+++ b/services/aris-web/middleware.ts
@@ -95,7 +95,7 @@ export function middleware(request: NextRequest) {
     );
   }
 
-  if (pathname.startsWith('/_next') || pathname.startsWith('/favicon.ico') || pathname.startsWith('/api/auth/')) {
+  if (pathname.startsWith('/_next') || pathname.startsWith('/favicon.ico') || pathname.startsWith('/icons/') || pathname.startsWith('/api/auth/')) {
     return withSecurityHeaders(NextResponse.next());
   }
 

--- a/services/aris-web/tests/projectLayoutProviderLogos.test.ts
+++ b/services/aris-web/tests/projectLayoutProviderLogos.test.ts
@@ -5,6 +5,10 @@ import { describe, expect, it } from 'vitest';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const homeClient = readFileSync(resolve(__dirname, '../app/HomePageClient.tsx'), 'utf8');
+const providerLogo = readFileSync(resolve(__dirname, '../components/ui/ProviderLogo.tsx'), 'utf8');
+const chatTimeline = readFileSync(resolve(__dirname, '../app/sessions/[sessionId]/chat-screen/center-pane/ChatTimeline.tsx'), 'utf8');
+const chatInterfaceCss = readFileSync(resolve(__dirname, '../app/sessions/[sessionId]/ChatInterface.module.css'), 'utf8');
+const middleware = readFileSync(resolve(__dirname, '../middleware.ts'), 'utf8');
 const uiCss = readFileSync(resolve(__dirname, '../app/styles/ui.css'), 'utf8');
 
 describe('project layout and provider logo guards', () => {
@@ -16,15 +20,29 @@ describe('project layout and provider logo guards', () => {
   });
 
   it('uses the real provider logo assets in the model picker', () => {
-    expect(homeClient).toContain("claude: '/icons/claude.svg'");
-    expect(homeClient).toContain("codex: '/icons/codex.svg'");
-    expect(homeClient).toContain("gemini: '/icons/gemini.svg'");
-    expect(homeClient).toContain('function ProviderLogo({');
+    expect(providerLogo).toContain('PROVIDER_ICON_SVGS');
+    expect(providerLogo).toContain('svgToMaskDataUrl');
+    expect(providerLogo).toContain('data:image/svg+xml');
+    expect(middleware).toContain("pathname.startsWith('/icons/')");
+    expect(homeClient).toContain("import { ProviderLogo, type ProviderLogoProvider } from '@/components/ui/ProviderLogo';");
     expect(homeClient).toContain('<ProviderLogo provider={selectedProvider} />');
     expect(homeClient).toContain('<ProviderLogo provider={provider} />');
+    expect(homeClient).not.toContain('function ProviderLogo({');
     expect(homeClient).not.toContain('<span>{agentInitial(provider).slice(0, 1)}</span>');
 
     expect(uiCss).toContain('.provider-logo');
     expect(uiCss).toContain('mask-image: var(--provider-logo-url);');
+  });
+
+  it('uses the shared provider logo in chat avatars', () => {
+    expect(homeClient).toContain('msg__avatar');
+    expect(homeClient).toContain('<ProviderLogo provider={selectedProvider} />');
+    expect(homeClient).not.toContain("agentInitial(activeAgent)");
+    expect(uiCss).toContain('.pc-proto .msg__avatar .provider-logo');
+    expect(uiCss).toContain('.pc-proto .chturn__agent-avatar .provider-logo');
+
+    expect(chatTimeline).toContain("import { ProviderLogo } from '@/components/ui/ProviderLogo';");
+    expect(chatTimeline).toContain('<ProviderLogo provider={activeAgentFlavor} />');
+    expect(chatInterfaceCss).toContain(':global(.provider-logo)');
   });
 });

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -372,7 +372,7 @@ describe('project list surface', () => {
     expect(cssBlock('.pc-proto .msg--action')).toContain('padding-left: calc(28px + var(--sp-4));');
     expect(cssBlock('.pc-proto .msg--run-status')).toContain('justify-content: center;');
     expect(cssBlock('.pc-proto .msg--run-status')).toContain('gap: var(--sp-4);');
-    expect(cssBlock('.pc-proto .msg--run-status')).toContain('padding: var(--sp-1) 0;');
+    expect(cssBlock('.pc-proto .msg--run-status')).toContain('padding: var(--sp-1) var(--sp-8);');
     expect(cssBlock('.pc-proto .msg--run-status::before,\n.pc-proto .msg--run-status::after')).toContain('flex: 1 1 0;');
     expect(cssBlock('.pc-proto .msg--run-status::before,\n.pc-proto .msg--run-status::after')).toContain('background: color-mix(in srgb, var(--border-default) 58%, transparent);');
     expect(cssBlock('.pc-proto .pc-run-status')).toContain('display: inline-flex;');

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -146,14 +146,36 @@ describe('project list surface', () => {
 
   it('renders project chat action events through a dedicated action-card branch', () => {
     expect(homeClient).toContain('function isProjectActionEvent(event: UiEvent): boolean');
+    expect(homeClient).toContain('function isProjectRunStatusEvent(event: UiEvent): boolean');
+    expect(homeClient).toContain('function ProjectRunStatusChip({ event }: { event: UiEvent })');
     expect(homeClient).toContain('function ProjectActionCard({');
+    expect(homeClient).toContain('function GitActionMark({ size = 12 }: { size?: number })');
+    expect(homeClient).toContain('function DockerActionMark({ size = 12 }: { size?: number })');
+    expect(homeClient).toContain("if (kind === 'file_read') return { Icon: FileSearch, label: 'Read', tone: 'read' };");
+    expect(homeClient).toContain("if (kind === 'file_write') return { Icon: FilePenLine, label: 'Write', tone: 'write' };");
+    expect(homeClient).toContain("if (kind === 'file_list') return { Icon: FolderTree, label: 'List', tone: 'list' };");
+    expect(homeClient).toContain("if (kind === 'think') return { Icon: Brain, label: 'Thinking', tone: 'think' };");
+    expect(homeClient).toContain("if (kind === 'git_execution') return { Icon: GitActionMark, label: 'Git', tone: 'git' };");
+    expect(homeClient).toContain("if (kind === 'docker_execution') return { Icon: DockerActionMark, label: 'Docker', tone: 'docker' };");
+    expect(homeClient).toContain("return { Icon: TerminalSquare, label: 'Run', tone: 'run' };");
+    expect(homeClient).toContain('function renderCommandTokens(command: string)');
+    expect(homeClient).toContain('function commandTokenClass(token: string, tokenIndex: number): string');
     expect(homeClient).toContain('const actionEvent = !isUser && isProjectActionEvent(item);');
+    expect(homeClient).toContain('const runStatusEvent = !isUser && isProjectRunStatusEvent(item);');
+    expect(homeClient).toContain('if (runStatusEvent) {');
+    expect(homeClient).toContain('className={`msg msg--run-status');
+    expect(homeClient).toContain('<ProjectRunStatusChip event={event} />');
     expect(homeClient).toContain('if (actionEvent) {');
     expect(homeClient).toContain('data-project-action-card');
+    expect(homeClient).toContain('className="pc-action-stack"');
     expect(homeClient).toContain('className="pc-action-card"');
     expect(homeClient).toContain('className="pc-action-card__kind"');
     expect(homeClient).toContain('className="pc-action-card__primary"');
-    expect(homeClient).toContain('className="pc-action-card__preview"');
+    expect(homeClient).toContain('className="pc-action-card__cmd"');
+    expect(homeClient).toContain('aria-label={primary}>{renderCommandTokens(primary)}</span>');
+    expect(homeClient).toContain('className="pc-action-connector" aria-hidden="true" />');
+    expect(homeClient).toContain('className="pc-action-result"');
+    expect(homeClient).toContain('className="pc-action-result__body"');
     expect(homeClient).toContain("handleCopy(eventCommand(event), 'Action command')");
     expect(homeClient).not.toContain('const toolLike = !isUser && isToolLikeEvent(item);');
   });
@@ -312,9 +334,13 @@ describe('project list surface', () => {
       '.pc-proto .tl',
       '.pc-proto .msg',
       '.pc-proto .msg--action',
+      '.pc-proto .msg--run-status',
+      '.pc-proto .pc-run-status',
+      '.pc-proto .pc-action-stack',
       '.pc-proto .pc-action-card',
       '.pc-proto .pc-action-card__kind',
       '.pc-proto .pc-action-card__primary',
+      '.pc-proto .pc-action-result',
       '.pc-proto .tool',
       '.pc-proto .code',
       '.pc-proto .artifact',
@@ -340,8 +366,49 @@ describe('project list surface', () => {
     expect(uiCss).toContain('grid-template-columns: minmax(0, 1fr) 420px;');
     expect(cssBlock('.pc-proto .tl')).toContain('padding: var(--sp-12) var(--sp-10) var(--sp-24);');
     expect(cssBlock('.pc-proto .cmp')).toContain('border-radius: 14px;');
-    expect(cssBlock('.pc-proto .pc-action-card')).toContain('border-radius: 8px;');
-    expect(cssBlock('.pc-proto .pc-action-card')).toContain('grid-template-columns: minmax(0, 1fr) auto;');
+    expect(cssBlock('.pc-proto .msg--action')).toContain('width: 100%;');
+    expect(cssBlock('.pc-proto .msg--action')).toContain('box-sizing: border-box;');
+    expect(cssBlock('.pc-proto .msg--action')).toContain('padding-left: calc(28px + var(--sp-4));');
+    expect(cssBlock('.pc-proto .msg--run-status')).toContain('padding-left: calc(28px + var(--sp-4));');
+    expect(cssBlock('.pc-proto .pc-run-status')).toContain('display: inline-flex;');
+    expect(cssBlock('.pc-proto .pc-run-status[data-tone="done"]')).toContain('--pc-run-status-accent: var(--success-fg);');
+    expect(cssBlock('.pc-proto .pc-action-stack')).toContain('display: grid;');
+    expect(cssBlock('.pc-proto .pc-action-stack')).toContain('position: relative;');
+    expect(cssBlock('.pc-proto .pc-action-stack')).toContain('width: 100%;');
+    expect(cssBlock('.pc-proto .pc-action-stack')).toContain('max-width: 100%;');
+    expect(cssBlock('.pc-proto .pc-action-stack')).toContain('--pc-action-connector-opacity: 0.42;');
+    expect(cssBlock("html[data-theme='dark'] .pc-proto .pc-action-stack")).toContain('--pc-action-connector-opacity: 0.34;');
+    expect(cssBlock('.pc-proto .pc-action-stack[data-kind="git"]')).toContain('--pc-action-accent: #f05033;');
+    expect(cssBlock('.pc-proto .pc-action-stack[data-kind="docker"]')).toContain('--pc-action-accent: #2496ed;');
+    expect(cssBlock('.pc-proto .pc-action-card')).toContain('display: inline-flex;');
+    expect(cssBlock('.pc-proto .pc-action-card')).toContain('width: 100%;');
+    expect(cssBlock('.pc-proto .pc-action-card')).toContain('max-width: 100%;');
+    expect(cssBlock('.pc-proto .pc-action-card')).toContain('overflow: hidden;');
+    expect(cssBlock('.pc-proto .pc-action-card')).toContain('padding: 7px 10px 7px 6px;');
+    expect(cssBlock('.pc-proto .pc-action-card__kind')).toContain('width: 22px;');
+    expect(cssBlock('.pc-proto .pc-action-card__kind')).toContain('background: var(--pc-action-accent);');
+    expect(cssBlock('.pc-proto .pc-action-card__cmd')).toContain('display: block;');
+    expect(cssBlock('.pc-proto .pc-action-card__cmd')).toContain('white-space: pre;');
+    expect(cssBlock('.pc-proto .pc-action-token--bin')).toContain('font-weight: 700;');
+    expect(cssBlock('.pc-proto .pc-action-token--flag')).toContain('color: var(--info-fg);');
+    expect(cssBlock('.pc-proto .pc-action-result')).toContain('display: block;');
+    expect(cssBlock('.pc-proto .pc-action-result')).toContain('width: 100%;');
+    expect(cssBlock('.pc-proto .pc-action-connector')).toContain('position: absolute;');
+    expect(cssBlock('.pc-proto .pc-action-connector')).toContain('left: calc(-1 * (var(--sp-4) + 18px));');
+    expect(cssBlock('.pc-proto .pc-action-connector')).toContain('top: var(--pc-action-card-center, 22px);');
+    expect(cssBlock('.pc-proto .pc-action-connector')).toContain('width: 18px;');
+    expect(cssBlock('.pc-proto .pc-action-connector')).toContain('height: max(38px, calc(var(--pc-action-result-center, 82px) - var(--pc-action-card-center, 22px)));');
+    expect(cssBlock('.pc-proto .pc-action-connector')).toContain('opacity: var(--pc-action-connector-opacity);');
+    expect(cssBlock('.pc-proto .pc-action-connector::before')).toContain('border-top: 2px solid currentColor;');
+    expect(cssBlock('.pc-proto .pc-action-connector::before')).toContain('height: 100%;');
+    expect(cssBlock('.pc-proto .pc-action-connector::before')).toContain('border-left: 2px solid currentColor;');
+    expect(cssBlock('.pc-proto .pc-action-connector::before')).toContain('border-bottom: 2px solid currentColor;');
+    expect(cssBlock('.pc-proto .pc-action-connector::before')).toContain('border-top-left-radius: 7px;');
+    expect(cssBlock('.pc-proto .pc-action-connector::before')).toContain('border-bottom-left-radius: 7px;');
+    expect(cssBlock('.pc-proto .pc-action-result__body')).toContain('width: 100%;');
+    expect(cssBlock('.pc-proto .pc-action-result__body')).toContain('padding: var(--sp-4);');
+    expect(cssBlock('.pc-proto .pc-action-result__body')).toContain('white-space: pre-wrap;');
+    expect(uiCss).toContain('padding-left: calc(28px + var(--sp-3));');
     expect(cssBlock('.pc-proto .ws__pane')).toContain('display: none;');
     expect(cssBlock('.pc-proto .ws__pane--active')).toContain('display: flex;');
     expect(uiCss).toContain('.pc-proto[data-workspace="closed"] .shell');

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -147,7 +147,7 @@ describe('project list surface', () => {
   it('renders project chat action events through a dedicated action-card branch', () => {
     expect(homeClient).toContain('function isProjectActionEvent(event: UiEvent): boolean');
     expect(homeClient).toContain('function isProjectRunStatusEvent(event: UiEvent): boolean');
-    expect(homeClient).toContain('function ProjectRunStatusLine({ event }: { event: UiEvent })');
+    expect(homeClient).toContain('function ProjectRunStatusChip({ event }: { event: UiEvent })');
     expect(homeClient).toContain('function ProjectActionCard({');
     expect(homeClient).toContain('function GitActionMark({ size = 12 }: { size?: number })');
     expect(homeClient).toContain('function DockerActionMark({ size = 12 }: { size?: number })');
@@ -164,8 +164,8 @@ describe('project list surface', () => {
     expect(homeClient).toContain('const runStatusEvent = !isUser && isProjectRunStatusEvent(item);');
     expect(homeClient).toContain('if (runStatusEvent) {');
     expect(homeClient).toContain('className={`msg msg--run-status');
-    expect(homeClient).toContain('<ProjectRunStatusLine event={event} />');
-    expect(homeClient).toContain('className="pc-run-status__dash" aria-hidden="true">-</span>');
+    expect(homeClient).toContain('<ProjectRunStatusChip event={event} />');
+    expect(homeClient).toContain('className="pc-run-status__icon" aria-hidden="true"><Icon size={12} /></span>');
     expect(homeClient).toContain('if (actionEvent) {');
     expect(homeClient).toContain('data-project-action-card');
     expect(homeClient).toContain('className="pc-action-stack"');
@@ -373,10 +373,9 @@ describe('project list surface', () => {
     expect(cssBlock('.pc-proto .msg--run-status')).toContain('justify-content: center;');
     expect(cssBlock('.pc-proto .msg--run-status')).toContain('padding: var(--sp-1) 0;');
     expect(cssBlock('.pc-proto .pc-run-status')).toContain('display: inline-flex;');
-    expect(cssBlock('.pc-proto .pc-run-status')).toContain('background: transparent;');
-    expect(cssBlock('.pc-proto .pc-run-status')).toContain('font-family: var(--font-mono);');
-    expect(cssBlock('.pc-proto .pc-run-status[data-tone="done"]')).toContain('--pc-run-status-color: color-mix(in srgb, var(--success-fg) 62%, var(--text-tertiary));');
-    expect(cssBlock('.pc-proto .pc-run-status__dash')).toContain('color: color-mix(in srgb, var(--pc-run-status-color) 70%, transparent);');
+    expect(cssBlock('.pc-proto .pc-run-status')).toContain('border-radius: var(--r-full);');
+    expect(cssBlock('.pc-proto .pc-run-status[data-tone="done"]')).toContain('--pc-run-status-accent: var(--success-fg);');
+    expect(cssBlock('.pc-proto .pc-run-status__icon')).toContain('border-radius: var(--r-full);');
     expect(cssBlock('.pc-proto .pc-action-stack')).toContain('display: grid;');
     expect(cssBlock('.pc-proto .pc-action-stack')).toContain('position: relative;');
     expect(cssBlock('.pc-proto .pc-action-stack')).toContain('width: 100%;');

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -371,8 +371,12 @@ describe('project list surface', () => {
     expect(cssBlock('.pc-proto .msg--action')).toContain('box-sizing: border-box;');
     expect(cssBlock('.pc-proto .msg--action')).toContain('padding-left: calc(28px + var(--sp-4));');
     expect(cssBlock('.pc-proto .msg--run-status')).toContain('justify-content: center;');
+    expect(cssBlock('.pc-proto .msg--run-status')).toContain('gap: var(--sp-4);');
     expect(cssBlock('.pc-proto .msg--run-status')).toContain('padding: var(--sp-1) 0;');
+    expect(cssBlock('.pc-proto .msg--run-status::before,\n.pc-proto .msg--run-status::after')).toContain('flex: 1 1 0;');
+    expect(cssBlock('.pc-proto .msg--run-status::before,\n.pc-proto .msg--run-status::after')).toContain('background: color-mix(in srgb, var(--border-default) 58%, transparent);');
     expect(cssBlock('.pc-proto .pc-run-status')).toContain('display: inline-flex;');
+    expect(cssBlock('.pc-proto .pc-run-status')).toContain('flex: 0 0 auto;');
     expect(cssBlock('.pc-proto .pc-run-status')).toContain('border-radius: var(--r-full);');
     expect(cssBlock('.pc-proto .pc-run-status[data-tone="done"]')).toContain('--pc-run-status-accent: var(--success-fg);');
     expect(cssBlock('.pc-proto .pc-run-status__icon')).toContain('border-radius: var(--r-full);');

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -147,7 +147,7 @@ describe('project list surface', () => {
   it('renders project chat action events through a dedicated action-card branch', () => {
     expect(homeClient).toContain('function isProjectActionEvent(event: UiEvent): boolean');
     expect(homeClient).toContain('function isProjectRunStatusEvent(event: UiEvent): boolean');
-    expect(homeClient).toContain('function ProjectRunStatusChip({ event }: { event: UiEvent })');
+    expect(homeClient).toContain('function ProjectRunStatusLine({ event }: { event: UiEvent })');
     expect(homeClient).toContain('function ProjectActionCard({');
     expect(homeClient).toContain('function GitActionMark({ size = 12 }: { size?: number })');
     expect(homeClient).toContain('function DockerActionMark({ size = 12 }: { size?: number })');
@@ -164,7 +164,8 @@ describe('project list surface', () => {
     expect(homeClient).toContain('const runStatusEvent = !isUser && isProjectRunStatusEvent(item);');
     expect(homeClient).toContain('if (runStatusEvent) {');
     expect(homeClient).toContain('className={`msg msg--run-status');
-    expect(homeClient).toContain('<ProjectRunStatusChip event={event} />');
+    expect(homeClient).toContain('<ProjectRunStatusLine event={event} />');
+    expect(homeClient).toContain('className="pc-run-status__dash" aria-hidden="true">-</span>');
     expect(homeClient).toContain('if (actionEvent) {');
     expect(homeClient).toContain('data-project-action-card');
     expect(homeClient).toContain('className="pc-action-stack"');
@@ -369,9 +370,13 @@ describe('project list surface', () => {
     expect(cssBlock('.pc-proto .msg--action')).toContain('width: 100%;');
     expect(cssBlock('.pc-proto .msg--action')).toContain('box-sizing: border-box;');
     expect(cssBlock('.pc-proto .msg--action')).toContain('padding-left: calc(28px + var(--sp-4));');
-    expect(cssBlock('.pc-proto .msg--run-status')).toContain('padding-left: calc(28px + var(--sp-4));');
+    expect(cssBlock('.pc-proto .msg--run-status')).toContain('justify-content: center;');
+    expect(cssBlock('.pc-proto .msg--run-status')).toContain('padding: var(--sp-1) 0;');
     expect(cssBlock('.pc-proto .pc-run-status')).toContain('display: inline-flex;');
-    expect(cssBlock('.pc-proto .pc-run-status[data-tone="done"]')).toContain('--pc-run-status-accent: var(--success-fg);');
+    expect(cssBlock('.pc-proto .pc-run-status')).toContain('background: transparent;');
+    expect(cssBlock('.pc-proto .pc-run-status')).toContain('font-family: var(--font-mono);');
+    expect(cssBlock('.pc-proto .pc-run-status[data-tone="done"]')).toContain('--pc-run-status-color: color-mix(in srgb, var(--success-fg) 62%, var(--text-tertiary));');
+    expect(cssBlock('.pc-proto .pc-run-status__dash')).toContain('color: color-mix(in srgb, var(--pc-run-status-color) 70%, transparent);');
     expect(cssBlock('.pc-proto .pc-action-stack')).toContain('display: grid;');
     expect(cssBlock('.pc-proto .pc-action-stack')).toContain('position: relative;');
     expect(cssBlock('.pc-proto .pc-action-stack')).toContain('width: 100%;');


### PR DESCRIPTION
## 요약
- 모델 provider 로고를 공통 컴포넌트로 분리하고 모델 선택기/채팅 아바타에 적용했습니다.
- 프로젝트 채팅 액션 카드, 실행 상태 칩, 구분선 UI를 정리했습니다.
- 모바일/프로젝트 레이아웃 폭 및 dev proxy fast path 문서/스크립트 변경을 포함했습니다.
- 최신 main의 terminal mode execution 변경과 충돌을 해결했습니다.

## 검증
- npm test -- projectListSurface.test.ts projectLayoutProviderLogos.test.ts chatTimeline.test.ts
- npm exec -- tsc --noEmit
- git diff --check

## 배포
- production 배포 없음
- dev proxy 확인 URL: https://lawdigest.cloud/proxy/2233/
