### PR TITLE
프로젝트 채팅 Terminal 모드 명령 실행 연결

### DIFF
--- a/services/aris-backend/src/runtime/prismaStore.ts
+++ b/services/aris-backend/src/runtime/prismaStore.ts
@@ -148,6 +148,26 @@ function deriveRunningStateFromMeta(meta: unknown): boolean | null {
   return null;
 }
 
+function readRunLifecycleStatus(meta: unknown): 'run_started' | 'completed' | 'failed' | 'aborted' | null {
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+    return null;
+  }
+  const record = meta as Record<string, unknown>;
+  const status = typeof record.sessionTurnStatus === 'string'
+    ? record.sessionTurnStatus.trim()
+    : typeof record.runStatus === 'string'
+      ? record.runStatus.trim()
+      : '';
+  if (status === 'run_started' || status === 'completed' || status === 'failed' || status === 'aborted') {
+    return status;
+  }
+  return null;
+}
+
+function toSessionRunStatus(status: 'completed' | 'failed' | 'aborted'): 'completed' | 'failed' | 'aborted' {
+  return status;
+}
+
 export function resolveChatRunningState<
   TRow extends {
     meta: unknown;
@@ -440,24 +460,36 @@ export class PrismaRuntimeStore {
     }
 
     const row = await this.runRuntimeWriteMutationWithRetry(async (tx) => {
-      const role = typeof input.meta?.role === 'string' ? input.meta.role.trim() : '';
       let resolvedRunId = input.runId;
-      if (!resolvedRunId && role === 'user') {
-        const createdRun = await tx.sessionRun.create({
-          data: {
-            sessionId: input.sessionId,
-            chatId,
-            agent: typeof input.meta?.agent === 'string' && input.meta.agent.trim().length > 0
-              ? input.meta.agent.trim()
-              : 'unknown',
-            model: typeof input.meta?.model === 'string' && input.meta.model.trim().length > 0
-              ? input.meta.model.trim()
-              : null,
-            status: 'running',
-          },
+      const lifecycleStatus = readRunLifecycleStatus(input.meta);
+      if (!resolvedRunId && lifecycleStatus === 'run_started') {
+        const activeRun = await tx.sessionRun.findFirst({
+          where: { chatId, status: 'running' },
+          orderBy: { startedAt: 'desc' },
         });
-        resolvedRunId = createdRun.id;
-      } else if (!resolvedRunId && role === 'agent') {
+        if (activeRun) {
+          resolvedRunId = activeRun.id;
+        } else {
+          const createdRun = await tx.sessionRun.create({
+            data: {
+              sessionId: input.sessionId,
+              chatId,
+              agent: typeof input.meta?.agent === 'string' && input.meta.agent.trim().length > 0
+                ? input.meta.agent.trim()
+                : 'unknown',
+              model: typeof input.meta?.model === 'string' && input.meta.model.trim().length > 0
+                ? input.meta.model.trim()
+                : null,
+              status: 'running',
+            },
+          });
+          resolvedRunId = createdRun.id;
+        }
+      } else if (!resolvedRunId && (
+        lifecycleStatus === 'completed'
+        || lifecycleStatus === 'failed'
+        || lifecycleStatus === 'aborted'
+      )) {
         const latestRun = await tx.sessionRun.findFirst({
           where: { chatId, status: 'running' },
           orderBy: { startedAt: 'desc' },
@@ -467,7 +499,7 @@ export class PrismaRuntimeStore {
           await tx.sessionRun.update({
             where: { id: latestRun.id },
             data: {
-              status: 'completed',
+              status: toSessionRunStatus(lifecycleStatus),
               finishedAt: new Date(),
             },
           });

--- a/services/aris-backend/src/server.ts
+++ b/services/aris-backend/src/server.ts
@@ -80,6 +80,21 @@ const appendChatEventSchema = z.object({
   meta: z.record(z.string(), z.unknown()).optional(),
 });
 
+const submitUserPromptSchema = appendChatEventSchema.extend({
+  type: z.literal('message').default('message'),
+  text: z.string().min(1),
+});
+
+const submitSessionUserPromptSchema = appendMessageSchema.extend({
+  type: z.literal('message').default('message'),
+  text: z.string().min(1),
+});
+
+const terminalCommandSchema = z.object({
+  sessionId: z.string().min(1),
+  command: z.string().trim().min(1),
+});
+
 type AppendMessageInput = z.infer<typeof appendMessageSchema>;
 
 type HappyBridgeAppendMessage = {
@@ -667,6 +682,29 @@ export function buildServer(config: ServerConfig) {
     }
   });
 
+  app.post('/v1/sessions/:sessionId/user-prompts', async (request, reply) => {
+    const { sessionId } = request.params as { sessionId: string };
+    const parsed = submitSessionUserPromptSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'Invalid request body' });
+    }
+
+    try {
+      const session = await store.getSession(sessionId);
+      if (!session) {
+        return reply.code(404).send({ error: 'Session not found' });
+      }
+      const message = await store.submitUserPrompt(sessionId, parsed.data);
+      return reply.code(201).send({ message });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'SESSION_NOT_FOUND') {
+        return reply.code(404).send({ error: 'Session not found' });
+      }
+      const message = toErrorMessage(error, 'Failed to submit user prompt');
+      return reply.code(502).send({ error: message });
+    }
+  });
+
   app.get('/v1/chats/:chatId/events', async (request, reply) => {
     try {
       const { chatId } = request.params as { chatId: string };
@@ -711,6 +749,64 @@ export function buildServer(config: ServerConfig) {
         return reply.code(404).send({ error: 'Chat not found' });
       }
       const message = toErrorMessage(error, 'Failed to append chat event');
+      return reply.code(502).send({ error: message });
+    }
+  });
+
+  app.post('/v1/chats/:chatId/user-prompts', async (request, reply) => {
+    const { chatId } = request.params as { chatId: string };
+    const parsed = submitUserPromptSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'Invalid request body' });
+    }
+
+    try {
+      const session = await store.getSession(parsed.data.sessionId);
+      if (!session) {
+        return reply.code(404).send({ error: 'Session not found' });
+      }
+      if (!supportsChatScopedRuntime(session)) {
+        return reply.code(409).send({ error: 'Legacy sessions are read-only for chat-scoped runtime writes.' });
+      }
+      const event = await store.submitChatUserPrompt(chatId, parsed.data);
+      return reply.code(201).send({ event });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'SESSION_NOT_FOUND') {
+        return reply.code(404).send({ error: 'Session not found' });
+      }
+      if (error instanceof Error && error.message === 'CHAT_NOT_FOUND') {
+        return reply.code(404).send({ error: 'Chat not found' });
+      }
+      const message = toErrorMessage(error, 'Failed to submit user prompt');
+      return reply.code(502).send({ error: message });
+    }
+  });
+
+  app.post('/v1/chats/:chatId/terminal/commands', async (request, reply) => {
+    const { chatId } = request.params as { chatId: string };
+    const parsed = terminalCommandSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'Invalid request body' });
+    }
+
+    try {
+      const session = await store.getSession(parsed.data.sessionId);
+      if (!session) {
+        return reply.code(404).send({ error: 'Session not found' });
+      }
+      if (!supportsChatScopedRuntime(session)) {
+        return reply.code(409).send({ error: 'Legacy sessions are read-only for chat-scoped runtime writes.' });
+      }
+      const event = await store.runTerminalCommand(chatId, parsed.data);
+      return reply.code(201).send({ events: [event] });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'SESSION_NOT_FOUND') {
+        return reply.code(404).send({ error: 'Session not found' });
+      }
+      if (error instanceof Error && error.message === 'CHAT_NOT_FOUND') {
+        return reply.code(404).send({ error: 'Chat not found' });
+      }
+      const message = toErrorMessage(error, 'Failed to run terminal command');
       return reply.code(502).send({ error: message });
     }
   });

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from 'node:crypto';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
 import type {
   ApprovalPolicy,
   GeminiSessionCapabilities,
@@ -15,6 +17,10 @@ import { PrismaRuntimeStore } from './runtime/prismaStore.js';
 import { computeWorktreePath, ensureWorktree } from './runtime/worktreeManager.js';
 
 type RuntimeBackend = 'mock' | 'happy' | 'prisma';
+const execAsync = promisify(exec);
+const TERMINAL_COMMAND_TIMEOUT_MS = 30_000;
+const TERMINAL_COMMAND_MAX_BUFFER = 1024 * 1024;
+const TERMINAL_OUTPUT_MAX_CHARS = 12_000;
 
 type CreateSessionInput = {
   path: string;
@@ -44,6 +50,54 @@ type AppendMessageInput = {
   meta?: Record<string, unknown>;
 };
 
+type AppendChatEventInput = {
+  sessionId: string;
+  runId?: string;
+  type: string;
+  title?: string;
+  text: string;
+  meta?: Record<string, unknown>;
+};
+
+type RunTerminalCommandInput = {
+  sessionId: string;
+  command: string;
+};
+
+function asUserPromptInput(input: AppendMessageInput): AppendMessageInput {
+  return {
+    ...input,
+    type: 'message',
+    meta: {
+      ...(input.meta ?? {}),
+      actor: 'user',
+      kind: 'user_message',
+      role: 'user',
+    },
+  };
+}
+
+function asChatUserPromptInput(chatId: string, input: AppendChatEventInput): AppendChatEventInput {
+  return {
+    ...input,
+    type: 'message',
+    meta: {
+      ...(input.meta ?? {}),
+      chatId,
+      actor: 'user',
+      kind: 'user_message',
+      role: 'user',
+    },
+  };
+}
+
+function trimTerminalOutput(value: string): string {
+  if (value.length <= TERMINAL_OUTPUT_MAX_CHARS) {
+    return value;
+  }
+  return `${value.slice(0, TERMINAL_OUTPUT_MAX_CHARS)}\n\n[output truncated at ${TERMINAL_OUTPUT_MAX_CHARS} chars]`;
+}
+
 type CreatePermissionInput = {
   sessionId: string;
   chatId?: string | null;
@@ -63,10 +117,7 @@ interface RuntimeStoreBackend {
   listChatEvents?(chatId: string, options?: { afterSeq?: number; limit?: number }): Promise<RuntimeMessage[]>;
   listRealtimeEvents?(sessionId: string, options?: { afterCursor?: number; limit?: number; chatId?: string }): Promise<{ events: RuntimeMessage[]; cursor: number }>;
   appendMessage(sessionId: string, input: AppendMessageInput): Promise<RuntimeMessage>;
-  appendChatEvent?(
-    chatId: string,
-    input: { sessionId: string; runId?: string; type: string; title?: string; text: string; meta?: Record<string, unknown> },
-  ): Promise<RuntimeMessage>;
+  appendChatEvent?(chatId: string, input: AppendChatEventInput): Promise<RuntimeMessage>;
   getLatestUserMessageForAction?(sessionId: string, chatId?: string): Promise<AppendMessageInput | null>;
   applySessionAction(sessionId: string, action: SessionAction, chatId?: string): Promise<{ accepted: boolean; message: string; at: string }>;
   isSessionRunning(sessionId: string, chatId?: string): Promise<boolean>;
@@ -562,30 +613,97 @@ export class RuntimeStore {
   }
 
   async appendMessage(sessionId: string, input: AppendMessageInput) {
-    const created = await this.delegate.appendMessage(sessionId, input);
-    if (this.runtimeExecutor && input.meta?.role !== 'agent') {
-      await this.runtimeExecutor.triggerPersistedUserMessage(sessionId, input);
+    return this.delegate.appendMessage(sessionId, input);
+  }
+
+  async submitUserPrompt(sessionId: string, input: AppendMessageInput) {
+    const promptInput = asUserPromptInput(input);
+    const created = await this.delegate.appendMessage(sessionId, promptInput);
+    if (this.runtimeExecutor) {
+      await this.runtimeExecutor.triggerPersistedUserMessage(sessionId, promptInput);
     }
     return created;
   }
 
   async appendChatEvent(
     chatId: string,
-    input: { sessionId: string; runId?: string; type: string; title?: string; text: string; meta?: Record<string, unknown> },
+    input: AppendChatEventInput,
   ) {
     if (typeof this.delegate.appendChatEvent === 'function') {
-      const created = await this.delegate.appendChatEvent(chatId, input);
-      if (this.runtimeExecutor && input.meta?.role !== 'agent') {
-        await this.runtimeExecutor.triggerPersistedUserMessage(input.sessionId, {
-          type: input.type,
-          title: input.title,
-          text: input.text,
-          meta: input.meta,
-        });
-      }
-      return created;
+      return this.delegate.appendChatEvent(chatId, input);
     }
     throw new Error('APPEND_CHAT_EVENT_NOT_SUPPORTED');
+  }
+
+  async submitChatUserPrompt(chatId: string, input: AppendChatEventInput) {
+    if (typeof this.delegate.appendChatEvent !== 'function') {
+      throw new Error('APPEND_CHAT_EVENT_NOT_SUPPORTED');
+    }
+
+    const promptInput = asChatUserPromptInput(chatId, input);
+    const created = await this.delegate.appendChatEvent(chatId, promptInput);
+    if (this.runtimeExecutor) {
+      await this.runtimeExecutor.triggerPersistedUserMessage(promptInput.sessionId, {
+        type: promptInput.type,
+        title: promptInput.title,
+        text: promptInput.text,
+        meta: promptInput.meta,
+      });
+    }
+    return created;
+  }
+
+  async runTerminalCommand(chatId: string, input: RunTerminalCommandInput) {
+    const command = input.command.trim();
+    if (!command) {
+      throw new Error('COMMAND_REQUIRED');
+    }
+
+    const session = await this.delegate.getSession(input.sessionId);
+    if (!session) {
+      throw new Error('SESSION_NOT_FOUND');
+    }
+
+    const startedAt = new Date().toISOString();
+    let stdout = '';
+    let stderr = '';
+    let exitCode = 0;
+    try {
+      const result = await execAsync(command, {
+        cwd: session.metadata.path,
+        timeout: TERMINAL_COMMAND_TIMEOUT_MS,
+        maxBuffer: TERMINAL_COMMAND_MAX_BUFFER,
+        shell: '/bin/bash',
+      });
+      stdout = result.stdout;
+      stderr = result.stderr;
+    } catch (error) {
+      const err = error as Error & { stdout?: string; stderr?: string; code?: number | string };
+      stdout = err.stdout ?? '';
+      stderr = err.stderr ?? err.message;
+      exitCode = typeof err.code === 'number' ? err.code : 1;
+    }
+
+    const output = trimTerminalOutput([stdout, stderr].filter(Boolean).join('\n'));
+    const preview = output || '(no output)';
+    return this.appendChatEvent(chatId, {
+      sessionId: input.sessionId,
+      type: 'tool',
+      title: exitCode === 0 ? 'Terminal completed' : 'Terminal failed',
+      text: `$ ${command}\n${preview}`,
+      meta: {
+        role: 'terminal',
+        actor: 'terminal',
+        kind: 'terminal_result',
+        chatId,
+        actionType: 'command_execution',
+        composerMode: 'terminal',
+        startedAt,
+        completedAt: new Date().toISOString(),
+        exitCode,
+        command,
+      },
+    });
   }
 
   async listRealtimeEvents(sessionId: string, options?: { afterCursor?: number; limit?: number; chatId?: string }) {

--- a/services/aris-backend/tests/prismaRuntimeStore.test.ts
+++ b/services/aris-backend/tests/prismaRuntimeStore.test.ts
@@ -302,7 +302,7 @@ describe('PrismaRuntimeStore chat-scoped events', () => {
     expect(sessionChat.update).toHaveBeenCalledTimes(1);
   });
 
-  it('appends chat events with chat-local seq and updates the chat snapshot', async () => {
+  it('appends chat events with chat-local seq and updates the chat snapshot without starting runs from display role', async () => {
     const sessionChat = {
       findFirst: vi.fn().mockResolvedValue({
         id: 'chat-1',
@@ -352,14 +352,14 @@ describe('PrismaRuntimeStore chat-scoped events', () => {
     };
 
     const event = await store.appendChatEvent('chat-1', {
-        sessionId: 'session-1',
-        type: 'message',
-        title: 'Text Reply',
-        text: '완료',
-        meta: { role: 'user' },
-      });
+      sessionId: 'session-1',
+      type: 'message',
+      title: 'Text Reply',
+      text: '완료',
+      meta: { role: 'user' },
+    });
 
-    expect(sessionRun.create).toHaveBeenCalledTimes(1);
+    expect(sessionRun.create).not.toHaveBeenCalled();
     expect(sessionChatEvent.aggregate).toHaveBeenCalledWith({
       where: { chatId: 'chat-1' },
       _max: { seq: true },
@@ -368,7 +368,6 @@ describe('PrismaRuntimeStore chat-scoped events', () => {
       data: expect.objectContaining({
         chatId: 'chat-1',
         sessionId: 'session-1',
-        runId: 'run-1',
         seq: 3,
       }),
     }));
@@ -376,7 +375,7 @@ describe('PrismaRuntimeStore chat-scoped events', () => {
     expect(event.meta?.seq).toBe(3);
   });
 
-  it('marks the latest running run as completed when an agent event closes the chat turn', async () => {
+  it('marks the latest running run as completed when a lifecycle event closes the chat turn', async () => {
     const sessionChat = {
       findFirst: vi.fn().mockResolvedValue({
         id: 'chat-1',
@@ -432,9 +431,9 @@ describe('PrismaRuntimeStore chat-scoped events', () => {
     const event = await store.appendChatEvent('chat-1', {
       sessionId: 'session-1',
       type: 'message',
-      title: 'Text Reply',
-      text: '완료',
-      meta: { role: 'agent' },
+      title: 'Run Status',
+      text: 'run status: completed',
+      meta: { role: 'agent', streamEvent: 'run_status', sessionTurnStatus: 'completed' },
     });
 
     expect(sessionRun.findFirst).toHaveBeenCalledTimes(1);

--- a/services/aris-backend/tests/server.test.ts
+++ b/services/aris-backend/tests/server.test.ts
@@ -218,6 +218,109 @@ describe('aris-backend API', () => {
     await app.close();
   });
 
+  it('submits user prompts through the explicit chat prompt route', async () => {
+    const app = buildServer({
+      RUNTIME_API_TOKEN: TOKEN,
+      DEFAULT_PROJECT_PATH: '/tmp/project',
+      LOG_LEVEL: 'silent',
+    });
+
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: '/v1/sessions',
+      headers: {
+        ...authHeader(),
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({
+        path: '/tmp/project',
+        flavor: 'claude',
+      }),
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const sessionId = (createResponse.json() as { session: { id: string } }).session.id;
+
+    const promptResponse = await app.inject({
+      method: 'POST',
+      url: '/v1/chats/chat-1/user-prompts',
+      headers: {
+        ...authHeader(),
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({
+        sessionId,
+        type: 'message',
+        title: 'User Instruction',
+        text: '구조를 올바르게 리팩토링해줘',
+        meta: { role: 'user', agent: 'codex' },
+      }),
+    });
+
+    expect(promptResponse.statusCode).toBe(201);
+    const promptPayload = promptResponse.json() as { event?: { text?: string; meta?: { role?: string; chatId?: string } } };
+    expect(promptPayload.event).toEqual(expect.objectContaining({
+      text: '구조를 올바르게 리팩토링해줘',
+      meta: expect.objectContaining({
+        role: 'user',
+        chatId: 'chat-1',
+      }),
+    }));
+
+    await app.close();
+  });
+
+  it('runs terminal commands through a dedicated terminal command route', async () => {
+    const app = buildServer({
+      RUNTIME_API_TOKEN: TOKEN,
+      DEFAULT_PROJECT_PATH: '/tmp',
+      LOG_LEVEL: 'silent',
+    });
+
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: '/v1/sessions',
+      headers: {
+        ...authHeader(),
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({
+        path: '/tmp',
+        flavor: 'claude',
+      }),
+    });
+    expect(createResponse.statusCode).toBe(201);
+    const sessionId = (createResponse.json() as { session: { id: string } }).session.id;
+
+    const terminalResponse = await app.inject({
+      method: 'POST',
+      url: '/v1/chats/chat-1/terminal/commands',
+      headers: {
+        ...authHeader(),
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({
+        sessionId,
+        command: 'printf aris-terminal',
+      }),
+    });
+
+    expect(terminalResponse.statusCode).toBe(201);
+    const terminalPayload = terminalResponse.json() as {
+      events?: Array<{ text?: string; meta?: { role?: string; kind?: string; exitCode?: number; command?: string } }>;
+    };
+    expect(terminalPayload.events?.[0]).toEqual(expect.objectContaining({
+      text: expect.stringContaining('aris-terminal'),
+      meta: expect.objectContaining({
+        role: 'terminal',
+        kind: 'terminal_result',
+        exitCode: 0,
+        command: 'printf aris-terminal',
+      }),
+    }));
+
+    await app.close();
+  });
+
   it('returns Gemini capabilities even when the session flavor is not gemini', async () => {
     const app = buildServer({
       RUNTIME_API_TOKEN: TOKEN,

--- a/services/aris-backend/tests/store.test.ts
+++ b/services/aris-backend/tests/store.test.ts
@@ -30,6 +30,141 @@ describe('RuntimeStore.isSessionRunning', () => {
   });
 });
 
+describe('RuntimeStore.appendChatEvent', () => {
+  it('does not wake an agent turn for terminal-authored command events', async () => {
+    const delegate = {
+      appendChatEvent: vi.fn().mockResolvedValue({
+        id: 'event-1',
+        sessionId: 'session-1',
+        type: 'tool',
+        title: 'Terminal completed',
+        text: '$ pwd\n/home/ubuntu/project/ARIS',
+        meta: {
+          role: 'terminal',
+          chatId: 'chat-1',
+          command: 'pwd',
+        },
+      }),
+    };
+    const runtimeExecutor = {
+      triggerPersistedUserMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    const store = buildRuntimeStore({ delegate, runtimeExecutor });
+
+    await store.appendChatEvent('chat-1', {
+      sessionId: 'session-1',
+      type: 'tool',
+      title: 'Terminal completed',
+      text: '$ pwd\n/home/ubuntu/project/ARIS',
+      meta: {
+        role: 'terminal',
+        chatId: 'chat-1',
+        command: 'pwd',
+      },
+    });
+
+    expect(runtimeExecutor.triggerPersistedUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not wake an agent turn for persisted user chat messages', async () => {
+    const delegate = {
+      appendChatEvent: vi.fn().mockResolvedValue({
+        id: 'event-1',
+        sessionId: 'session-1',
+        type: 'message',
+        title: 'User Instruction',
+        text: 'continue',
+        meta: {
+          role: 'user',
+          chatId: 'chat-1',
+          agent: 'codex',
+        },
+      }),
+    };
+    const runtimeExecutor = {
+      triggerPersistedUserMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    const store = buildRuntimeStore({ delegate, runtimeExecutor });
+
+    await store.appendChatEvent('chat-1', {
+      sessionId: 'session-1',
+      type: 'message',
+      title: 'User Instruction',
+      text: 'continue',
+      meta: {
+        role: 'user',
+        chatId: 'chat-1',
+        agent: 'codex',
+      },
+    });
+
+    expect(runtimeExecutor.triggerPersistedUserMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('RuntimeStore.submitChatUserPrompt', () => {
+  it('persists the user prompt and explicitly wakes the agent turn', async () => {
+    const delegate = {
+      appendChatEvent: vi.fn().mockResolvedValue({
+        id: 'event-1',
+        sessionId: 'session-1',
+        type: 'message',
+        title: 'User Instruction',
+        text: 'continue',
+        meta: {
+          role: 'user',
+          chatId: 'chat-1',
+          agent: 'codex',
+        },
+      }),
+    };
+    const runtimeExecutor = {
+      triggerPersistedUserMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    const store = buildRuntimeStore({ delegate, runtimeExecutor });
+
+    await store.submitChatUserPrompt('chat-1', {
+      sessionId: 'session-1',
+      type: 'message',
+      title: 'User Instruction',
+      text: 'continue',
+      meta: {
+        actor: 'user',
+        role: 'user',
+        kind: 'user_message',
+        chatId: 'chat-1',
+        agent: 'codex',
+      },
+    });
+
+    expect(delegate.appendChatEvent).toHaveBeenCalledWith('chat-1', {
+      sessionId: 'session-1',
+      type: 'message',
+      title: 'User Instruction',
+      text: 'continue',
+      meta: {
+        actor: 'user',
+        kind: 'user_message',
+        role: 'user',
+        chatId: 'chat-1',
+        agent: 'codex',
+      },
+    });
+    expect(runtimeExecutor.triggerPersistedUserMessage).toHaveBeenCalledWith('session-1', {
+      type: 'message',
+      title: 'User Instruction',
+      text: 'continue',
+      meta: {
+        actor: 'user',
+        kind: 'user_message',
+        role: 'user',
+        chatId: 'chat-1',
+        agent: 'codex',
+      },
+    });
+  });
+});
+
 describe('RuntimeStore.applySessionAction', () => {
   it('replays the latest persisted chat user message when retry is requested', async () => {
     const delegate = {

--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -1673,12 +1673,24 @@ function ProjectDetailSurface({
   );
 }
 
-function readEventRole(event: UiEvent): 'user' | 'agent' {
-  return event.meta?.role === 'user' ? 'user' : 'agent';
+function readEventRole(event: UiEvent): 'user' | 'agent' | 'terminal' {
+  if (event.meta?.role === 'user') return 'user';
+  if (event.meta?.role === 'terminal') return 'terminal';
+  return 'agent';
 }
 
 function getEventText(event: UiEvent): string {
   return event.result?.preview || event.body || event.title;
+}
+
+function terminalCommand(event: UiEvent): string {
+  const metaCommand = typeof event.meta?.command === 'string' ? event.meta.command.trim() : '';
+  return event.action?.command || metaCommand || eventCommand(event);
+}
+
+function terminalOutput(event: UiEvent): string {
+  const bodyOutput = event.body.replace(/\r\n/g, '\n').split('\n').slice(1).join('\n').trim();
+  return event.result?.preview || bodyOutput || getEventText(event) || '(no output)';
 }
 
 function agentLabel(agent: SessionSummary['agent'], model?: string | null): string {
@@ -2217,33 +2229,47 @@ function ProjectChatSurface({
         throw new Error('활성 채팅을 찾지 못했습니다.');
       }
       const submittedAt = new Date().toISOString();
-      const response = await fetch(`/api/runtime/sessions/${encodeURIComponent(session.id)}/events`, {
+      const isTerminalMode = composerMode === 'terminal';
+      const endpoint = isTerminalMode ? `/api/runtime/sessions/${encodeURIComponent(session.id)}/terminal` : `/api/runtime/sessions/${encodeURIComponent(session.id)}/events`;
+      const payload = isTerminalMode ? {
+        chatId: chat.id,
+        command: text,
+        agent: selectedProvider,
+        model: activeModelLabel,
+        modelReasoningEffort: serializeReasoningEffort(selectedEffort),
+      } : {
+        type: 'message',
+        title: 'User Instruction',
+        text,
+        meta: {
+          role: 'user',
+          chatId: chat.id,
+          agent: selectedProvider,
+          model: activeModelLabel,
+          mode: composerMode,
+          modelReasoningEffort: serializeReasoningEffort(selectedEffort),
+          workspaceTab,
+        },
+      };
+      const response = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          type: 'message',
-          title: 'User Instruction',
-          text,
-          meta: {
-            role: 'user',
-            chatId: chat.id,
-            agent: selectedProvider,
-            model: activeModelLabel,
-            mode: composerMode,
-            modelReasoningEffort: serializeReasoningEffort(selectedEffort),
-            workspaceTab,
-          },
-        }),
+        body: JSON.stringify(payload),
       });
-      const body = (await response.json().catch(() => ({}))) as { event?: UiEvent; error?: string };
-      if (!response.ok || !body.event) {
+      const body = (await response.json().catch(() => ({}))) as { event?: UiEvent; events?: UiEvent[]; error?: string };
+      const submittedEvents = isTerminalMode
+        ? body.events ?? []
+        : body.event ? [body.event] : [];
+      if (!response.ok || submittedEvents.length === 0) {
         throw new Error(body.error ?? '메시지 전송에 실패했습니다.');
       }
+      const latestEvent = submittedEvents[submittedEvents.length - 1] as UiEvent;
+      const latestEventAt = latestEvent.timestamp || submittedAt;
       setPrompt('');
-      setEvents((previous) => [...previous, body.event as UiEvent]);
+      setEvents((previous) => [...previous, ...submittedEvents]);
       setChats((previous) => previous.map((item) => (
         item.id === chat.id
-          ? { ...item, latestPreview: text, latestEventAt: submittedAt, latestEventIsUser: true, lastActivityAt: submittedAt }
+          ? { ...item, latestPreview: isTerminalMode ? `$ ${text}` : text, latestEventAt, latestEventIsUser: !isTerminalMode, lastActivityAt: latestEventAt }
           : item
       )));
       void fetch(`/api/runtime/sessions/${encodeURIComponent(session.id)}/chats/${encodeURIComponent(chat.id)}`, {
@@ -2251,10 +2277,10 @@ function ProjectChatSurface({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           touchActivity: true,
-          latestPreview: text,
-          latestEventId: body.event.id,
-          latestEventAt: submittedAt,
-          latestEventIsUser: true,
+          latestPreview: isTerminalMode ? `$ ${text}` : text,
+          latestEventId: latestEvent.id,
+          latestEventAt,
+          latestEventIsUser: !isTerminalMode,
         }),
       });
     } catch (submitError) {
@@ -2402,8 +2428,9 @@ function ProjectChatSurface({
                 const event = item;
                 const role = readEventRole(item);
                 const isUser = role === 'user';
+                const isTerminal = role === 'terminal';
                 const snippet = item.parsed?.snippets?.[0];
-                const actionEvent = !isUser && isProjectActionEvent(item);
+                const actionEvent = !isUser && !isTerminal && isProjectActionEvent(item);
                 if (actionEvent) {
                   return (
                     <div key={item.id} className={`msg msg--action${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
@@ -2417,10 +2444,10 @@ function ProjectChatSurface({
                 }
                 return (
                   <div key={item.id} className={`msg${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
-                    <span className={`msg__avatar ${isUser ? 'msg__avatar--user' : agentAvatarClass(activeAgent)}`}>{isUser ? 'U' : agentInitial(activeAgent)}</span>
+                    <span className={`msg__avatar ${isUser ? 'msg__avatar--user' : isTerminal ? 'msg__avatar--terminal' : agentAvatarClass(activeAgent)}`}>{isUser ? 'U' : isTerminal ? <Terminal size={14} /> : agentInitial(activeAgent)}</span>
                     <div className="msg__body">
                       <div className="msg__header">
-                        <span className="msg__name">{isUser ? 'You' : agentLabel(activeAgent, activeModelLabel)}</span>
+                        <span className="msg__name">{isUser ? 'You' : isTerminal ? 'Terminal' : agentLabel(activeAgent, activeModelLabel)}</span>
                         <span className="msg__time">{formatRelativeTime(item.timestamp)}</span>
                       </div>
                       {isUser ? (
@@ -2438,6 +2465,11 @@ function ProjectChatSurface({
                             </div>
                           ) : null}
                         </>
+                      ) : isTerminal ? (
+                        <div className="msg__terminal-output" data-terminal-response>
+                          <div className="msg__terminal-command">$ {terminalCommand(item)}</div>
+                          <pre>{terminalOutput(item)}</pre>
+                        </div>
                       ) : (
                         <>
                           <div className="msg__text"><p>{getEventText(item)}</p></div>

--- a/services/aris-web/app/api/runtime/sessions/[sessionId]/events/route.ts
+++ b/services/aris-web/app/api/runtime/sessions/[sessionId]/events/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import path from 'node:path';
 import { requireApiUser } from '@/lib/auth/guard';
-import { getSessionEvents, appendSessionMessage, HappyHttpError } from '@/lib/happy/client';
+import { getSessionEvents, appendSessionMessage, submitUserPrompt, HappyHttpError } from '@/lib/happy/client';
 import { prisma } from '@/lib/db/prisma';
 import {
   normalizeSupportedAgent,
@@ -178,13 +178,20 @@ export async function POST(
       };
     }
 
-    const event = await appendSessionMessage({
-      sessionId,
-      type,
-      title: body.title,
-      text: body.text,
-      meta,
-    });
+    const event = role === 'user' && type === 'message'
+      ? await submitUserPrompt({
+          sessionId,
+          title: body.title,
+          text: body.text,
+          meta,
+        })
+      : await appendSessionMessage({
+          sessionId,
+          type,
+          title: body.title,
+          text: body.text,
+          meta,
+        });
     return NextResponse.json({ event });
   } catch (error) {
     if (error instanceof HappyHttpError && [401, 403, 404].includes(error.status)) {

--- a/services/aris-web/app/api/runtime/sessions/[sessionId]/terminal/route.ts
+++ b/services/aris-web/app/api/runtime/sessions/[sessionId]/terminal/route.ts
@@ -1,19 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
 import { requireApiUser } from '@/lib/auth/guard';
-import { appendSessionMessage, HappyHttpError } from '@/lib/happy/client';
+import { runChatTerminalCommand, HappyHttpError } from '@/lib/happy/client';
 import { getWorkspaceById } from '@/lib/happy/workspaces';
-
-const execAsync = promisify(exec);
-const MAX_OUTPUT_CHARS = 12000;
-
-function trimOutput(value: string): string {
-  if (value.length <= MAX_OUTPUT_CHARS) {
-    return value;
-  }
-  return `${value.slice(0, MAX_OUTPUT_CHARS)}\n\n[output truncated at ${MAX_OUTPUT_CHARS} chars]`;
-}
 
 export async function POST(
   request: NextRequest,
@@ -46,62 +34,14 @@ export async function POST(
     return NextResponse.json({ error: 'WORKSPACE_NOT_FOUND' }, { status: 404 });
   }
 
-  const startedAt = new Date().toISOString();
   try {
-    const userEvent = await appendSessionMessage({
+    const events = await runChatTerminalCommand({
       sessionId,
-      type: 'message',
-      title: 'Terminal Command',
-      text: command,
-      meta: {
-        role: 'user',
-        chatId,
-        agent: body.agent,
-        model: body.model,
-        modelReasoningEffort: body.modelReasoningEffort,
-        composerMode: 'terminal',
-      },
+      chatId,
+      command,
     });
 
-    let stdout = '';
-    let stderr = '';
-    let exitCode = 0;
-    try {
-      const result = await execAsync(command, {
-        cwd: workspace.path,
-        timeout: 30000,
-        maxBuffer: 1024 * 1024,
-        shell: '/bin/bash',
-      });
-      stdout = result.stdout;
-      stderr = result.stderr;
-    } catch (error) {
-      const err = error as Error & { stdout?: string; stderr?: string; code?: number };
-      stdout = err.stdout ?? '';
-      stderr = err.stderr ?? err.message;
-      exitCode = typeof err.code === 'number' ? err.code : 1;
-    }
-
-    const output = trimOutput([stdout, stderr].filter(Boolean).join('\n'));
-    const preview = output || '(no output)';
-    const resultEvent = await appendSessionMessage({
-      sessionId,
-      type: 'tool',
-      title: exitCode === 0 ? 'Terminal completed' : 'Terminal failed',
-      text: `$ ${command}\n${preview}`,
-      meta: {
-        role: 'agent',
-        chatId,
-        kind: 'command_execution',
-        composerMode: 'terminal',
-        startedAt,
-        completedAt: new Date().toISOString(),
-        exitCode,
-        command,
-      },
-    });
-
-    return NextResponse.json({ events: [userEvent, resultEvent] });
+    return NextResponse.json({ events });
   } catch (error) {
     if (error instanceof HappyHttpError && [401, 403, 404].includes(error.status)) {
       return NextResponse.json({ error: error.message }, { status: error.status });

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -2868,6 +2868,15 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 .pc-proto .msg__avatar--codex { background: var(--agent-codex); }
 .pc-proto .msg__avatar--gemini { background: var(--agent-gemini); }
 .pc-proto .msg__avatar--sys { background: var(--n-400); }
+.pc-proto .msg__avatar--terminal {
+  background: var(--n-900);
+  color: #fff;
+}
+
+.pc-proto .msg__avatar--terminal svg {
+  width: 14px;
+  height: 14px;
+}
 
 .pc-proto .msg__body {
   flex: 1;
@@ -2913,6 +2922,31 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 }
 
 .pc-proto .msg__text p {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.pc-proto .msg__terminal-output {
+  width: min(680px, 100%);
+  padding: 10px 12px;
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  background: var(--surface-sunken);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.pc-proto .msg__terminal-command {
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.pc-proto .msg__terminal-output pre {
   margin: 0;
   white-space: pre-wrap;
   overflow-wrap: anywhere;

--- a/services/aris-web/lib/happy/client.ts
+++ b/services/aris-web/lib/happy/client.ts
@@ -820,6 +820,73 @@ export async function appendSessionMessage(input: {
   throw new Error('백엔드 응답에서 이벤트를 읽을 수 없습니다.');
 }
 
+export async function submitUserPrompt(input: {
+  sessionId: string;
+  title?: string;
+  text: string;
+  meta?: Record<string, unknown>;
+}): Promise<UiEvent> {
+  const chatId = typeof input.meta?.chatId === 'string' && input.meta.chatId.trim().length > 0
+    ? input.meta.chatId.trim()
+    : null;
+  const raw = chatId
+    ? await fetchHappy(`/v1/chats/${encodeURIComponent(chatId)}/user-prompts`, {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: input.sessionId,
+          type: 'message',
+          title: input.title,
+          text: input.text,
+          meta: input.meta,
+        }),
+      })
+    : await fetchHappy(`/v1/sessions/${encodeURIComponent(input.sessionId)}/user-prompts`, {
+        method: 'POST',
+        body: JSON.stringify({
+          type: 'message',
+          title: input.title,
+          text: input.text,
+          meta: input.meta,
+        }),
+      });
+
+  const obj = asObject(raw);
+  const message = obj?.message ?? obj?.event;
+  const normalized = normalizeEvents(message ? [message] : []);
+  if (normalized[0]) {
+    return normalized[0];
+  }
+
+  throw new Error('백엔드 응답에서 사용자 프롬프트 이벤트를 읽을 수 없습니다.');
+}
+
+export async function runChatTerminalCommand(input: {
+  sessionId: string;
+  chatId: string;
+  command: string;
+}): Promise<UiEvent[]> {
+  const raw = await fetchHappy(`/v1/chats/${encodeURIComponent(input.chatId)}/terminal/commands`, {
+    method: 'POST',
+    body: JSON.stringify({
+      sessionId: input.sessionId,
+      command: input.command,
+    }),
+  });
+  const events = normalizeEvents(extractArrayPayload(raw, 'events'));
+  if (events.length > 0) {
+    return events;
+  }
+
+  const obj = asObject(raw);
+  const event = obj?.event;
+  const normalized = normalizeEvents(event ? [event] : []);
+  if (normalized.length > 0) {
+    return normalized;
+  }
+
+  throw new Error('백엔드 응답에서 터미널 실행 결과를 읽을 수 없습니다.');
+}
+
 export async function getSessionRealtimeEvents(input: {
   sessionId: string;
   afterCursor?: number;

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const homeClient = readFileSync(resolve(__dirname, '../app/HomePageClient.tsx'), 'utf8');
 const uiCss = readFileSync(resolve(__dirname, '../app/styles/ui.css'), 'utf8');
+const terminalRoute = readFileSync(resolve(__dirname, '../app/api/runtime/sessions/[sessionId]/terminal/route.ts'), 'utf8');
 
 function cssBlock(selector: string) {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -147,7 +148,7 @@ describe('project list surface', () => {
   it('renders project chat action events through a dedicated action-card branch', () => {
     expect(homeClient).toContain('function isProjectActionEvent(event: UiEvent): boolean');
     expect(homeClient).toContain('function ProjectActionCard({');
-    expect(homeClient).toContain('const actionEvent = !isUser && isProjectActionEvent(item);');
+    expect(homeClient).toContain('const actionEvent = !isUser && !isTerminal && isProjectActionEvent(item);');
     expect(homeClient).toContain('if (actionEvent) {');
     expect(homeClient).toContain('data-project-action-card');
     expect(homeClient).toContain('className="pc-action-card"');
@@ -156,6 +157,43 @@ describe('project list surface', () => {
     expect(homeClient).toContain('className="pc-action-card__preview"');
     expect(homeClient).toContain("handleCopy(eventCommand(event), 'Action command')");
     expect(homeClient).not.toContain('const toolLike = !isUser && isToolLikeEvent(item);');
+  });
+
+  it('routes Terminal composer submissions through the command execution endpoint', () => {
+    const submitStart = homeClient.indexOf('const handleSubmit = async');
+    const submitEnd = homeClient.indexOf('const projectShellClasses =', submitStart);
+    const submitSource = homeClient.slice(submitStart, submitEnd);
+
+    expect(submitSource).toContain("const isTerminalMode = composerMode === 'terminal';");
+    expect(submitSource).toContain("isTerminalMode ? `/api/runtime/sessions/${encodeURIComponent(session.id)}/terminal`");
+    expect(submitSource).toContain('command: text,');
+    expect(submitSource).toContain("const body = (await response.json().catch(() => ({}))) as { event?: UiEvent; events?: UiEvent[]; error?: string };");
+    expect(submitSource).toContain('const submittedEvents = isTerminalMode');
+    expect(submitSource).toContain('setEvents((previous) => [...previous, ...submittedEvents]);');
+  });
+
+  it('renders Terminal command output as a Terminal timeline response with its own avatar', () => {
+    expect(homeClient).toContain("function readEventRole(event: UiEvent): 'user' | 'agent' | 'terminal'");
+    expect(homeClient).toContain("if (event.meta?.role === 'terminal') return 'terminal';");
+    expect(homeClient).toContain('const isTerminal = role === \'terminal\';');
+    expect(homeClient).toContain('data-terminal-response');
+    expect(homeClient).toContain('className="msg__terminal-command"');
+    expect(homeClient).toContain('<Terminal size={14} />');
+    expect(homeClient).toContain("{isUser ? 'You' : isTerminal ? 'Terminal' : agentLabel(activeAgent, activeModelLabel)}");
+    expect(cssBlock('.pc-proto .msg__avatar--terminal')).toContain('background: var(--n-900);');
+    expect(cssBlock('.pc-proto .msg__terminal-output')).toContain('font-family: var(--font-mono);');
+  });
+
+  it('marks command execution results as Terminal-authored events', () => {
+    expect(terminalRoute).toContain('runChatTerminalCommand({');
+    expect(terminalRoute).toContain('command,');
+    expect(terminalRoute).not.toContain("from 'node:child_process'");
+    expect(terminalRoute).not.toContain('execAsync(command');
+    expect(terminalRoute).not.toContain('appendSessionMessage');
+    expect(terminalRoute).not.toContain("role: 'agent'");
+    expect(terminalRoute).not.toContain("displayRole: 'terminal'");
+    expect(terminalRoute).not.toContain("role: 'user'");
+    expect(terminalRoute).toContain('return NextResponse.json({ events });');
   });
 
   it('uses the prototype workspace panel icon and toggle wiring in the chat header', () => {


### PR DESCRIPTION
## 변경 요약

- Project chat Terminal 모드가 `/terminal` 웹 라우트를 거쳐 백엔드의 전용 terminal command 유스케이스로 실행되도록 연결했습니다.
- `appendMessage` / `appendChatEvent`는 저장 전용으로 두고, 사용자 프롬프트 실행은 `submitUserPrompt` / `submitChatUserPrompt`에서만 에이전트를 깨우도록 분리했습니다.
- Terminal 실행 결과는 `role: terminal`, `actor: terminal`, `kind: terminal_result` 메타를 가진 Terminal 이벤트로 저장되고, 더 이상 에이전트 응답으로 표시되거나 agent run을 트리거하지 않습니다.
- Prisma chat run 처리는 `role`이 아니라 `sessionTurnStatus` / `runStatus` lifecycle 이벤트를 기준으로 시작/완료되도록 바꿨습니다.

## 검증

- `services/aris-backend`: `rtk npm test -- --run tests/store.test.ts tests/server.test.ts tests/prismaRuntimeStore.test.ts`
- `services/aris-backend`: `rtk npm run typecheck`
- `services/aris-web`: `rtk npm test -- --run tests/projectListSurface.test.ts`
- `services/aris-web`: `rtk npx tsc --noEmit`
- repo root: `rtk git diff --check`
- dev proxy: `https://lawdigest.cloud/proxy/2235/`
