### PR TITLE
feat(aris-web): improve home Recent Project readability and show 3 recent chats

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -390,7 +390,7 @@ function ProjectRecentChatRows({
   onChatOpen?: (chatId: string) => void;
   session: SessionSummary;
 }) {
-  const chats = (session.recentChats ?? []).filter((chat) => !isChatEmpty(chat)).slice(0, 2);
+  const chats = (session.recentChats ?? []).filter((chat) => !isChatEmpty(chat)).slice(0, 3);
 
   return (
     <div className={`home-proj__chats${className ? ` ${className}` : ''}`}>

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -1318,10 +1318,11 @@ html[data-theme='dark'] .home-proj:focus-visible {
 }
 
 .home-proj__title {
-  font-size: var(--text-sm);
-  font-weight: 600;
+  font-size: var(--text-h4);
+  font-weight: 700;
   color: var(--text-primary);
-  letter-spacing: 0;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
@@ -1330,10 +1331,10 @@ html[data-theme='dark'] .home-proj:focus-visible {
 }
 
 .home-proj__path {
-  font-size: var(--text-2xs);
-  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
-  margin-top: 2px;
+  margin-top: 4px;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/services/aris-web/lib/happy/homeSessions.ts
+++ b/services/aris-web/lib/happy/homeSessions.ts
@@ -39,7 +39,7 @@ function toSessionChat(record: PrismaSessionChat): SessionChat {
 export async function enrichSessionsWithRecentChats(
   userId: string,
   sessions: SessionSummary[],
-  recentPerSession = 2,
+  recentPerSession = 5,
 ): Promise<SessionSummary[]> {
   const sessionIds = sessions.map((session) => session.id);
   if (sessionIds.length === 0) {


### PR DESCRIPTION
## Summary
랜딩(홈) 화면 Recent Project 카드의 프로젝트명 가독성 개선 + 최근 채팅 노출 3개로 확장.

### Changes
- **CSS**: \`.home-proj__title\` 13px/600 → 16px/700, letter-spacing -0.01em, line-height 1.3 (시인성 강화)
- **CSS**: \`.home-proj__path\` 11px → 12px, color tertiary → secondary (가독성 개선)
- **컴포넌트**: \`ProjectRecentChatRows\`에서 \`slice(0, 2)\` → \`slice(0, 3)\` (3개 노출)
- **백엔드 쿼리**: \`enrichSessionsWithRecentChats\` default \`recentPerSession\` 2 → 5 (빈 채팅 필터 후에도 3개 보장)

## Test plan
- [ ] 홈 화면 Recent Project 카드의 프로젝트명이 더 잘 보이는지 확인
- [ ] 카드당 최근 채팅 3개까지 노출되는지 확인
- [ ] 채팅이 1~2개뿐인 프로젝트도 정상 렌더링 확인