### PR TITLE
fix: hide and cleanup empty chats with no messages

### DIFF
--- a/services/aris-backend/src/index.ts
+++ b/services/aris-backend/src/index.ts
@@ -19,18 +19,45 @@ async function bootstrap() {
     process.exit(1);
   }
 
+  const runtimeStore = (app as typeof app & {
+    arisRuntimeStore?: {
+      cleanupEmptyChats: (maxAgeMs: number) => Promise<number>;
+      beginShutdownDrain: () => void;
+      awaitDrain: (timeoutMs: number) => Promise<void>;
+    };
+  }).arisRuntimeStore;
+
+  const isClusterPrimary = process.env.NODE_APP_INSTANCE === undefined
+    || process.env.NODE_APP_INSTANCE === '0';
+  const EMPTY_CHAT_MAX_AGE_MS = 60 * 60 * 1000;
+  const CLEANUP_INTERVAL_MS = 10 * 60 * 1000;
+  let cleanupTimer: NodeJS.Timeout | null = null;
+  if (runtimeStore && isClusterPrimary) {
+    const runCleanup = async () => {
+      try {
+        const removed = await runtimeStore.cleanupEmptyChats(EMPTY_CHAT_MAX_AGE_MS);
+        if (removed > 0) {
+          app.log.info({ removed }, 'cleaned up empty chats');
+        }
+      } catch (error) {
+        app.log.error(error, 'failed to cleanup empty chats');
+      }
+    };
+    void runCleanup();
+    cleanupTimer = setInterval(() => { void runCleanup(); }, CLEANUP_INTERVAL_MS);
+    cleanupTimer.unref();
+  }
+
   let shuttingDown = false;
   const shutdown = async () => {
     if (shuttingDown) {
       return;
     }
     shuttingDown = true;
-    const runtimeStore = (app as typeof app & {
-      arisRuntimeStore?: {
-        beginShutdownDrain: () => void;
-        awaitDrain: (timeoutMs: number) => Promise<void>;
-      };
-    }).arisRuntimeStore;
+    if (cleanupTimer) {
+      clearInterval(cleanupTimer);
+      cleanupTimer = null;
+    }
     runtimeStore?.beginShutdownDrain();
     await app.close();
     await runtimeStore?.awaitDrain(drainTimeoutMs);

--- a/services/aris-backend/src/runtime/prismaStore.ts
+++ b/services/aris-backend/src/runtime/prismaStore.ts
@@ -270,6 +270,17 @@ export class PrismaRuntimeStore {
     await this.db.$disconnect();
   }
 
+  async cleanupEmptyChats(maxAgeMs: number): Promise<number> {
+    const threshold = new Date(Date.now() - maxAgeMs);
+    const result = await this.db.sessionChat.deleteMany({
+      where: {
+        latestEventId: null,
+        createdAt: { lt: threshold },
+      },
+    });
+    return result.count;
+  }
+
   private async runRuntimeWriteMutationWithRetry<T>(
     operation: (tx: Prisma.TransactionClient) => Promise<T>,
   ): Promise<T> {

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -753,6 +753,13 @@ export class RuntimeStore {
     this.runtimeExecutor?.beginShutdownDrain();
   }
 
+  async cleanupEmptyChats(maxAgeMs: number): Promise<number> {
+    if (this.delegate instanceof PrismaRuntimeStore) {
+      return this.delegate.cleanupEmptyChats(maxAgeMs);
+    }
+    return 0;
+  }
+
   async awaitDrain(timeoutMs: number): Promise<void> {
     if (!this.runtimeExecutor) {
       return;

--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -51,7 +51,7 @@ import {
 import { BottomNav, TabType } from '@/components/layout/BottomNav';
 import { BackendNotice } from '@/components/ui/BackendNotice';
 import { ProviderLogo, type ProviderLogoProvider } from '@/components/ui/ProviderLogo';
-import { selectRecentChats, selectRecentProjects, type HomeRecentChat } from './homeProjects';
+import { isChatEmpty, selectRecentChats, selectRecentProjects, type HomeRecentChat } from './homeProjects';
 import { readUiEventRunStatus } from '@/lib/happy/chatRuntime';
 import { withAppBasePath } from '@/lib/routing/appPath';
 import { applyTheme, readThemeMode, type ThemeMode } from '@/lib/theme/clientTheme';
@@ -390,7 +390,7 @@ function ProjectRecentChatRows({
   onChatOpen?: (chatId: string) => void;
   session: SessionSummary;
 }) {
-  const chats = (session.recentChats ?? []).slice(0, 2);
+  const chats = (session.recentChats ?? []).filter((chat) => !isChatEmpty(chat)).slice(0, 2);
 
   return (
     <div className={`home-proj__chats${className ? ` ${className}` : ''}`}>

--- a/services/aris-web/app/homeProjects.ts
+++ b/services/aris-web/app/homeProjects.ts
@@ -23,6 +23,10 @@ function chatActivityTime(chat: SessionChat): number {
   );
 }
 
+export function isChatEmpty(chat: SessionChat): boolean {
+  return chat.latestEventId == null && !(chat.latestPreview ?? '').trim();
+}
+
 function displaySessionName(session: SessionSummary): string {
   const candidate = session.alias || session.projectName || session.id;
   const normalized = candidate.replace(/\\/g, '/').replace(/\/+$/, '');
@@ -56,12 +60,14 @@ export function selectRecentChats(
   const count = Math.max(0, Math.floor(limit));
 
   return sessions
-    .flatMap((session) => (session.recentChats ?? []).map((chat): HomeRecentChat => ({
-      ...chat,
-      sessionName: displaySessionName(session),
-      sessionProjectPath: session.projectName || session.id,
-      sessionLastActivityAt: session.lastActivityAt,
-    })))
+    .flatMap((session) => (session.recentChats ?? [])
+      .filter((chat) => !isChatEmpty(chat))
+      .map((chat): HomeRecentChat => ({
+        ...chat,
+        sessionName: displaySessionName(session),
+        sessionProjectPath: session.projectName || session.id,
+        sessionLastActivityAt: session.lastActivityAt,
+      })))
     .sort((a, b) => {
       const timeDelta = chatActivityTime(b) - chatActivityTime(a);
       if (timeDelta !== 0) return timeDelta;


### PR DESCRIPTION
## Summary
빈 채팅(메시지 없는 채팅)이 홈 화면 Recent Chat 등에 계속 노출되던 문제 해결.

### 1. 프론트엔드 필터링
- `selectRecentChats`(홈 화면 Recent Chat feed)에서 빈 채팅 제외
- `ProjectRecentChatRows`(프로젝트 카드 내 최근 채팅)에서 빈 채팅 제외
- 판정 기준: `latestEventId == null && !latestPreview.trim()`
- 프로젝트 내 채팅 디렉토리(전체 목록)에는 그대로 표시 — 사용자가 방금 만든 채팅을 잃지 않도록

### 2. 백엔드 자동 정리
- `PrismaRuntimeStore.cleanupEmptyChats(maxAgeMs)`: `latestEventId IS NULL AND createdAt < now - maxAgeMs` 조건의 채팅 일괄 삭제
- 부트스트랩에서 10분마다 cleanup 실행, 임계값 1시간
- 클러스터 모드에서는 `NODE_APP_INSTANCE === '0'` 인스턴스만 실행 (중복 방지)
- shutdown 시 interval 정리

## Test plan
- [ ] 새 채팅 생성 직후 → 홈 Recent Chat에 노출되지 않음 (1번 효과)
- [ ] 새 채팅 생성 → 첫 메시지 전송 → 홈 Recent Chat에 노출됨
- [ ] 1시간 이상 메시지 없는 빈 채팅이 자동 삭제되는지 확인 (2번 효과)
- [ ] 백엔드 로그에 `cleaned up empty chats` 출력 확인