### PR TITLE
feat(aris-web): wire HomePageClient Stop + Files panel

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -50,6 +50,8 @@ import { withAppBasePath } from '@/lib/routing/appPath';
 import { applyTheme, readThemeMode, type ThemeMode } from '@/lib/theme/clientTheme';
 import type { AuthenticatedUser } from '@/lib/auth/types';
 import type { SessionChat, SessionStatus, SessionSummary, UiEvent } from '@/lib/happy/types';
+import { abortActiveChat } from '@/lib/runtime/abortChat';
+import { useWorkspaceFiles, type WorkspaceFileItem } from '@/lib/hooks/useWorkspaceFiles';
 
 type ProjectView = 'overview' | 'chats' | 'chat' | 'files' | 'context';
 type ComposerMode = 'agent' | 'plan' | 'terminal';
@@ -1857,6 +1859,7 @@ function ProjectChatSurface({
   const [isLoadingChats, setIsLoadingChats] = useState(true);
   const [isLoadingEvents, setIsLoadingEvents] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isAborting, setIsAborting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const activeChat = selectedChatId ? chats.find((chat) => chat.id === selectedChatId) ?? null : null;
   const runtimeModelLabel = activeChat?.model ?? modelLabel;
@@ -1877,7 +1880,7 @@ function ProjectChatSurface({
   const [selectedEffort, setSelectedEffort] = useState<ReasoningEffort>(() => normalizeReasoningEffort(activeChat?.modelReasoningEffort));
   const [expandedTurnId, setExpandedTurnId] = useState<ExpandedTurnState>(null);
   const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
-  const [selectedWorkspaceFile, setSelectedWorkspaceFile] = useState('HomePageClient.tsx');
+  const [selectedWorkspaceFile, setSelectedWorkspaceFile] = useState('');
   const [draftTerminalCommand, setDraftTerminalCommand] = useState('npm test -- --run tests/projectListSurface.test.ts');
   const [previewDevice, setPreviewDevice] = useState<'1200' | '768' | '390'>('1200');
   const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
@@ -1895,13 +1898,7 @@ function ProjectChatSurface({
   const previewTarget = `aris.lawdigest.cloud${projectChatRoute}`;
   const prototypeRef = useRef<HTMLDivElement | null>(null);
   const composerWrapRef = useRef<HTMLElement | null>(null);
-  const workspaceFiles = [
-    { id: 'root', name: projectPath, kind: 'dir', meta: 'project' },
-    { id: 'home-client', name: 'services/aris-web/app/HomePageClient.tsx', kind: 'file', meta: '+ UI' },
-    { id: 'ui-css', name: 'services/aris-web/app/styles/ui.css', kind: 'file', meta: '+ CSS' },
-    { id: 'surface-test', name: 'services/aris-web/tests/projectListSurface.test.ts', kind: 'file', meta: '+ tests' },
-    { id: 'prototype', name: 'design/chat-prototype.html', kind: 'file', meta: 'source' },
-  ];
+  const workspaceFiles = useWorkspaceFiles('/workspace');
   const terminalSnippets = [
     { id: 'test', name: 'test target', cmd: 'npm test -- --run tests/projectListSurface.test.ts', tag: 'test' },
     { id: 'mobile', name: 'mobile guard', cmd: 'npm test -- --run tests/mobileOverflowLayout.test.ts', tag: 'mobile' },
@@ -2290,6 +2287,21 @@ function ProjectChatSurface({
     }
   };
 
+  const handleStopActiveChat = useCallback(async () => {
+    if (isAborting) return;
+    if (!isSubmitting && !activeChat) return;
+    setIsAborting(true);
+    try {
+      await abortActiveChat({ sessionId: session.id, chatId: activeChat?.id });
+      showTransientFeedback('Stop 요청을 보냈습니다');
+    } catch (abortError) {
+      setError(abortError instanceof Error ? abortError.message : '에이전트 실행 중단에 실패했습니다.');
+    } finally {
+      setIsAborting(false);
+      setIsSubmitting(false);
+    }
+  }, [activeChat, isAborting, isSubmitting, session.id]);
+
   if (!selectedChatId) {
     return (
       <div className="pc-chat-directory" data-project-chat-list>
@@ -2654,15 +2666,28 @@ function ProjectChatSurface({
                 </div>
                 <div className="cmp__right">
                   <span className="cmp__hint"><span className="kbd">⌘</span><span className="kbd">↵</span><span>send</span></span>
-                  <button
-                    type="submit"
-                    className={`cmp__send${isSubmitting ? ' cmp__send--running' : ''}`}
-                    disabled={isSubmitting ? false : !prompt.trim()}
-                    aria-label={isSubmitting ? 'Stop generation' : 'Send message'}
-                  >
-                    {isSubmitting ? 'Stop' : 'Send'}
-                    {isSubmitting ? <Square size={11} /> : <Send size={13} />}
-                  </button>
+                  {isSubmitting || isAborting ? (
+                    <button
+                      type="button"
+                      className={`cmp__send cmp__send--running${isAborting ? ' cmp__send--aborting' : ''}`}
+                      disabled={isAborting}
+                      aria-label="Stop generation"
+                      onClick={() => { void handleStopActiveChat(); }}
+                    >
+                      {isAborting ? 'Stopping…' : 'Stop'}
+                      <Square size={11} />
+                    </button>
+                  ) : (
+                    <button
+                      type="submit"
+                      className="cmp__send"
+                      disabled={!prompt.trim()}
+                      aria-label="Send message"
+                    >
+                      Send
+                      <Send size={13} />
+                    </button>
+                  )}
                 </div>
               </div>
             </form>
@@ -2698,7 +2723,15 @@ function ProjectChatSurface({
             </div>
             <div className="ws__status-right">
               <span>{tokenLabel}</span>
-              <button type="button" className="ws__stop" aria-label="Stop" onClick={() => showTransientFeedback('Stop request staged for this project chat')}><Square size={10} /></button>
+              <button
+                type="button"
+                className="ws__stop"
+                aria-label="Stop"
+                disabled={!isSubmitting && !isAborting}
+                onClick={() => { void handleStopActiveChat(); }}
+              >
+                <Square size={10} />
+              </button>
             </div>
           </div>
           <div className="ws__body">
@@ -2780,22 +2813,60 @@ function ProjectChatSurface({
               </div>
             </div>
             <div className={`ws__pane${workspaceTab === 'files' ? ' ws__pane--active' : ''}`} data-pane="files">
+              <div className="file-tree__head">
+                <span className="file-tree__cwd" title={workspaceFiles.currentPath}>{workspaceFiles.currentPath}</span>
+                <button
+                  type="button"
+                  className="file-tree__refresh"
+                  aria-label="Refresh files"
+                  onClick={() => workspaceFiles.refresh()}
+                  disabled={workspaceFiles.loading}
+                >
+                  <RefreshCcw size={11} />
+                </button>
+              </div>
               <div className="file-tree">
-                {workspaceFiles.map((file) => (
+                {workspaceFiles.parentPath && (
                   <button
-                    key={file.id}
                     type="button"
-                    className={`file-row${selectedWorkspaceFile === file.name ? ' file-row--selected' : ''}`}
+                    className="file-row file-row--parent"
+                    onClick={() => workspaceFiles.goUp()}
+                  >
+                    <span className="file-row__icon file-row__icon--dir">
+                      <FolderOpen size={13} />
+                    </span>
+                    <span className="file-row__name">..</span>
+                    <span className="file-row__meta">parent</span>
+                  </button>
+                )}
+                {workspaceFiles.loading && workspaceFiles.items.length === 0 && (
+                  <div className="file-row file-row--state">Loading…</div>
+                )}
+                {workspaceFiles.error && (
+                  <div className="file-row file-row--state file-row--error">{workspaceFiles.error}</div>
+                )}
+                {!workspaceFiles.loading && !workspaceFiles.error && workspaceFiles.items.length === 0 && (
+                  <div className="file-row file-row--state">빈 디렉터리</div>
+                )}
+                {workspaceFiles.items.map((file: WorkspaceFileItem) => (
+                  <button
+                    key={file.path}
+                    type="button"
+                    className={`file-row${selectedWorkspaceFile === file.path ? ' file-row--selected' : ''}`}
                     onClick={() => {
-                      setSelectedWorkspaceFile(file.name);
-                      if (file.kind === 'file') setPreviewState('dock');
+                      if (file.isDirectory) {
+                        workspaceFiles.cdInto(file);
+                      } else {
+                        setSelectedWorkspaceFile(file.path);
+                        setPreviewState('dock');
+                      }
                     }}
                   >
-                    <span className={`file-row__icon${file.kind === 'dir' ? ' file-row__icon--dir' : ''}`}>
-                      {file.kind === 'dir' ? <FolderOpen size={13} /> : <FileText size={13} />}
+                    <span className={`file-row__icon${file.isDirectory ? ' file-row__icon--dir' : ''}`}>
+                      {file.isDirectory ? <FolderOpen size={13} /> : <FileText size={13} />}
                     </span>
                     <span className="file-row__name">{file.name}</span>
-                    <span className="file-row__meta">{file.meta}</span>
+                    <span className="file-row__meta">{file.isDirectory ? 'dir' : 'file'}</span>
                   </button>
                 ))}
               </div>

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -4162,6 +4162,70 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
   flex-shrink: 0;
 }
 
+.pc-proto .file-tree__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-default);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-tertiary);
+}
+
+.pc-proto .file-tree__cwd {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+}
+
+.pc-proto .file-tree__refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.pc-proto .file-tree__refresh:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}
+
+.pc-proto .file-row--parent .file-row__name {
+  color: var(--text-secondary);
+}
+
+.pc-proto .file-row--state {
+  padding: 8px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  cursor: default;
+}
+
+.pc-proto .file-row--state.file-row--error {
+  color: var(--accent-danger, #d8554d);
+}
+
+.pc-proto .cmp__send--aborting {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.pc-proto .ws__stop:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .pc-proto .term {
   overflow: hidden;
   background: #0F1117;

--- a/services/aris-web/lib/hooks/useWorkspaceFiles.ts
+++ b/services/aris-web/lib/hooks/useWorkspaceFiles.ts
@@ -1,0 +1,127 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export type WorkspaceFileItem = {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+  isFile: boolean;
+};
+
+export type WorkspaceFilesApi = {
+  currentPath: string;
+  parentPath: string | null;
+  items: WorkspaceFileItem[];
+  loading: boolean;
+  error: string | null;
+  cdInto: (item: WorkspaceFileItem) => void;
+  cd: (path: string) => void;
+  goUp: () => void;
+  refresh: () => void;
+};
+
+type ListResponse = {
+  currentPath?: string;
+  parentPath?: string | null;
+  directories?: unknown;
+  error?: string;
+};
+
+function normalizeItem(raw: unknown): WorkspaceFileItem | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const candidate = raw as Record<string, unknown>;
+  const name = typeof candidate.name === 'string' ? candidate.name : null;
+  const itemPath = typeof candidate.path === 'string' ? candidate.path : null;
+  if (!name || !itemPath) return null;
+  return {
+    name,
+    path: itemPath,
+    isDirectory: candidate.isDirectory === true,
+    isFile: candidate.isFile === true,
+  };
+}
+
+export function useWorkspaceFiles(initialPath: string): WorkspaceFilesApi {
+  const [currentPath, setCurrentPath] = useState(initialPath);
+  const [parentPath, setParentPath] = useState<string | null>(null);
+  const [items, setItems] = useState<WorkspaceFileItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const url = `/api/fs/list?path=${encodeURIComponent(currentPath)}`;
+        const response = await fetch(url, { cache: 'no-store', signal: controller.signal });
+        const body = (await response.json().catch(() => ({}))) as ListResponse;
+        if (cancelled) return;
+
+        if (!response.ok) {
+          throw new Error(typeof body.error === 'string' && body.error.length > 0
+            ? body.error
+            : '파일 목록을 불러올 수 없습니다.');
+        }
+
+        const rawItems = Array.isArray(body.directories) ? body.directories : [];
+        const normalized = rawItems
+          .map((entry) => normalizeItem(entry))
+          .filter((entry): entry is WorkspaceFileItem => entry !== null);
+        setItems(normalized);
+        setParentPath(typeof body.parentPath === 'string' ? body.parentPath : null);
+      } catch (err) {
+        if (cancelled || (err instanceof DOMException && err.name === 'AbortError')) return;
+        setError(err instanceof Error ? err.message : '파일 목록을 불러올 수 없습니다.');
+        setItems([]);
+        setParentPath(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [currentPath, refreshKey]);
+
+  const cdInto = useCallback((item: WorkspaceFileItem) => {
+    if (item.isDirectory) {
+      setCurrentPath(item.path);
+    }
+  }, []);
+
+  const cd = useCallback((next: string) => {
+    if (typeof next === 'string' && next.length > 0) {
+      setCurrentPath(next);
+    }
+  }, []);
+
+  const goUp = useCallback(() => {
+    if (parentPath) {
+      setCurrentPath(parentPath);
+    }
+  }, [parentPath]);
+
+  const refresh = useCallback(() => {
+    setRefreshKey((value) => value + 1);
+  }, []);
+
+  return {
+    currentPath,
+    parentPath,
+    items,
+    loading,
+    error,
+    cdInto,
+    cd,
+    goUp,
+    refresh,
+  };
+}

--- a/services/aris-web/lib/runtime/abortChat.ts
+++ b/services/aris-web/lib/runtime/abortChat.ts
@@ -1,0 +1,36 @@
+export type AbortChatInput = {
+  sessionId: string;
+  chatId?: string | null;
+};
+
+export type AbortChatResult = {
+  accepted: boolean;
+  message: string;
+};
+
+export async function abortActiveChat({ sessionId, chatId }: AbortChatInput): Promise<AbortChatResult> {
+  const trimmedChatId = typeof chatId === 'string' && chatId.trim().length > 0 ? chatId.trim() : undefined;
+  const response = await fetch(`/api/runtime/sessions/${encodeURIComponent(sessionId)}/actions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action: 'abort', chatId: trimmedChatId }),
+    cache: 'no-store',
+  });
+
+  const body = (await response.json().catch(() => ({}))) as {
+    error?: string;
+    result?: { accepted?: boolean; message?: string };
+  };
+
+  if (!response.ok) {
+    throw new Error(typeof body?.error === 'string' && body.error.length > 0
+      ? body.error
+      : '에이전트 실행 중단에 실패했습니다.');
+  }
+
+  const result = body?.result ?? {};
+  return {
+    accepted: Boolean(result.accepted),
+    message: typeof result.message === 'string' ? result.message : '',
+  };
+}

--- a/services/aris-web/tests/abortChat.test.ts
+++ b/services/aris-web/tests/abortChat.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { abortActiveChat } from '@/lib/runtime/abortChat';
+
+describe('abortActiveChat', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs the abort action with chatId trimmed', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: { accepted: true, message: 'ok' } }),
+    });
+
+    const result = await abortActiveChat({ sessionId: 'sess-1', chatId: '  chat-9  ' });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/runtime/sessions/sess-1/actions');
+    expect(init.method).toBe('POST');
+    expect(init.cache).toBe('no-store');
+    expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
+    expect(JSON.parse(init.body as string)).toEqual({ action: 'abort', chatId: 'chat-9' });
+    expect(result).toEqual({ accepted: true, message: 'ok' });
+  });
+
+  it('omits chatId when blank', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: {} }),
+    });
+
+    await abortActiveChat({ sessionId: 'sess-2', chatId: '   ' });
+
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(init.body as string)).toEqual({ action: 'abort', chatId: undefined });
+  });
+
+  it('throws with backend error when not ok', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: '권한 없음' }),
+    });
+
+    await expect(abortActiveChat({ sessionId: 'sess-3' })).rejects.toThrow('권한 없음');
+  });
+
+  it('throws default message when error body missing', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+
+    await expect(abortActiveChat({ sessionId: 'sess-4' })).rejects.toThrow('에이전트 실행 중단에 실패했습니다.');
+  });
+});


### PR DESCRIPTION
## Summary
- HomePageClient의 composer Stop과 workspace Stop이 toast/no-op이었던 문제를 해결. 새 헬퍼 `abortActiveChat`이 기존 `POST /api/runtime/sessions/{id}/actions { action: 'abort', chatId }` 라우트를 호출. composer는 Send/Stop을 분리된 두 버튼으로 렌더(submit vs type=button)하고, isAborting 동안 `Stopping…`로 표시.
- 우측 workspace **Files** 패널의 하드코딩된 `workspaceFiles` 5-row 더미를 제거. 새 `useWorkspaceFiles('/workspace')` hook을 만들어 `GET /api/fs/list`로 실제 디렉터리/파일 트리를 로드. 부모 폴더(..) 행, refresh 버튼, loading/empty/error 상태, 파일 클릭 시 preview dock 트리거를 지원.
- 새 클래스(file-tree__head, file-tree__cwd, file-tree__refresh, file-row--parent/state/error, cmp__send--aborting, ws__stop:disabled)에 대한 최소 CSS를 `services/aris-web/app/styles/ui.css`에 추가.
- 새 helper `services/aris-web/lib/runtime/abortChat.ts`와 hook `services/aris-web/lib/hooks/useWorkspaceFiles.ts`. abortChat 단위 테스트 4개 추가.

## Test plan
- [x] `npx tsc --noEmit` (services/aris-web)
- [x] `npx vitest run tests/abortChat.test.ts` → 4 PASS
- [x] `npx vitest run tests/chatComposer*.ts tests/projectListSurface.test.ts` → 34 PASS
- [ ] dev proxy `https://lawdigest.cloud/proxy/2233/` 에서:
  - 채팅 전송 후 응답 도중 Send→Stop 클릭 → 백엔드 `applySessionAction sessionId=… action=abort` 발생 + composer가 idle로 복귀
  - 우측 workspace Files 탭 → `/workspace` 트리 진입/이탈, 파일 클릭 시 `selectedWorkspaceFile` 갱신 + preview dock 표시
  - 401/403 시 에러 토스트
