### PR TITLE
refactor(provider-arch): phase 0 - diagnosis & refactor plan

### DIFF
--- a/docs/03-platform/codex-backend-alignment-plan.md
+++ b/docs/03-platform/codex-backend-alignment-plan.md
@@ -1,0 +1,198 @@
+# Plan: Codex Backend Alignment
+
+**Generated**: 2026-05-06
+**Estimated Complexity**: High
+**Parent Plan**: [`provider-architecture-refactor-plan.md`](./provider-architecture-refactor-plan.md)
+**Precedent**: [`gemini-backend-alignment-plan.md`](./gemini-backend-alignment-plan.md)
+
+## Overview
+
+Claude/Gemini alignment를 통해 정착한 `runtime/providers/<flavor>/` subtree 구조에 맞춰 Codex 런타임을 정렬한다. 현재 Codex 경로는 어댑터 디렉터리 자체가 없고, [`happyClient.ts`](../../services/aris-backend/src/runtime/happyClient.ts) (5,921 LOC) 본문 안에 환경 상수, 타입, 라이프사이클, 정책, 이벤트 로그 호출이 인라인으로 박혀 있다. 동시에 [`providerCommandFactory.ts`](../../services/aris-backend/src/runtime/providers/providerCommandFactory.ts)는 claude/gemini만 분기하며 codex는 누락 상태다. 본 계획은 Codex를 Claude·Gemini와 동일한 구조로 끌어올리되, 새 `CliProvider` 인터페이스(Phase 1에서 도입)를 implement하는 첫 provider로 활용한다.
+
+## Guiding Invariants
+
+- 상위 레이어는 Codex `app-server` JSON-RPC 또는 `exec --json` raw payload key shape를 직접 알지 않는다.
+- provider identity와 local correlation key (threadId, callId, runKey)는 절대로 같은 값으로 취급하지 않는다.
+- `parseStdout` 류 파서는 순수 함수이며 side effect는 `ParsedMessageSideEffect` descriptor로 반환한다.
+- `CODEX_RUNTIME_MODE`(`app-server` 기본 / `exec` 대체) 두 채널은 동등하게 지원한다.
+- ndjson 로그 포맷(`chat-codex-{chatId}-{threadId}-{parsed,raw}.ndjson`)과 stage/turnStatus 키 이름은 변경하지 않는다.
+- WebSocket app-server 라이프사이클(reserve port → spawn → connect → drain → terminate)은 변경하지 않는다 — race condition 검증된 형태 그대로 옮긴다.
+
+## Current State Snapshot
+
+### 구조적 누락
+- `runtime/providers/codex/` 디렉터리 부재.
+- `providerCommandFactory.ts`에 codex 분기 부재. 결과적으로 codex turn은 factory 경로를 우회해 `happyClient.ts`의 인라인 분기로 들어간다.
+
+### `happyClient.ts` 인라인 인벤토리
+| 카테고리 | 심볼 | 위치(라인) |
+|---|---|---|
+| 환경 상수 | `CODEX_SANDBOX_MODE` | 80 |
+| 환경 상수 | `CODEX_RUNTIME_MODE` | 81 |
+| 환경 상수 | `CODEX_TURN_TIMEOUT_MS` | 102 |
+| 환경 상수 | `CODEX_APP_SERVER_POST_TURN_QUIET_MS` | 109 |
+| 환경 상수 | `CODEX_APP_SERVER_POST_TURN_DRAIN_TIMEOUT_MS` | 116 |
+| 타입 | `CodexPermissionRequest` | 149 |
+| 타입 | `CodexAppServerFailureKind` / `CodexAppServerFailureInfo` | 1148 / 1158 |
+| 타입 | `CodexAppServerSocket` | 1628 |
+| 정책 헬퍼 | `normalizeCodexApprovalPolicy` | ~378 |
+| 정책 헬퍼 | `normalizeCodexApprovalDecision` | ~1280 |
+| 정책 헬퍼 | `inferCodexApprovalRisk` | ~1289 |
+| 정책 헬퍼 | `inferCodexFileWriteItem` | ~3731 |
+| 정책 헬퍼 | `isMissingCodexThreadError` | ~1133 |
+| 정책 헬퍼 | `buildCodexThreadCacheKey` | ~1357 |
+| 정책 헬퍼 | `categorizeCodexAppServerFailure` | ~1166 |
+| WebSocket 라이프사이클 | `buildCodexAppServerSpawnOptions` | ~1586 |
+| WebSocket 라이프사이클 | `buildCodexAppServerListenUrl` | 1600 |
+| WebSocket 라이프사이클 | `reserveCodexAppServerPort` | ~1604 |
+| WebSocket 라이프사이클 | `createCodexAppServerSocket` | 1642 |
+| WebSocket 라이프사이클 | `connectCodexAppServerSocket` | 1650 |
+| WebSocket 라이프사이클 | `terminateCodexAppServerProcess` | 1797 |
+| WebSocket 라이프사이클 | `rejectCodexAppServerPendingRequests` | 1821 |
+| WebSocket 라이프사이클 | `createCodexAppServerAbortPromise` | ~1834 |
+| WebSocket 라이프사이클 | `normalizeCodexAppServerMessageData` | ~3944 (호출 위치) |
+| 인라인 분기 | `if (input.flavor === 'codex')` | 923 |
+| 인라인 분기 | `channel = input.agent === 'codex' && CODEX_RUNTIME_MODE !== 'exec' ? 'app_server' : 'exec_cli'` | 2438 |
+| 인라인 분기 | `if (flavor === 'codex' && isMissingCodexThreadError(error))` | 5368 |
+| 인라인 분기 | `spawn('codex', args, ...)` | 4221 |
+| 이벤트 로그 spawn | `agent: 'codex'` | 3283, 3301, 3334, 3358, 3435, 3851, 3874, 3884, 3895, 4060, 4148, 4169, 4202, 4229, 4260, 4302, 4323, 4333, 4344, 4501, 4524, 4541 (총 22회) |
+
+총 32회의 codex 키워드, 약 700~900 LOC의 codex 종속 코드가 happyClient.ts 본문에 흩어져 있는 것으로 추정.
+
+### 1급 시민 정의는 멀쩡함
+- [`types.ts`](../../services/aris-backend/src/types.ts:1): `AgentFlavor = 'codex' | 'claude' | 'gemini' | 'unknown'`
+- [`server.ts`](../../services/aris-backend/src/server.ts): zod schema 두 곳에서 codex enum 입력 받음.
+- 즉 입력은 codex를 알지만, 실행은 codex를 모르는 상태가 어댑터 추출의 직접적 동기.
+
+## Status Snapshot
+
+- 완료: 없음 (Phase 0 진단 단계).
+- 다음 우선순위:
+  1. Phase 1 PR(`CliProvider` 인터페이스 + registry) 머지.
+  2. 본 계획의 Sprint 1 시작.
+
+## Sprint Plan
+
+### Sprint 1 — Identity & Resume Boundary 문서화
+**목표**: Codex의 thread/session identity 처리 규칙을 명시화. 추출 전에 invariant을 글로 굳힌다.
+
+산출물:
+- `docs/03-platform/codex-session-identity-boundary.md` — Claude/Gemini 선례 양식 따름.
+- `docs/03-platform/codex-protocol-conformance.md` — `app-server` JSON-RPC와 `exec --json` 두 채널의 envelope 매핑.
+- 단위 테스트: `buildCodexThreadCacheKey` 입출력 고정.
+
+### Sprint 2 — Provider Subtree Skeleton
+**목표**: `runtime/providers/codex/` 신설. 빈 클래스/모듈만 만들고 실제 동작은 happyClient.ts에 그대로 위임.
+
+생성 파일 (모두 50~150 LOC 이내 예상):
+```
+runtime/providers/codex/
+  codexAdapter.ts             # CliProvider 빈 implementation
+  codexLauncher.ts             # buildCodexCommand (현재 buildAgentCommand의 codex 부분)
+  codexSessionRegistry.ts
+  codexSessionSource.ts
+  codexProtocolFields.ts
+  types.ts
+```
+
+이 단계에서:
+- `providerCommandFactory.ts`의 `if (input.agent === 'codex')` 분기 추가.
+- `cliProviderRegistry.registerIfAbsent('codex', () => codexAdapter)` 추가.
+- `codexAdapter.spawn` / `sendMessage` / `parseStdout`은 happyClient.ts의 기존 함수에 위임 (지금은 export만 하면 됨).
+
+검증: `tsc --noEmit` 통과, codex 채팅 회귀 0건.
+
+### Sprint 3 — Protocol Mapper & Conformance Fixture
+**목표**: `parseStdout`을 순수 함수화. happyClient.ts의 `parseAgentStreamLine` codex 분기를 추출.
+
+산출물:
+- `codexProtocolMapper.ts` — `app-server` JSON-RPC envelope과 `exec --json` 라인을 `SessionProtocolEnvelope`로 매핑.
+- `codexProtocolFields.ts` — payload key extractors (현재 `extractFirstStringByKeys` 등 generic helper의 codex 부분).
+- 테스트 fixture: 실제 codex 세션에서 캡처한 raw ndjson 5개 시나리오.
+  - thread/start 응답
+  - assistant text streaming
+  - tool call (file_write)
+  - permission request
+  - turn-end with error / missing thread
+- conformance 테스트: fixture → mapper → 기대 envelope 비교.
+
+검증: fixture diff 0, codex 채팅 회귀 0건.
+
+### Sprint 4 — App-Server Lifecycle Extraction
+**목표**: WebSocket app-server 라이프사이클 9개 함수를 `codexAppServerClient.ts`/`codexAppServerLifecycle.ts`로 추출. 본 sprint가 가장 위험하다 — race condition 영역.
+
+추출 대상 (happyClient.ts → codex/):
+- `buildCodexAppServerSpawnOptions`, `buildCodexAppServerListenUrl`, `reserveCodexAppServerPort`
+- `createCodexAppServerSocket`, `connectCodexAppServerSocket`
+- `terminateCodexAppServerProcess`, `rejectCodexAppServerPendingRequests`
+- `createCodexAppServerAbortPromise`, `normalizeCodexAppServerMessageData`
+- 타입 `CodexAppServerSocket`, `CodexAppServerFailureKind`, `CodexAppServerFailureInfo`
+
+검증:
+- 기존 connection / drain / abort 시나리오 단위 테스트 그대로 통과.
+- `CODEX_RUNTIME_MODE=exec`로 강제하고 회귀 한 번, default(`app-server`)로 회귀 한 번 — 양쪽 채널 모두 정상 동작.
+
+### Sprint 5 — Permission Bridge & Policy Helpers
+**목표**: 정책/권한 헬퍼를 `codexPermissionBridge.ts` / `codexSandboxPolicy.ts`로 추출.
+
+추출 대상:
+- `normalizeCodexApprovalPolicy`, `normalizeCodexApprovalDecision`
+- `inferCodexApprovalRisk`, `inferCodexFileWriteItem`
+- `CodexPermissionRequest` 타입과 그 builder
+
+이 sprint에서 `claudePermissionBridge.ts` 인터페이스와 동일한 surface로 맞춘다 (sendApproval, mapDecision 등).
+
+검증: 기존 permission 결정 회귀 fixture 통과.
+
+### Sprint 6 — Codex Runtime Extraction
+**목표**: codex turn 본체(`spawn('codex', args, ...)` ~ stdin write ~ stdout drain ~ turn-end persistence)를 `codexRuntime.ts`로 추출. happyClient.ts의 codex 분기는 thin caller로 축소.
+
+이 시점에서 happyClient.ts의 codex 키워드 등장이 0회(또는 import 1회 이내)가 되어야 한다.
+
+검증:
+- ndjson byte-level diff: Phase 0에서 캡처한 raw/parsed fixture와 비교, 차이 0.
+- 운영 시나리오 E2E:
+  - new turn (thread 없음) → threadId 발급 → assistant text → turn-end
+  - resume turn (thread 있음)
+  - missing thread error → 자동 재시도 (line 5368 분기)
+  - permission request → approve/decline → tool 실행
+  - abort 중간 (signal) → app-server graceful drain → SIGTERM/SIGKILL 단계
+  - timeout (`CODEX_TURN_TIMEOUT_MS` 초과)
+
+### Sprint 7 — E2E & 운영 검증 매트릭스
+**목표**: gemini-happy-alignment-e2e-matrix와 동일한 형식의 codex 매트릭스 작성 후 PR.
+
+산출물:
+- `docs/03-platform/codex-happy-alignment-e2e-matrix.md`
+- production-like 환경 (dev proxy)에서 매트릭스 모든 항목 통과 확인 후 사용자 검증.
+
+### Sprint 8 — Trace 기반 fixture 보강 (선택)
+실제 codex 세션 trace 추가 수집해 mapper fixture 확장. gemini sprint 8과 동일 패턴.
+
+## Validation Gates
+
+- 각 Sprint PR 머지 직전:
+  - `tsc --noEmit` (aris-backend, aris-web 양쪽)
+  - 단위 테스트: `vitest run` (관련 영역만 targeted)
+  - codex 채팅 1회 회귀 (dev proxy)
+  - ndjson fixture diff 0
+- Phase 2 전체 머지 직전:
+  - 전체 운영 매트릭스 (Sprint 7 산출물) 모든 항목 ✅
+  - `pm2 reload aris-backend` 후 진행 중 codex turn이 안전 종료
+  - app-server 모드와 exec 모드 양쪽 정상
+
+## Out of Scope (이번 alignment에서 제외)
+
+- happy-server 클라이언트 코드 정리 (Phase 6에서 처리)
+- happyClient.ts의 비-provider 영역(`runStaleCleanup`, `appendAgentMessage`, `messagePersistence`) 분해 (Phase 6)
+- aris-web 측 ChatComposer / ChatInterface의 codex UX 개선 (별도 트랙)
+
+## Definition of Done
+
+- `runtime/providers/codex/` 디렉터리에 13~16개 파일, 각 50~400 LOC.
+- `happyClient.ts`에서 `codex` 또는 `Codex` 키워드 등장 0회 (import 1회 이내 허용).
+- `providerCommandFactory.ts`가 codex 분기 보유.
+- `cliProviderRegistry.getProvider('codex')` 반환 가능.
+- ndjson 로그 포맷·키 변동 0건.
+- app-server 모드와 exec 모드 양쪽 회귀 0건.
+- 운영 매트릭스 [`codex-happy-alignment-e2e-matrix.md`](./codex-happy-alignment-e2e-matrix.md) 모든 항목 ✅.

--- a/docs/03-platform/provider-architecture-refactor-plan.md
+++ b/docs/03-platform/provider-architecture-refactor-plan.md
@@ -1,0 +1,222 @@
+# Plan: Provider Architecture Refactor
+
+**Generated**: 2026-05-06
+**Estimated Complexity**: High
+**Inspired By**: [horang-labs/tessera](https://github.com/horang-labs/tessera) — `src/lib/cli/providers/` adapter pattern
+
+## Overview
+
+`runtime/providers/` 하위 구조가 파편화되어 있다. `claude/`와 `gemini/`는 16개 파일씩 별도 디렉터리로 정상화되어 있는 반면, **Codex는 디렉터리 자체가 존재하지 않고 5,921줄짜리 [`happyClient.ts`](../../services/aris-backend/src/runtime/happyClient.ts)에 인라인으로 박혀 있다.** 그 결과 [`providerCommandFactory.ts`](../../services/aris-backend/src/runtime/providers/providerCommandFactory.ts)는 `claude`와 `gemini`만 분기하고 codex는 누락된 상태다.
+
+본 계획은 Tessera의 `CliProvider` adapter 패턴, managed worktree 자동화, graceful shutdown 가드 세 가지를 도입하면서, 그 과정에서 Codex를 정상 위치(`runtime/providers/codex/`)로 추출하고 `happyClient.ts`를 슬림화하는 것을 목표로 한다.
+
+빅뱅 마이그레이션은 금지한다. **새 인터페이스로 Codex를 먼저 옮기고, 그 다음 Claude/Gemini를 점진 마이그레이션**한다.
+
+## Guiding Invariants
+
+- 상위 레이어는 provider raw payload key shape를 직접 알지 않는다.
+- provider identity와 local correlation key는 절대로 같은 값으로 취급하지 않는다.
+- `parseStdout` 류 파서는 **순수 함수**여야 하며, side effect는 descriptor로 반환한다 (caller가 실행 책임).
+- ndjson 로그 포맷(`chat-{agent}-{chatId}-{threadId}-parsed.ndjson`)은 변경하지 않는다 — `deploy/ops/debug-chat-log.sh` 등 외부 도구 의존성 보존.
+- `ProviderRuntime`(기존)과 `CliProvider`(신규)는 마이그레이션 기간 동안 공존을 허용하되 **최대 2주 이내에 일원화**한다.
+- worktree 명명 규칙은 AGENTS.md의 표준 절차(`scripts/create_worktree_with_shared_node_modules.sh`)와 호환되어야 한다.
+- PM2 cluster 환경 (aris-backend는 cluster mode)에서 worker 충돌 없이 동작해야 한다.
+
+## Current State Snapshot
+
+### 정상화된 영역
+- `runtime/providers/claude/` — 16개 파일, 약 2,400 LOC. `claudeAdapter`/`Runtime`/`ProtocolMapper`/`SessionRegistry`/`PermissionBridge`/`MessageQueue`/`EventBridge` 등 책임별 분리 완료.
+- `runtime/providers/gemini/` — 16개 파일, 약 3,300 LOC. ACP 클라이언트 포함 동일 구조.
+- `runtime/contracts/providerRuntime.ts` — `ProviderRuntime` 인터페이스 (sendTurn / abortTurn / recoverSession / isRunning).
+- `runtime/contracts/sessionProtocol.ts` — `SessionProtocolEnvelope` 6종(turn-start/turn-end/tool-call-start/tool-call-end/text/stop).
+
+### 파편화된 영역
+- `runtime/providers/codex/` — **존재하지 않음**.
+- [`happyClient.ts`](../../services/aris-backend/src/runtime/happyClient.ts) — 5,921줄 단일 파일. codex 키워드 32회 등장. 다음 심볼이 모두 인라인:
+  - 환경 상수: `CODEX_SANDBOX_MODE`, `CODEX_RUNTIME_MODE`, `CODEX_TURN_TIMEOUT_MS`, `CODEX_APP_SERVER_POST_TURN_QUIET_MS`, `CODEX_APP_SERVER_POST_TURN_DRAIN_TIMEOUT_MS`
+  - 타입: `CodexPermissionRequest`, `CodexAppServerFailureKind`, `CodexAppServerFailureInfo`, `CodexAppServerSocket`
+  - WebSocket 라이프사이클: `connectCodexAppServerSocket` (line 1650), `terminateCodexAppServerProcess` (1797), `rejectCodexAppServerPendingRequests` (1821), `createCodexAppServerSocket`, `reserveCodexAppServerPort`, `buildCodexAppServerSpawnOptions`, `buildCodexAppServerListenUrl`, `createCodexAppServerAbortPromise`, `normalizeCodexAppServerMessageData`
+  - 정책: `normalizeCodexApprovalPolicy`, `normalizeCodexApprovalDecision`, `inferCodexApprovalRisk`, `inferCodexFileWriteItem`, `isMissingCodexThreadError`, `buildCodexThreadCacheKey`
+  - 인라인 분기: `flavor === 'codex'` (line 923, 5368), `channel` 선택 (line 2438), `spawn('codex', args, ...)` (line 4221)
+  - `agent: 'codex'` 이벤트 로그 호출 22회 (lines 3283 ~ 4541 산재)
+- [`providerCommandFactory.ts`](../../services/aris-backend/src/runtime/providers/providerCommandFactory.ts) — claude/gemini만 분기. codex 분기 누락.
+
+### 1급 시민으로 정의된 점
+- [`types.ts`](../../services/aris-backend/src/types.ts:1): `AgentFlavor = 'codex' | 'claude' | 'gemini' | 'unknown'`
+- [`server.ts`](../../services/aris-backend/src/server.ts) zod schema: `z.enum(['codex', 'claude', 'gemini', 'unknown'])` × 2
+
+즉 **타입과 입력 게이트는 codex를 알지만, 실행 어댑터 계층은 codex를 모른다.** 이 단절을 `ProviderRuntime` 인터페이스 너머에서 인라인으로 메우고 있는 곳이 `happyClient.ts`다.
+
+## Target Architecture
+
+```
+runtime/
+  contracts/
+    providerRuntime.ts        # 기존 — 마이그레이션 종료 후 cliProvider로 흡수 또는 deprecated
+    sessionProtocol.ts        # 기존
+    cliProvider.ts            # NEW — Tessera 스타일 CliProvider 인터페이스
+    parsedMessage.ts          # NEW — { envelope, sideEffect } 타입
+    cliStatus.ts              # NEW — 'connected' | 'needs_login' | 'not_installed'
+    providerRegistry.ts       # NEW — globalThis 싱글턴, registerIfAbsent
+  providers/
+    providerCommandFactory.ts # claude/gemini/codex 모두 분기
+    claude/                   # 기존 16파일 + claudeAdapter (CliProvider impl) 추가
+    gemini/                   # 기존 16파일 + geminiAdapter 추가
+    codex/                    # NEW — 아래 구조
+      codexAdapter.ts
+      codexLauncher.ts
+      codexProtocolMapper.ts
+      codexAppServerClient.ts # connectCodexAppServerSocket 등 흡수
+      codexAppServerLifecycle.ts # terminate/reject/abort
+      codexThreadCache.ts
+      codexSandboxPolicy.ts
+      codexPermissionBridge.ts
+      codexMessageQueue.ts
+      codexSessionRegistry.ts
+      codexProtocolFields.ts
+      codexEventBridge.ts
+      types.ts
+  managedWorktree/            # NEW — Tessera src/lib/worktrees/ 기반
+    naming.ts
+    allocator.ts
+    preflight.ts
+    retention.ts
+  happyClient/                # Phase 6 — 기존 happyClient.ts 골격 분해
+    index.ts
+    runtimeStore.ts
+    runStaleCleanup.ts
+    messagePersistence.ts
+    ...
+```
+
+## Phase Plan
+
+각 Phase는 **별도 worktree, 별도 PR**. PR 머지 사이에 dev proxy 검증 필수.
+
+### Phase 0 — Diagnosis & Plan (현재 PR)
+- 본 문서 (`provider-architecture-refactor-plan.md`)
+- [`codex-backend-alignment-plan.md`](./codex-backend-alignment-plan.md) — gemini-backend-alignment-plan과 같은 깊이의 Codex 정렬 세부 계획
+- 코드 변경 없음. 리뷰 후 머지.
+
+### Phase 1 — CliProvider 인터페이스 도입 (worktree 2)
+**목표**: 새 인터페이스를 도입하되 기존 `ProviderRuntime`은 손대지 않는다. 어떤 provider도 아직 새 인터페이스를 implement하지 않는 "빈 골격" 상태에서 PR.
+
+- `runtime/contracts/cliProvider.ts` — Tessera `CliProvider` 인터페이스 그대로 차용 (`getProviderId`, `getDisplayName`, `isAvailable`, `getCliArgs`, `spawn`, `sendMessage`, `parseStdout`, `parseSessionStdout?`, `handleSessionExit?`, `generateTitle`, `updateSessionConfig?`, `sendApprovalResponse?`, `sendInterrupt?`, `createSkillSource?`, `onSessionReady?`, `checkStatus`)
+- `runtime/contracts/parsedMessage.ts` — `ParsedMessage = { serverMessage, sideEffect? }` + `ParsedMessageSideEffect` discriminated union
+- `runtime/contracts/cliStatus.ts` — `CliConnectionStatus` 3-state + `CliStatusResult` (version 포함)
+- `runtime/contracts/providerRegistry.ts` — `CliProviderRegistry` + `cliProviderRegistry` globalThis 싱글턴 + `registerIfAbsent`
+- 단위 테스트: registry register/getProvider/registerIfAbsent/listAvailable
+
+**검증**: `tsc --noEmit` 통과, 기존 동작 무영향, 새 파일들이 어디서도 import되지 않음.
+
+### Phase 2 — Codex Provider 정상화 ⭐ 최대 가치 (worktree 3)
+[`codex-backend-alignment-plan.md`](./codex-backend-alignment-plan.md) 참조.
+
+요지:
+1. `runtime/providers/codex/` 신설.
+2. `happyClient.ts`에서 codex 전용 코드(환경 상수 6개, 타입 4개, 헬퍼 15개+, 분기 2곳, 이벤트 로그 호출 22개)를 추출.
+3. `codexAdapter`가 `CliProvider`를 implement.
+4. `providerCommandFactory.ts`에 codex 분기 추가.
+5. `cliProviderRegistry.registerIfAbsent('codex', () => codexAdapter)`.
+6. `happyClient.ts`는 codex 부분만 thin caller로 축소 — 이때 **기존 ndjson 이벤트 로그 포맷은 절대 변경 금지**.
+7. 회귀 검증: codex chat 시나리오 E2E + 기존 happy event logger 출력 비교 fixture.
+
+**검증**: codex 채팅 통합 테스트 통과, ndjson 로그 diff 빈 결과, `tsc --noEmit` 통과.
+
+### Phase 3 — Managed Worktree 자동화 (worktree 4)
+- `runtime/managedWorktree/naming.ts` — Tessera `naming.ts` 그대로 차용. 한국어 IME `isComposing` 가드, slug 정규화, mmdd-xx 슬러그.
+- `runtime/managedWorktree/allocator.ts` — `~/.aris/worktrees/<projectSlug>/<branchName>` 자동 할당. 충돌 시 suffix.
+- `runtime/managedWorktree/preflight.ts` — git 설치 / repo 여부 체크, 명확한 에러 코드 (`GIT_NOT_INSTALLED`, `PROJECT_NOT_GIT_REPOSITORY`).
+- `runtime/managedWorktree/retention.ts` — 만료된 worktree 자동 정리. **PM2 cluster guard**: `process.env.NODE_APP_INSTANCE === '0'`인 leader worker만 실행 (또는 별도 cron 컨테이너).
+- 기존 [`worktreeManager.ts`](../../services/aris-backend/src/runtime/worktreeManager.ts) (2.4KB)와 [`scripts/create_worktree_with_shared_node_modules.sh`](../../scripts/create_worktree_with_shared_node_modules.sh)는 유지. allocator 내부에서 후크로 호출해 node_modules 심볼릭 링크 자동 연결까지 한 번에.
+
+**검증**: allocator 단위 테스트, PM2 cluster 환경에서 retention 중복 실행 없음을 로그로 확인.
+
+### Phase 4 — Claude/Gemini 마이그레이션 (worktree 5)
+- 기존 디렉터리는 손대지 않고 `claudeAdapter` / `geminiAdapter` 클래스를 추가해서 `CliProvider`를 implement.
+- `cliProviderRegistry.registerIfAbsent('claude', ...)` / `'gemini'` 등록.
+- 기존 `ProviderRuntime`을 어댑터 안에서 위임 호출하는 형태로 시작.
+
+**검증**: 두 provider의 채팅 회귀 테스트 통과.
+
+### Phase 5 — Graceful Shutdown + Status Prewarm (worktree 6)
+- aris-backend `server.ts` + aris-web `server.mjs`에 동일 패턴 도입:
+  - 중복 시그널 가드 (`shuttingDown` flag)
+  - 10초 강제 종료 타이머 (`unref` 처리)
+  - `processManager.cleanup()` 동등 — provider별 spawned child 그룹 kill
+- `prewarmCliStatusSnapshot('server')` — 서버 시작 시 모든 등록된 CliProvider의 `checkStatus`를 비동기로 미리 호출, 첫 페이지 진입 지연 ↓.
+- 기존 PM2 graceful shutdown 설정과 호환 확인.
+
+**검증**: `pm2 reload aris-backend` 시 진행 중 turn이 안전하게 마무리되는지, `kill -SIGTERM` 시 child process group까지 정리되는지 확인.
+
+### Phase 6 — happyClient.ts 해체 (worktree 7)
+- Phase 2 이후 codex가 빠져나가도 happyClient.ts는 약 4,500줄 남음. claude/gemini 잔여 일반 로직과 runtime store, persistence, run-key 관리, agent message sanitizer 잔여물 등이 섞여 있음.
+- `happyClient/` 디렉터리로 분해. CLAUDE.md "MANY SMALL FILES > FEW LARGE FILES" (200~400 LOC) 원칙 적용.
+- `happyClient.ts`는 barrel export로 축소.
+
+**검증**: 외부 import 경로 호환성 유지, 단위 테스트 통과.
+
+## Risks & Mitigations
+
+### R1. happyClient.ts에 비-provider 로직이 섞여 있다
+**증상**: `runStaleCleanup`, `messagePersistence`, `appendAgentMessage`, `agentMessageSanitizer` 등 provider-agnostic 로직과 codex/claude/gemini 분기가 같은 메서드에 공존.
+
+**완화**: Phase 2에서는 **provider 종속 코드만** 추출한다. provider-agnostic 코드는 happyClient에 그대로 둔다. Phase 6에서 별도 분해.
+
+### R2. ProviderRuntime ↔ CliProvider 중복 인터페이스
+**증상**: 마이그레이션 기간 동안 두 인터페이스가 공존해 caller가 어느 것을 써야 할지 헷갈림.
+
+**완화**: Phase 1 PR 본문에 deprecation 일정 명기. Phase 4 종료 직후 PR로 `ProviderRuntime` 사용처를 모두 `CliProvider`로 교체하고 `ProviderRuntime` 삭제 또는 thin wrapper로 축소.
+
+### R3. PM2 cluster + retention 충돌
+**증상**: 4개 worker가 동시에 retention 돌리면 worktree 삭제 race.
+
+**완화**: `process.env.NODE_APP_INSTANCE === '0'` leader 가드 또는 PM2 ecosystem에 별도 `aris-backend-cron` 프로세스 분리. Phase 3 PR에서 둘 중 결정.
+
+### R4. ndjson 로그 포맷 회귀
+**증상**: codex 추출 과정에서 `agent: 'codex'` 이벤트 페이로드 키가 한 글자라도 바뀌면 [`debug-chat-log.sh`](../../deploy/ops/debug-chat-log.sh) / project memory 조회 / 외부 분석 파이프라인이 깨짐.
+
+**완화**:
+1. Phase 0에서 codex 채팅 1회 실행해 raw/parsed ndjson을 fixture로 저장.
+2. Phase 2에서 동일 시나리오 실행 후 fixture와 byte-level diff. 차이 0 확인 후 PR 가능.
+
+### R5. CODEX_RUNTIME_MODE 분기 (`app-server` vs `exec`)
+**증상**: codex는 두 가지 채널을 가지고 있다. WebSocket app-server (default)와 exec stdin/stdout. 추출 시 두 경로 모두 보존 필요.
+
+**완화**: `codexAdapter`는 두 채널을 strategy 패턴으로 내장. `codexAppServerClient` vs `codexExecClient` 두 모듈로 분리하고 adapter가 환경변수에 따라 선택.
+
+### R6. happy-server JWT vs RUNTIME_API_TOKEN 혼동
+**증상**: AGENTS.md 디버깅 가이드에 명시된 인증 토큰 분리. 리팩토링 중 토큰 사용처가 섞이면 production 디버깅 불가.
+
+**완화**: 본 리팩토링은 토큰 처리 코드를 건드리지 않는다 — happy-server 클라이언트 부분은 Phase 6에서만 정리.
+
+## Definition of Done (전체)
+
+- `happyClient.ts`에서 `codex` 키워드 출현 0회 (또는 import문 1회 이내).
+- `runtime/providers/{claude,gemini,codex}/` 세 디렉터리가 동등한 책임 분포.
+- `cliProviderRegistry`에 세 provider 모두 등록.
+- `providerCommandFactory.ts`가 세 provider 모두 분기.
+- AgentFlavor union의 모든 1급 시민이 실행 어댑터 계층에서도 1급 시민.
+- 기존 채팅 시나리오 회귀 0건. ndjson fixture diff 0건.
+- happyClient.ts < 1,500 LOC (Phase 6 종료 시점).
+- PM2 cluster 환경에서 graceful shutdown 시 자식 프로세스 잔존 0건.
+
+## Phase별 PR 라벨 / 브랜치 컨벤션
+
+- 브랜치: `refactor/provider-architecture-phaseN-<short-name>`
+- PR 제목 prefix: `refactor(provider-arch): phaseN - <name>`
+- 라벨: `refactor`, `provider-arch`, `phase-N`
+
+## 참고
+
+- Tessera 원본: <https://github.com/horang-labs/tessera>
+- Tessera 핵심 파일:
+  - `src/lib/cli/providers/provider-contract.ts` — CliProvider 인터페이스
+  - `src/lib/cli/providers/registry.ts` — globalThis 싱글턴 패턴
+  - `src/lib/cli/providers/message-types.ts` — ParsedMessage + sideEffect
+  - `src/lib/worktrees/managed.ts` + `naming.ts` — managed worktree
+  - `server.ts` — graceful shutdown 패턴
+- 선례 문서:
+  - [`gemini-backend-alignment-plan.md`](./gemini-backend-alignment-plan.md) — Phase 2의 톤/깊이 기준
+  - [`claude-protocol-conformance.md`](./claude-protocol-conformance.md)
+  - [`gemini-protocol-conformance.md`](./gemini-protocol-conformance.md)


### PR DESCRIPTION
## Summary

Provider 아키텍처 리팩토링 마스터 플랜과 Codex backend alignment 세부 계획을 담은 **진단·계획 PR**. 코드 변경 없음, 문서 2개만 추가.

배경:
- `runtime/providers/`가 `claude/`(16파일) + `gemini/`(16파일)로는 정상화되어 있으나, **Codex는 디렉터리 자체가 없고** 환경 상수·타입·라이프사이클·정책 헬퍼·이벤트 로그 호출 32회가 `happyClient.ts` (5,921 LOC)에 인라인으로 박혀 있음.
- `providerCommandFactory.ts`도 claude/gemini만 분기, codex 누락.
- 동시에 [tessera](https://github.com/horang-labs/tessera)의 `CliProvider` adapter 패턴, managed worktree 자동화, graceful shutdown 가드를 도입하기 좋은 시점.

## 추가 문서

- `docs/03-platform/provider-architecture-refactor-plan.md` — Phase 0 ~ Phase 6 전체 마스터 플랜.
- `docs/03-platform/codex-backend-alignment-plan.md` — `gemini-backend-alignment-plan.md` 양식의 Codex 정렬 세부 계획 (Sprint 1~8).

## Phase 로드맵 (요약)

| Phase | 내용 | 결과물 위치 |
|---|---|---|
| 0 | **본 PR** — 진단 + 마스터 플랜 + Codex 정렬 계획 | `docs/03-platform/` |
| 1 | `CliProvider` 인터페이스 + ParsedMessage + Registry 도입 (구현 위임 없음) | `runtime/contracts/` |
| 2 | **Codex 정상화** — `runtime/providers/codex/` 신설, happyClient.ts에서 추출 | `runtime/providers/codex/` |
| 3 | Managed worktree 자동화 (slug, IME 가드, retention) | `runtime/managedWorktree/` |
| 4 | Claude/Gemini를 새 인터페이스로 마이그레이션 | 기존 디렉터리 유지 + 어댑터 추가 |
| 5 | Graceful shutdown + status prewarm | `server.ts`, `server.mjs` |
| 6 | happyClient.ts 해체 (4,500→1,500 LOC) | `happyClient/` |

## Test plan

- [x] `tsc --noEmit` 영향 없음 (문서만 추가)
- [x] 마크다운 내부 링크 대상 파일 존재 확인
- [x] 기존 docs convention(`03-platform`에 alignment-plan류 비등재) 준수
- [x] `gemini-backend-alignment-plan.md` 톤·구조와 정렬

## Definition of Done (이 PR)

- [x] Phase 0 진단 문서 2개 작성
- [x] 외부 링크가 모두 실제 파일을 가리킴
- [ ] 리뷰 후 main 머지 → Phase 1 worktree 시작
