### PR TITLE
fix(aris-web): replace nested button with article in home project card

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -1248,12 +1248,14 @@ function HomeSurface({
           const latestChatActivityAt = session.recentChats?.[0] ? chatActivityAt(session.recentChats[0]) : null;
 
           return (
-            <button
+            <article
               key={session.id}
-              type="button"
               className="home-proj"
+              role="button"
+              tabIndex={0}
               data-project-href={buildProjectDetailPath(session.id)}
               onClick={() => onProjectOpen(session.id)}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onProjectOpen(session.id); } }}
             >
               <div className="home-proj__head">
                 <div>
@@ -1267,7 +1269,7 @@ function HomeSurface({
                 <span>{session.totalChats ?? 0} chats</span>
                 <span>{formatRelativeTime(latestChatActivityAt ?? session.lastActivityAt)}</span>
               </div>
-            </button>
+            </article>
           );
         })}
       </section>


### PR DESCRIPTION
## Summary
- 이전 PR에서 `ProjectRecentChatRows`에 `onChatOpen`을 추가하면서 `<button>` 안에 `<button>`이 생기는 중첩 버튼 문제 발생
- 브라우저가 무효한 HTML을 강제 재배치하면서 "Recent Chat 등이 맨 위에 로드되는" UI 레이아웃 붕괴 발생
- 외부 `<button>`을 `<article role="button">`으로 교체해 내부 버튼을 허용

## Test plan
- [ ] 홈 화면 로드 시 "Recent Chat" 등이 맨 위에 튀어오르는 현상 없는지 확인
- [ ] 프로젝트 카드 클릭 → 프로젝트 홈으로 이동 확인
- [ ] 프로젝트 카드 내 채팅 행 클릭 → 해당 채팅으로 이동 확인