### PR TITLE
fix(backend): skip latestPreview update for lifecycle events

### DIFF
--- a/services/aris-backend/src/runtime/prismaStore.ts
+++ b/services/aris-backend/src/runtime/prismaStore.ts
@@ -526,7 +526,7 @@ export class PrismaRuntimeStore {
       await tx.sessionChat.update({
         where: { id: chatId },
         data: {
-          latestPreview: input.text.slice(0, 280),
+          ...(lifecycleStatus === null && { latestPreview: input.text.slice(0, 280) }),
           latestEventId: created.id,
           latestEventAt: created.createdAt,
           latestEventIsUser: input.meta?.role === 'user',


### PR DESCRIPTION
## Summary
- `appendChatEvent`에서 lifecycle 이벤트(completed/failed/aborted/run_started)가 `latestPreview`를 덮어쓰던 버그 수정
- 홈 화면 Recent Projects에서 마지막 메시지 대신 "run status: completed" 텍스트가 표시되던 문제 해결
- `lifecycleStatus === null`일 때만 `latestPreview`를 업데이트하도록 변경

## Test plan
- [ ] 채팅 완료 후 홈 화면 Recent Projects에서 마지막 실제 메시지가 표시되는지 확인
- [ ] run이 failed/aborted로 끝나도 동일하게 동작하는지 확인
- [ ] 기존 latestPreview가 정상 메시지인 경우 변경되지 않는지 확인