### PR TITLE
feat(aris-web): real Preview dock with File / URL toggle

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -59,6 +59,7 @@ import type { AuthenticatedUser } from '@/lib/auth/types';
 import type { SessionChat, SessionStatus, SessionSummary, UiEvent } from '@/lib/happy/types';
 import { abortActiveChat } from '@/lib/runtime/abortChat';
 import { useWorkspaceFiles, type WorkspaceFileItem } from '@/lib/hooks/useWorkspaceFiles';
+import { WorkspacePreview, type WorkspacePreviewMode } from '@/components/preview/WorkspacePreview';
 
 type ProjectView = 'overview' | 'chats' | 'chat' | 'files' | 'context';
 type ComposerMode = 'agent' | 'plan' | 'terminal';
@@ -2016,6 +2017,10 @@ function ProjectChatSurface({
   const [selectedWorkspaceFile, setSelectedWorkspaceFile] = useState('');
   const [draftTerminalCommand, setDraftTerminalCommand] = useState('npm test -- --run tests/projectListSurface.test.ts');
   const [previewDevice, setPreviewDevice] = useState<'1200' | '768' | '390'>('1200');
+  const [previewSourceMode, setPreviewSourceMode] = useState<WorkspacePreviewMode>('file');
+  const [previewRefreshKey, setPreviewRefreshKey] = useState(0);
+  const [previewZoom, setPreviewZoom] = useState(1);
+  const [previewUrl, setPreviewUrl] = useState('');
   const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
   const visibleEvents = events.slice(-40);
   const activeModelLabel = selectedModel || runtimeModelLabel;
@@ -2029,6 +2034,18 @@ function ProjectChatSurface({
     ?? new Date().toISOString();
   const projectChatRoute = `/?tab=project&project=${session.id}&view=chat${selectedChatId ? `&chat=${selectedChatId}` : ''}`;
   const previewTarget = `aris.lawdigest.cloud${projectChatRoute}`;
+  const defaultPreviewUrl = `https://${previewTarget}`;
+  const effectivePreviewUrl = previewUrl.trim().length > 0 ? previewUrl.trim() : defaultPreviewUrl;
+  const handlePreviewRefresh = () => {
+    setPreviewRefreshKey((value) => value + 1);
+    showTransientFeedback('Preview refreshed');
+  };
+  const handlePreviewZoomOut = () => {
+    setPreviewZoom((value) => Math.max(0.5, Math.round((value - 0.1) * 100) / 100));
+  };
+  const handlePreviewZoomIn = () => {
+    setPreviewZoom((value) => Math.min(1.5, Math.round((value + 0.1) * 100) / 100));
+  };
   const prototypeRef = useRef<HTMLDivElement | null>(null);
   const composerWrapRef = useRef<HTMLElement | null>(null);
   const workspaceFiles = useWorkspaceFiles('/workspace');
@@ -3095,53 +3112,72 @@ function ProjectChatSurface({
           <div className="preview-topbar">
             <div className="preview-topbar__nav">
               <button type="button" className="preview-topbar__btn" aria-label="Back"><ChevronLeft size={13} /></button>
-              <button type="button" className="preview-topbar__btn" aria-label="Refresh" onClick={() => showTransientFeedback('Preview refreshed')}><RefreshCcw size={13} /></button>
+              <button type="button" className="preview-topbar__btn" aria-label="Refresh" onClick={handlePreviewRefresh}><RefreshCcw size={13} /></button>
             </div>
-            <div className="preview-url">
-              <span className="preview-url__protocol">https://</span>
-              <span className="preview-url__target">{previewTarget}</span>
-              <span className="preview-url__meta">project</span>
+            <div className="preview-source" role="tablist" aria-label="Preview source">
+              <button
+                type="button"
+                className={`preview-source__chip${previewSourceMode === 'file' ? ' preview-source__chip--active' : ''}`}
+                aria-pressed={previewSourceMode === 'file'}
+                onClick={() => setPreviewSourceMode('file')}
+              >
+                File
+              </button>
+              <button
+                type="button"
+                className={`preview-source__chip${previewSourceMode === 'url' ? ' preview-source__chip--active' : ''}`}
+                aria-pressed={previewSourceMode === 'url'}
+                onClick={() => setPreviewSourceMode('url')}
+              >
+                URL
+              </button>
             </div>
+            {previewSourceMode === 'url' ? (
+              <input
+                type="url"
+                className="preview-url preview-url--input"
+                value={previewUrl}
+                placeholder={defaultPreviewUrl}
+                onChange={(event) => setPreviewUrl(event.target.value)}
+                aria-label="Preview URL"
+              />
+            ) : (
+              <div className="preview-url" title={selectedWorkspaceFile || '파일 미선택'}>
+                <span className="preview-url__protocol">file://</span>
+                <span className="preview-url__target">{selectedWorkspaceFile || '— 파일을 선택하세요 —'}</span>
+                <span className="preview-url__meta">file</span>
+              </div>
+            )}
             <div className="preview-device" role="tablist" aria-label="Preview size">
               {(['1200', '768', '390'] as const).map((device) => (
                 <button key={device} type="button" aria-pressed={previewDevice === device} onClick={() => setPreviewDevice(device)}>{device}</button>
               ))}
             </div>
-            <button type="button" className="preview-topbar__btn" aria-label="Copy preview URL" onClick={() => handleCopy(`https://${previewTarget}`, 'Preview URL')}><ExternalLink size={13} /></button>
+            <button
+              type="button"
+              className="preview-topbar__btn"
+              aria-label="Copy preview URL"
+              onClick={() => handleCopy(previewSourceMode === 'url' ? effectivePreviewUrl : selectedWorkspaceFile, 'Preview URL')}
+            >
+              <ExternalLink size={13} />
+            </button>
             <button type="button" className="preview-topbar__btn" data-preview-dock aria-label="Dock preview" onClick={() => setPreviewState('dock')}><PanelsTopLeft size={13} /></button>
             <button type="button" className="preview-topbar__btn" aria-label="Close preview" onClick={() => setPreviewState('closed')}><X size={13} /></button>
           </div>
           <div className="preview-canvas" data-preview-size={previewDevice}>
-            <div className="preview-page">
-              <aside className="preview-page__sb">
-                <div className="preview-page__sb-logo">ARIS</div>
-                <div className="preview-page__sb-item preview-page__sb-item--active">{displayProjectName(session)}</div>
-                <div className="preview-page__sb-item">{activeChat?.title ?? 'Project chat'}</div>
-                <div className="preview-page__sb-item">{selectedWorkspaceFile}</div>
-              </aside>
-              <main className="preview-page__main">
-                <h2 className="preview-page__h">{activeChat?.title ?? 'Project chat'}</h2>
-                <p className="preview-page__sub">{agentLabel(activeAgent, activeModelLabel)} · {COMPOSER_MODE_COPY[composerMode]} · {tokenLabel}</p>
-                <div className="preview-page__cards">
-                  <div className="preview-page__card">
-                    <div className="preview-page__card-t">Workspace</div>
-                    <div className="preview-page__card-m">{workspaceTab} · {selectedWorkspaceFile}</div>
-                    <div className="preview-page__bar"><div className="preview-page__bar-fill" style={{ width: '74%' }} /></div>
-                  </div>
-                  <div className="preview-page__card">
-                    <div className="preview-page__card-t">Context</div>
-                    <div className="preview-page__card-m">{projectPath}</div>
-                    <div className="preview-page__bar"><div className="preview-page__bar-fill" style={{ width: '42%' }} /></div>
-                  </div>
-                </div>
-              </main>
-            </div>
+            <WorkspacePreview
+              filePath={selectedWorkspaceFile || null}
+              mode={previewSourceMode}
+              url={effectivePreviewUrl}
+              refreshKey={previewRefreshKey}
+              zoom={previewZoom}
+            />
             <div className="preview-controls">
-              <button type="button" aria-label="Zoom out" onClick={() => showTransientFeedback('Preview zoom 90%')}><ChevronLeft size={12} /></button>
-              <span className="preview-controls__zoom">100%</span>
-              <button type="button" aria-label="Zoom in" onClick={() => showTransientFeedback('Preview zoom 110%')}><ChevronRight size={12} /></button>
+              <button type="button" aria-label="Zoom out" onClick={handlePreviewZoomOut} disabled={previewZoom <= 0.5}><ChevronLeft size={12} /></button>
+              <span className="preview-controls__zoom">{Math.round(previewZoom * 100)}%</span>
+              <button type="button" aria-label="Zoom in" onClick={handlePreviewZoomIn} disabled={previewZoom >= 1.5}><ChevronRight size={12} /></button>
               <span className="preview-controls__sep" />
-              <button type="button" aria-label="Screenshot" onClick={() => showTransientFeedback('Screenshot staged')}><Copy size={12} /></button>
+              <button type="button" aria-label="Screenshot" onClick={() => showTransientFeedback('Screenshot capture not implemented yet')}><Copy size={12} /></button>
             </div>
           </div>
         </div>

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -5283,6 +5283,123 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
   background: linear-gradient(90deg, #5E82FD, #1E50DB);
 }
 
+.pc-proto .preview-source {
+  display: inline-flex;
+  padding: 2px;
+  background: var(--surface-sunken);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  flex-shrink: 0;
+}
+
+.pc-proto .preview-source__chip {
+  padding: 3px 10px;
+  border-radius: var(--r-sm);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.pc-proto .preview-source__chip--active {
+  background: var(--surface);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-xs);
+}
+
+.pc-proto .preview-url--input {
+  display: block;
+  width: 100%;
+  outline: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-primary);
+}
+
+.pc-proto .ws-preview {
+  position: relative;
+  width: min(90%, 960px);
+  height: min(80%, 720px);
+  background: #fff;
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-lg);
+  overflow: auto;
+  color: #0F1117;
+}
+
+.pc-proto .preview-canvas[data-preview-size="768"] .ws-preview {
+  width: min(76%, 720px);
+}
+
+.pc-proto .preview-canvas[data-preview-size="390"] .ws-preview {
+  width: min(42%, 390px);
+  min-width: 280px;
+  aspect-ratio: 9 / 16;
+  height: auto;
+}
+
+.pc-proto .ws-preview__inner {
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+}
+
+.pc-proto .ws-preview__file,
+.pc-proto .ws-preview__url,
+.pc-proto .ws-preview__pdf {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #fff;
+}
+
+.pc-proto .ws-preview__image-frame {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  background: #0F1117;
+  padding: 16px;
+}
+
+.pc-proto .ws-preview__image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.pc-proto .ws-preview__empty {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 24px;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  text-align: center;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.pc-proto .ws-preview__empty--error {
+  color: var(--accent-danger, #d8554d);
+}
+
+.pc-proto .ws-preview__empty-meta {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  word-break: break-all;
+}
+
+.pc-proto .preview-controls button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .pc-proto .preview-controls {
   position: absolute;
   right: 18px;

--- a/services/aris-web/components/preview/WorkspacePreview.tsx
+++ b/services/aris-web/components/preview/WorkspacePreview.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { WorkspaceFileEditor } from '@/components/files/WorkspaceFileEditor';
+
+export type WorkspacePreviewMode = 'file' | 'url';
+
+export type WorkspacePreviewProps = {
+  filePath: string | null;
+  mode: WorkspacePreviewMode;
+  url: string;
+  refreshKey: number;
+  zoom: number;
+  className?: string;
+};
+
+type FileKind = 'text' | 'image' | 'pdf' | 'binary';
+
+const TEXT_EXTENSIONS = new Set([
+  'md', 'mdx', 'markdown', 'txt', 'log',
+  'js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs',
+  'json', 'yaml', 'yml', 'toml', 'ini', 'env',
+  'css', 'scss', 'less', 'html', 'htm', 'xml', 'svg',
+  'py', 'rb', 'go', 'rs', 'java', 'kt', 'swift',
+  'sh', 'bash', 'zsh',
+  'sql', 'graphql', 'gql',
+]);
+
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'bmp', 'ico']);
+
+function getExtension(filePath: string): string {
+  const slash = filePath.lastIndexOf('/');
+  const last = slash >= 0 ? filePath.slice(slash + 1) : filePath;
+  const dot = last.lastIndexOf('.');
+  if (dot < 0) return '';
+  return last.slice(dot + 1).toLowerCase();
+}
+
+function classifyFile(filePath: string): FileKind {
+  const ext = getExtension(filePath);
+  if (!ext) return 'text';
+  if (ext === 'pdf') return 'pdf';
+  if (IMAGE_EXTENSIONS.has(ext)) return 'image';
+  if (TEXT_EXTENSIONS.has(ext)) return 'text';
+  return 'binary';
+}
+
+function fileNameOf(filePath: string): string {
+  const slash = filePath.lastIndexOf('/');
+  return slash >= 0 ? filePath.slice(slash + 1) : filePath;
+}
+
+function FilePreviewBody({ filePath, refreshKey }: { filePath: string; refreshKey: number }) {
+  const [content, setContent] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const kind = useMemo(() => classifyFile(filePath), [filePath]);
+
+  useEffect(() => {
+    if (kind !== 'text') return;
+    let cancelled = false;
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const url = `/api/fs/read?path=${encodeURIComponent(filePath)}`;
+        const response = await fetch(url, { cache: 'no-store', signal: controller.signal });
+        const body = (await response.json().catch(() => ({}))) as { content?: string; error?: string; blockedReason?: string };
+        if (cancelled) return;
+        if (!response.ok) {
+          throw new Error(typeof body.error === 'string' && body.error.length > 0
+            ? body.error
+            : '파일을 불러올 수 없습니다.');
+        }
+        if (typeof body.blockedReason === 'string' && body.blockedReason.length > 0) {
+          setContent('');
+          setError(body.blockedReason);
+          return;
+        }
+        setContent(typeof body.content === 'string' ? body.content : '');
+      } catch (err) {
+        if (cancelled || (err instanceof DOMException && err.name === 'AbortError')) return;
+        setError(err instanceof Error ? err.message : '파일을 불러올 수 없습니다.');
+        setContent('');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [filePath, kind, refreshKey]);
+
+  if (kind === 'image') {
+    return (
+      <div className="ws-preview__image-frame">
+        <img
+          key={refreshKey}
+          src={`/api/fs/raw?path=${encodeURIComponent(filePath)}`}
+          alt={fileNameOf(filePath)}
+          className="ws-preview__image"
+        />
+      </div>
+    );
+  }
+
+  if (kind === 'pdf') {
+    return (
+      <iframe
+        key={refreshKey}
+        src={`/api/fs/raw?path=${encodeURIComponent(filePath)}`}
+        title={fileNameOf(filePath)}
+        className="ws-preview__pdf"
+      />
+    );
+  }
+
+  if (kind === 'binary') {
+    return (
+      <div className="ws-preview__empty">
+        <p>이 파일 형식은 미리보기를 지원하지 않습니다.</p>
+        <p className="ws-preview__empty-meta">{filePath}</p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return <div className="ws-preview__empty">파일을 불러오는 중…</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="ws-preview__empty ws-preview__empty--error">
+        <p>{error}</p>
+        <p className="ws-preview__empty-meta">{filePath}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ws-preview__file">
+      <WorkspaceFileEditor
+        fileName={fileNameOf(filePath)}
+        content={content}
+        filePath={filePath}
+        rawUrl={`/api/fs/raw?path=${encodeURIComponent(filePath)}`}
+        onChange={() => { /* read-only preview */ }}
+        onSave={() => { /* read-only preview */ }}
+        saveDisabled
+      />
+    </div>
+  );
+}
+
+function UrlPreviewBody({ url, refreshKey }: { url: string; refreshKey: number }) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+    iframe.src = url;
+  }, [url, refreshKey]);
+
+  if (!url) {
+    return (
+      <div className="ws-preview__empty">
+        <p>URL을 입력해 주세요.</p>
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      ref={iframeRef}
+      title="Workspace URL preview"
+      className="ws-preview__url"
+      sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+    />
+  );
+}
+
+export function WorkspacePreview({ filePath, mode, url, refreshKey, zoom, className }: WorkspacePreviewProps) {
+  const containerClass = `ws-preview${className ? ` ${className}` : ''}`;
+  const innerStyle = { transform: `scale(${zoom})`, transformOrigin: 'top left' };
+
+  return (
+    <div className={containerClass} data-mode={mode}>
+      <div className="ws-preview__inner" style={innerStyle}>
+        {mode === 'file' ? (
+          filePath ? (
+            <FilePreviewBody filePath={filePath} refreshKey={refreshKey} />
+          ) : (
+            <div className="ws-preview__empty">
+              <p>왼쪽 Files 패널에서 파일을 선택하세요.</p>
+            </div>
+          )
+        ) : (
+          <UrlPreviewBody url={url} refreshKey={refreshKey} />
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 우측 workspace overlay의 Preview가 정적 mock-DOM이었던 부분을 실제 미리보기로 교체. 새 컴포넌트 `WorkspacePreview` (services/aris-web/components/preview/WorkspacePreview.tsx)가 두 가지 모드를 처리.
  - **File 모드**: 선택된 워크스페이스 파일을 확장자 기반으로 분기. 텍스트/마크다운/코드는 `/api/fs/read` → 기존 `WorkspaceFileEditor` (read-only). 이미지는 `/api/fs/raw`를 `<img>`로, PDF는 같은 endpoint를 `<iframe>`으로. 비텍스트/대용량/blocked 파일은 fallback 메시지.
  - **URL 모드**: 입력한 URL을 sandboxed `<iframe>`으로 직접 로드. 디폴트 값은 기존 `https://${previewTarget}`. 사용자가 입력란에서 URL을 자유롭게 바꿀 수 있음.
- Topbar에 **File / URL chip 토글** 추가. URL 모드일 때 URL 입력란이 편집 가능, File 모드일 때 선택된 파일 경로를 표시.
- Refresh 버튼이 실제로 `previewRefreshKey`를 증가시켜 fetch / iframe `src`를 재할당.
- Zoom 버튼이 실제 `transform: scale(...)`을 적용 (0.5~1.5 단계, 0.1 단위). Zoom 표시도 실제 % 값.
- Screenshot 버튼은 본 PR 범위 외이므로 `Screenshot capture not implemented yet` 토스트로 명시적 다운그레이드.

## Test plan
- [x] `npx tsc --noEmit` (services/aris-web)
- [x] `npx vitest run tests/abortChat.test.ts tests/chatComposer.test.ts tests/projectListSurface.test.ts` → 29 PASS
- [ ] dev proxy `https://lawdigest.cloud/proxy/2233/` 에서:
  - 우측 Files에서 `.md` / `.tsx` / `.png` / `.pdf` 각각 클릭 후 preview overlay 열기 → 각 형식이 정상 렌더되는지
  - File / URL 토글 → URL 모드에서 기본 URL이 `https://aris.lawdigest.cloud/?tab=…`로 들어오고, iframe이 로드(또는 X-Frame-Options 차단 시 빈 iframe)되는지
  - URL 입력란을 임의 URL(예: `https://example.com`)로 바꾸고 Refresh → 새 src로 재로드
  - Zoom in/out 클릭 → 우측 미리보기가 0.6 → 1.0 → 1.4 등 단계로 스케일 변화
  - Screenshot 버튼 클릭 → "not implemented yet" 토스트
