### PR TITLE
feat(aris-web): default project detail to Chats tab and redesign chat list

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -258,13 +258,14 @@ function normalizeTab(tab: string | null): TabType {
 
 function normalizeProjectView(view: string | null): ProjectView {
   switch (view) {
-    case 'chats':
     case 'chat':
+    case 'overview':
     case 'files':
     case 'context':
       return view;
+    case 'chats':
     default:
-      return 'overview';
+      return 'chats';
   }
 }
 
@@ -468,11 +469,11 @@ function deriveProjectTokenLabel(session: SessionSummary, index: number): string
   return `${total.toFixed(1)}k`;
 }
 
-function buildProjectDetailPath(sessionId: string, view: ProjectView = 'overview', chatId?: string | null): string {
+function buildProjectDetailPath(sessionId: string, view: ProjectView = 'chats', chatId?: string | null): string {
   const params = new URLSearchParams();
   params.set('tab', 'project');
   params.set('project', sessionId);
-  if (view !== 'overview') {
+  if (view !== 'chats') {
     params.set('view', view);
   }
   if (view === 'chat' && chatId) {
@@ -1526,14 +1527,6 @@ function ProjectDetailSurface({
       <nav className="proj-tabs" aria-label={`${projectName} project sections`}>
         <button
           type="button"
-          className={`proj-tab${projectView === 'overview' ? ' proj-tab--active' : ''}`}
-          onClick={() => onProjectViewChange('overview')}
-        >
-          <PanelsTopLeft size={14} />
-          Overview
-        </button>
-        <button
-          type="button"
           className={`proj-tab${projectView === 'chats' ? ' proj-tab--active' : ''}`}
           onClick={() => onProjectViewChange('chats')}
         >
@@ -1558,6 +1551,14 @@ function ProjectDetailSurface({
           <Database size={14} />
           Context
           <span className="proj-tab__count">6</span>
+        </button>
+        <button
+          type="button"
+          className={`proj-tab${projectView === 'overview' ? ' proj-tab--active' : ''}`}
+          onClick={() => onProjectViewChange('overview')}
+        >
+          <PanelsTopLeft size={14} />
+          Overview
         </button>
       </nav>
 
@@ -2455,31 +2456,41 @@ function ProjectChatSurface({
         <div className="pc-chat-directory__grid">
           <section className="pc-chat-directory__list" aria-label={`${projectName} chat list`}>
             {isLoadingChats && <div className="pc-chat-loading">Loading chats...</div>}
+            {!isLoadingChats && chats.length > 0 && (
+              <button type="button" className="pc-chat-card pc-chat-card--new" onClick={handleNewChat}>
+                <span className="pc-chat-card__new-icon"><Plus size={16} /></span>
+                <span className="pc-chat-card__new-label">새 채팅 시작</span>
+              </button>
+            )}
             {!isLoadingChats && chats.map((chat) => (
               <button
                 key={chat.id}
                 type="button"
-                className="pc-chat-row"
+                className="pc-chat-card"
                 onClick={() => onChatOpen(chat.id)}
               >
-                <span className={`pc-chat-row__dot pc-chat-row__dot--${statusClass(session.status)}`} />
-                <span className="pc-chat-row__body">
-                  <span className="pc-chat-row__title">{chat.title}</span>
-                  <span className="pc-chat-row__preview">{chat.latestPreview || recentPreview}</span>
-                  <span className="pc-chat-row__meta">
-                    {agentLabel(chat.agent, chat.model ?? modelLabel)} · {formatRelativeTime(chat.lastActivityAt)}
+                <span className="pc-chat-card__head">
+                  <span className="pc-chat-card__title">{chat.title}</span>
+                  <span className={`pc-chat-card__status pc-chat-card__status--${statusClass(session.status)}`}>
+                    <span className="pc-chat-card__status-dot" />
+                    {projectStatusLabel(session.status)}
                   </span>
                 </span>
-                <ChevronRight size={14} />
+                <span className="pc-chat-card__preview">{chat.latestPreview || recentPreview}</span>
+                <span className="pc-chat-card__meta">
+                  <span>{agentLabel(chat.agent, chat.model ?? modelLabel)}</span>
+                  <span className="pc-chat-card__meta-sep">·</span>
+                  <span>{formatRelativeTime(chat.lastActivityAt)}</span>
+                </span>
               </button>
             ))}
             {!isLoadingChats && chats.length === 0 && (
-              <button type="button" className="pc-chat-row pc-chat-row--empty" onClick={handleNewChat}>
-                <span className="pc-chat-row__body">
-                  <span className="pc-chat-row__title">Start the first chat</span>
-                  <span className="pc-chat-row__preview">프로젝트 하위에 새 채팅을 만들고 프로토타입 화면으로 진입합니다.</span>
+              <button type="button" className="pc-chat-card pc-chat-card--empty" onClick={handleNewChat}>
+                <span className="pc-chat-card__empty-icon"><Plus size={20} /></span>
+                <span className="pc-chat-card__empty-body">
+                  <span className="pc-chat-card__empty-title">Start the first chat</span>
+                  <span className="pc-chat-card__empty-text">프로젝트 하위에 새 채팅을 만들고 프로토타입 화면으로 진입합니다.</span>
                 </span>
-                <Plus size={14} />
               </button>
             )}
           </section>
@@ -3478,13 +3489,13 @@ export default function HomePageWrapper({
   const searchParams = useSearchParams();
   const [activeTab, setActiveTab] = useState<TabType>('home');
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
-  const [selectedProjectView, setSelectedProjectView] = useState<ProjectView>('overview');
+  const [selectedProjectView, setSelectedProjectView] = useState<ProjectView>('chats');
   const [selectedProjectChatId, setSelectedProjectChatId] = useState<string | null>(null);
   const [metrics, setMetrics] = useState<RuntimeMetrics | null>(null);
 
   useEffect(() => {
     const nextTab = normalizeTab(searchParams.get('tab'));
-    const nextProjectView = nextTab === 'project' ? normalizeProjectView(searchParams.get('view')) : 'overview';
+    const nextProjectView = nextTab === 'project' ? normalizeProjectView(searchParams.get('view')) : 'chats';
     setActiveTab(nextTab);
     setSelectedProjectId(nextTab === 'project' ? (searchParams.get('project') ?? null) : null);
     setSelectedProjectView(nextProjectView);
@@ -3495,7 +3506,7 @@ export default function HomePageWrapper({
     const syncRouteFromLocation = () => {
       const url = new URL(window.location.href);
       const nextTab = normalizeTab(url.searchParams.get('tab'));
-      const nextProjectView = nextTab === 'project' ? normalizeProjectView(url.searchParams.get('view')) : 'overview';
+      const nextProjectView = nextTab === 'project' ? normalizeProjectView(url.searchParams.get('view')) : 'chats';
       setActiveTab(nextTab);
       setSelectedProjectId(nextTab === 'project' ? (url.searchParams.get('project') ?? null) : null);
       setSelectedProjectView(nextProjectView);
@@ -3550,12 +3561,12 @@ export default function HomePageWrapper({
   const handleTabChange = (tab: TabType) => {
     setActiveTab(tab);
     setSelectedProjectId(null);
-    setSelectedProjectView('overview');
+    setSelectedProjectView('chats');
     setSelectedProjectChatId(null);
     window.history.replaceState(null, '', withAppBasePath(`/?tab=${tab}`));
   };
 
-  const handleProjectOpen = (sessionId: string, view: ProjectView = 'overview', chatId?: string | null) => {
+  const handleProjectOpen = (sessionId: string, view: ProjectView = 'chats', chatId?: string | null) => {
     setActiveTab('project');
     setSelectedProjectId(sessionId);
     setSelectedProjectView(view);
@@ -3582,7 +3593,7 @@ export default function HomePageWrapper({
   const handleBackToProjects = () => {
     setActiveTab('project');
     setSelectedProjectId(null);
-    setSelectedProjectView('overview');
+    setSelectedProjectView('chats');
     setSelectedProjectChatId(null);
     window.history.pushState(null, '', withAppBasePath('/?tab=project'));
   };

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -2515,75 +2515,181 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 .pc-chat-directory__list {
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--border-subtle);
-  background: var(--surface);
-}
-
-.pc-chat-row {
-  width: 100%;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: var(--sp-5);
-  align-items: center;
+  gap: var(--sp-3);
   min-width: 0;
-  padding: var(--sp-8) var(--sp-9);
-  border-bottom: 1px solid var(--border-subtle);
+}
+
+.pc-chat-card {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  align-items: stretch;
+  min-width: 0;
+  padding: var(--sp-6) var(--sp-7);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
   text-align: left;
+  cursor: pointer;
+  transition: transform 180ms var(--ease-smooth), box-shadow 180ms var(--ease-smooth), border-color 180ms var(--ease-smooth);
 }
 
-.pc-chat-row:last-child {
-  border-bottom: 0;
-}
-
-.pc-chat-row:hover,
-.pc-chat-row:focus-visible {
-  background: var(--surface-sunken);
+.pc-chat-card:hover,
+.pc-chat-card:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--border-strong);
+  box-shadow: 0 12px 28px -18px rgba(15,23,42,0.18);
   outline: none;
 }
 
-.pc-chat-row--empty {
-  grid-template-columns: minmax(0, 1fr) auto;
+html[data-theme='dark'] .pc-chat-card:hover,
+html[data-theme='dark'] .pc-chat-card:focus-visible {
+  box-shadow: 0 12px 28px -18px rgba(0,0,0,0.55);
 }
 
-.pc-chat-row__dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--n-300);
-}
-
-.pc-chat-row__dot--run { background: var(--b-500); animation: msb-pulse 1.6s infinite; }
-.pc-chat-row__dot--done { background: var(--success-fg); }
-.pc-chat-row__dot--appr { background: var(--warning-fg); animation: msb-pulse 1.2s infinite; }
-
-.pc-chat-row__body {
+.pc-chat-card__head {
   display: flex;
-  flex-direction: column;
-  gap: 3px;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-4);
   min-width: 0;
 }
 
-.pc-chat-row__title {
+.pc-chat-card__title {
   color: var(--text-primary);
   font-size: var(--text-h4);
   font-weight: 650;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.pc-chat-row__preview {
+.pc-chat-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--surface-sunken);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-subtle);
+}
+
+.pc-chat-card__status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.pc-chat-card__status--run { color: var(--b-600); border-color: color-mix(in srgb, var(--b-500) 35%, var(--border-subtle)); }
+.pc-chat-card__status--run .pc-chat-card__status-dot { background: var(--b-500); animation: msb-pulse 1.6s infinite; }
+.pc-chat-card__status--done { color: var(--success-fg); border-color: color-mix(in srgb, var(--success-fg) 30%, var(--border-subtle)); }
+.pc-chat-card__status--appr { color: var(--warning-fg); border-color: color-mix(in srgb, var(--warning-fg) 35%, var(--border-subtle)); }
+.pc-chat-card__status--appr .pc-chat-card__status-dot { animation: msb-pulse 1.2s infinite; }
+
+.pc-chat-card__preview {
   color: var(--text-secondary);
   font-size: var(--text-sm);
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  min-width: 0;
 }
 
-.pc-chat-row__meta {
+.pc-chat-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: var(--text-2xs);
+  margin-top: var(--sp-1);
+}
+
+.pc-chat-card__meta-sep {
+  opacity: 0.6;
+}
+
+.pc-chat-card--new {
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-3);
+  padding: var(--sp-5) var(--sp-7);
+  border-style: dashed;
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.pc-chat-card--new:hover,
+.pc-chat-card--new:focus-visible {
+  color: var(--text-primary);
+  border-color: var(--b-500);
+  background: color-mix(in srgb, var(--b-500) 5%, transparent);
+}
+
+.pc-chat-card__new-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pc-chat-card__new-label {
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.pc-chat-card--empty {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--sp-5);
+  border-style: dashed;
+  background: transparent;
+  padding: var(--sp-8) var(--sp-7);
+}
+
+.pc-chat-card__empty-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--surface-sunken);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.pc-chat-card__empty-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.pc-chat-card__empty-title {
+  color: var(--text-primary);
+  font-size: var(--text-body);
+  font-weight: 650;
+}
+
+.pc-chat-card__empty-text {
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
 }
 
 .pc-chat-directory__side {
@@ -6023,13 +6129,8 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
     width: 100%;
   }
 
-  .pc-chat-row {
-    grid-template-columns: auto minmax(0, 1fr);
-    padding: var(--sp-6);
-  }
-
-  .pc-chat-row > svg {
-    display: none;
+  .pc-chat-card {
+    padding: var(--sp-5) var(--sp-6);
   }
 
   .pc-proto {

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -35,7 +35,7 @@ describe('project list surface', () => {
 
   it('routes project card clicks to the IA project detail instead of the legacy session screen', () => {
     expect(homeClient).toContain("type ProjectView = 'overview' | 'chats' | 'chat' | 'files' | 'context';");
-    expect(homeClient).toContain("function buildProjectDetailPath(sessionId: string, view: ProjectView = 'overview', chatId?: string | null)");
+    expect(homeClient).toContain("function buildProjectDetailPath(sessionId: string, view: ProjectView = 'chats', chatId?: string | null)");
     expect(homeClient).toContain("params.set('tab', 'project');");
     expect(homeClient).toContain("params.set('project', sessionId);");
     expect(homeClient).toContain("if (view === 'chat' && chatId) {");
@@ -55,7 +55,7 @@ describe('project list surface', () => {
     expect(homeClient).toContain('className="proj-tabs"');
     expect(homeClient).toContain('className="proj-pane"');
     expect(homeClient).toContain("setSelectedProjectId(nextTab === 'project' ? (searchParams.get('project') ?? null) : null);");
-    expect(homeClient).toContain("const nextProjectView = nextTab === 'project' ? normalizeProjectView(searchParams.get('view')) : 'overview';");
+    expect(homeClient).toContain("const nextProjectView = nextTab === 'project' ? normalizeProjectView(searchParams.get('view')) : 'chats';");
     expect(homeClient).toContain('setSelectedProjectView(nextProjectView);');
     expect(homeClient).toContain('if (selectedProject) {');
   });
@@ -367,7 +367,7 @@ describe('project list surface', () => {
       '.proj-list-stats',
       '.proj-list-new-btn',
       '.pc-chat-directory',
-      '.pc-chat-row',
+      '.pc-chat-card',
       '.pc-proto .shell',
       '.pc-proto .ch',
       '.pc-proto .tl',


### PR DESCRIPTION
## Summary
프로젝트 진입 기본 탭을 Chats로 바꾸고, Chats 목록을 카드 디자인으로 개선.

### 1. 기본 탭 변경
- 탭 순서: Chats / Files / Context / Overview (Overview를 끝으로)
- 프로젝트 진입 시 \`projectView=chats\`로 시작 — \`normalizeProjectView\`, \`buildProjectDetailPath\`, useState 초기값, searchParams 효과, 핸들러 모두 갱신

### 2. Chats 목록 카드 디자인
- 단일 bordered 컨테이너 → \`.pc-chat-card\` 카드 그리드
- 각 카드: 보더, 라운드 모서리, hover 시 lift + accent 보더
- 상태 점(dot) → 상태 pill(점 + 텍스트)로 시인성 강화
- preview 2-line clamp, meta(에이전트·시간) 라인 분리
- 상단에 dashed "새 채팅 시작" 카드, 빈 상태 카드 리프레시

### Test plan
- [ ] 홈 → 프로젝트 카드 클릭 → Chats 탭으로 진입
- [ ] 사이드바 → 프로젝트 클릭 → Chats 탭으로 진입
- [ ] 탭 클릭으로 Files / Context / Overview 정상 전환
- [ ] 채팅 카드 호버 시 lift, 클릭 시 채팅 진입
- [ ] 채팅 0개일 때 빈 상태 카드 표시