### PR TITLE
fix(aris-web): navigate to chat directly when clicking chat list rows

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -410,7 +410,7 @@ function ProjectRecentChatRows({
             key={chat.id}
             type="button"
             className="home-proj__chat home-proj__chat--button"
-            onClick={() => onChatOpen(chat.id)}
+            onClick={(e) => { e.stopPropagation(); onChatOpen(chat.id); }}
           >
             {content}
           </button>
@@ -1262,7 +1262,7 @@ function HomeSurface({
                 </div>
                 <ChevronRight size={15} />
               </div>
-              <ProjectRecentChatRows session={session} />
+              <ProjectRecentChatRows session={session} onChatOpen={(chatId) => onProjectOpen(session.id, 'chat', chatId)} />
               <div className="home-proj__foot">
                 <span>{session.totalChats ?? 0} chats</span>
                 <span>{formatRelativeTime(latestChatActivityAt ?? session.lastActivityAt)}</span>
@@ -3302,6 +3302,7 @@ function ProjectSurface({
                 className="home-proj__chats--project-list"
                 emptyCopy="프로젝트에서 채팅을 시작하면 최근 내역이 여기에 표시됩니다."
                 session={session}
+                onChatOpen={(chatId) => onProjectChatOpen(session.id, chatId)}
               />
               <div className="proj-list-card__foot">
                 <span className="proj-list-card__foot-meta">last {formatRelativeTime(latestChatActivityAt ?? session.lastActivityAt)}</span>


### PR DESCRIPTION
## Summary
- `ProjectRecentChatRows`에 `onChatOpen`이 없어서 채팅 행 클릭이 상위 컨테이너로 버블링되던 문제 수정
- 홈 화면 프로젝트 카드, 프로젝트 목록 카드 두 곳 모두 수정
- 이제 채팅 행 클릭 시 해당 채팅으로 바로 진입

## Root cause
`ProjectRecentChatRows`에 `onChatOpen` prop이 전달되지 않으면 채팅 행이 `<div>`(비대화형)로 렌더링됨.
클릭이 상위 `<button>`/`<article>`으로 버블링 → `onProjectOpen(session.id)` 호출 → 프로젝트 홈으로 이동.

## Changes
- `ProjectRecentChatRows` 버튼 onClick에 `e.stopPropagation()` 추가
- `HomeSurface` 프로젝트 카드에 `onChatOpen` 전달
- `ProjectSurface` 목록 카드에 `onChatOpen` 전달

## Test plan
- [ ] 홈 화면 프로젝트 카드의 채팅 행 클릭 → 해당 채팅으로 직접 진입되는지 확인
- [ ] 프로젝트 목록 카드의 채팅 행 클릭 → 해당 채팅으로 직접 진입되는지 확인
- [ ] 프로젝트 카드 자체(채팅 행 제외 영역) 클릭 → 프로젝트 홈으로 이동하는지 확인