### PR TITLE
refactor(aris-web): polish project chat list cards to design system

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -1500,28 +1500,6 @@ function ProjectDetailSurface({
             <div className="proj-stat-value">{tokenLabel}</div>
           </div>
         </div>
-        <div className="proj-docs">
-          <article className="proj-doc">
-            <div className="proj-doc__eyebrow">Project instructions</div>
-            <div className="proj-doc__body">
-              <p>작업 시작 전 프로젝트 지침과 최근 결정 맥락을 먼저 확인합니다.</p>
-              <p>모든 변경은 전용 브랜치와 git worktree에서 분리해 진행합니다.</p>
-              <p>모바일 UI 변경은 overflow 회귀를 기본 검증에 포함합니다.</p>
-              <p>배포는 공식 스크립트와 런타임 헬스 체크로 확인합니다.</p>
-            </div>
-            <button type="button" className="proj-doc__more">전체 보기 →</button>
-          </article>
-          <article className="proj-doc">
-            <div className="proj-doc__eyebrow">Project memory</div>
-            <div className="proj-doc__body">
-              <p>{projectName}의 최근 채팅과 실행 이력이 이 홈에 묶입니다.</p>
-              <p>활성 작업, 결정 사항, 파일 힌트를 프로젝트 단위로 재진입합니다.</p>
-              <p>모델과 에이전트 선택, 최근 실행 결과를 함께 유지합니다.</p>
-              <p>다음 작업 시작 시 같은 프로젝트 맥락을 이어받습니다.</p>
-            </div>
-            <button type="button" className="proj-doc__more">전체 보기 →</button>
-          </article>
-        </div>
       </section>
 
       <nav className="proj-tabs" aria-label={`${projectName} project sections`}>
@@ -2442,15 +2420,10 @@ function ProjectChatSurface({
     return (
       <div className="pc-chat-directory" data-project-chat-list>
         <div className="pc-chat-directory__head">
-          <div>
-            <div className="pc-chat-directory__eyebrow">Chats</div>
-            <h2>{projectName} conversations</h2>
-            <p>{projectPath}</p>
-          </div>
-          <button type="button" className="btn btn--primary btn--sm" onClick={handleNewChat}>
-            <Plus size={14} />
-            New chat
-          </button>
+          <span className="pc-chat-directory__eyebrow">
+            Chats
+            <span className="pc-chat-directory__count">{chats.length || session.totalChats || 0}</span>
+          </span>
         </div>
 
         <div className="pc-chat-directory__grid">
@@ -2471,16 +2444,14 @@ function ProjectChatSurface({
               >
                 <span className="pc-chat-card__head">
                   <span className="pc-chat-card__title">{chat.title}</span>
-                  <span className={`pc-chat-card__status pc-chat-card__status--${statusClass(session.status)}`}>
-                    <span className="pc-chat-card__status-dot" />
-                    {projectStatusLabel(session.status)}
-                  </span>
+                  <span className="pc-chat-card__time">{formatRelativeTime(chat.lastActivityAt)}</span>
                 </span>
                 <span className="pc-chat-card__preview">{chat.latestPreview || recentPreview}</span>
                 <span className="pc-chat-card__meta">
+                  <span className={`badge badge--dot ${projectStatusBadgeClass(session.status)}`}>
+                    {projectStatusLabel(session.status)}
+                  </span>
                   <span>{agentLabel(chat.agent, chat.model ?? modelLabel)}</span>
-                  <span className="pc-chat-card__meta-sep">·</span>
-                  <span>{formatRelativeTime(chat.lastActivityAt)}</span>
                 </span>
               </button>
             ))}

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -2142,9 +2142,9 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 }
 
 .proj-stats {
-  display: flex;
-  gap: var(--sp-14);
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--sp-10) var(--sp-14);
 }
 
 .proj-stat-label {
@@ -2247,6 +2247,18 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
   color: var(--text-secondary);
   position: relative;
   white-space: nowrap;
+  transition: color 140ms var(--ease-smooth);
+}
+
+.proj-tab:hover:not(.proj-tab--active) {
+  color: var(--text-primary);
+}
+
+.proj-tab:focus-visible {
+  outline: none;
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--b-500) 32%, transparent);
+  border-radius: var(--r-xs);
 }
 
 .proj-tab--active {
@@ -2420,6 +2432,7 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 .proj-empty-panel {
   min-height: 360px;
   border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
   background: var(--surface);
   display: grid;
   place-items: center;
@@ -2430,11 +2443,12 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 }
 
 .proj-empty-panel__icon {
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
   display: grid;
   place-items: center;
   border: 1px solid var(--border-default);
+  border-radius: var(--r-full);
   background: var(--surface-raised);
   color: var(--b-600);
 }
@@ -2463,45 +2477,40 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 .pc-chat-directory {
   display: flex;
   flex-direction: column;
-  gap: var(--sp-8);
+  gap: var(--sp-6);
   min-width: 0;
 }
 
 .pc-chat-directory__head {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: var(--sp-8);
+  gap: var(--sp-6);
   min-width: 0;
 }
 
 .pc-chat-directory__eyebrow {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--sp-3);
   font-family: var(--font-mono);
   font-size: var(--text-2xs);
-  color: var(--b-600);
-  text-transform: uppercase;
-  font-weight: 700;
-  letter-spacing: 0;
-  margin-bottom: var(--sp-2);
-}
-
-.pc-chat-directory__head h2 {
-  margin: 0;
-  font-size: var(--text-h3);
-  letter-spacing: 0;
-}
-
-.pc-chat-directory__head p {
-  margin: var(--sp-2) 0 0;
   color: var(--text-tertiary);
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.pc-chat-directory__count {
   font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  overflow-wrap: anywhere;
+  font-size: var(--text-2xs);
+  color: var(--text-tertiary);
+  font-weight: 500;
 }
 
 .pc-chat-directory__grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 340px);
+  grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
   gap: var(--sp-8);
   min-width: 0;
 }
@@ -2515,7 +2524,7 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 .pc-chat-directory__list {
   display: flex;
   flex-direction: column;
-  gap: var(--sp-3);
+  gap: var(--sp-4);
   min-width: 0;
 }
 
@@ -2523,105 +2532,82 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: var(--sp-2);
   align-items: stretch;
   min-width: 0;
-  padding: var(--sp-6) var(--sp-7);
+  padding: var(--sp-10);
   background: var(--surface);
   border: 1px solid var(--border-subtle);
-  border-radius: 10px;
+  border-radius: var(--r-md);
   text-align: left;
   cursor: pointer;
-  transition: transform 180ms var(--ease-smooth), box-shadow 180ms var(--ease-smooth), border-color 180ms var(--ease-smooth);
+  transition: border-color 160ms var(--ease-smooth), background-color 160ms var(--ease-smooth);
 }
 
-.pc-chat-card:hover,
+.pc-chat-card:hover {
+  border-color: var(--border-default);
+  background: var(--surface-hover);
+}
+
 .pc-chat-card:focus-visible {
-  transform: translateY(-1px);
-  border-color: var(--border-strong);
-  box-shadow: 0 12px 28px -18px rgba(15,23,42,0.18);
   outline: none;
-}
-
-html[data-theme='dark'] .pc-chat-card:hover,
-html[data-theme='dark'] .pc-chat-card:focus-visible {
-  box-shadow: 0 12px 28px -18px rgba(0,0,0,0.55);
+  border-color: var(--border-default);
+  background: var(--surface-hover);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--b-500) 32%, transparent);
 }
 
 .pc-chat-card__head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--sp-4);
+  gap: var(--sp-6);
+  margin-bottom: var(--sp-4);
   min-width: 0;
 }
 
 .pc-chat-card__title {
   color: var(--text-primary);
   font-size: var(--text-h4);
-  font-weight: 650;
-  letter-spacing: -0.01em;
-  line-height: 1.3;
+  font-weight: 600;
+  letter-spacing: 0;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.pc-chat-card__status {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+.pc-chat-card__time {
   flex-shrink: 0;
-  padding: 3px 8px;
-  border-radius: 999px;
   font-family: var(--font-mono);
   font-size: var(--text-2xs);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  background: var(--surface-sunken);
-  color: var(--text-secondary);
-  border: 1px solid var(--border-subtle);
+  color: var(--text-tertiary);
+  white-space: nowrap;
 }
-
-.pc-chat-card__status-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentColor;
-}
-
-.pc-chat-card__status--run { color: var(--b-600); border-color: color-mix(in srgb, var(--b-500) 35%, var(--border-subtle)); }
-.pc-chat-card__status--run .pc-chat-card__status-dot { background: var(--b-500); animation: msb-pulse 1.6s infinite; }
-.pc-chat-card__status--done { color: var(--success-fg); border-color: color-mix(in srgb, var(--success-fg) 30%, var(--border-subtle)); }
-.pc-chat-card__status--appr { color: var(--warning-fg); border-color: color-mix(in srgb, var(--warning-fg) 35%, var(--border-subtle)); }
-.pc-chat-card__status--appr .pc-chat-card__status-dot { animation: msb-pulse 1.2s infinite; }
 
 .pc-chat-card__preview {
   color: var(--text-secondary);
-  font-size: var(--text-sm);
-  line-height: 1.45;
+  font-size: var(--text-xs);
+  line-height: 1.55;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
+  margin-bottom: var(--sp-5);
 }
 
 .pc-chat-card__meta {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 6px;
-  color: var(--text-tertiary);
+  gap: var(--sp-6);
   font-family: var(--font-mono);
   font-size: var(--text-2xs);
-  margin-top: var(--sp-1);
+  color: var(--text-tertiary);
 }
 
 .pc-chat-card__meta-sep {
-  opacity: 0.6;
+  color: var(--text-disabled);
 }
 
 .pc-chat-card--new {
@@ -2629,7 +2615,7 @@ html[data-theme='dark'] .pc-chat-card:focus-visible {
   align-items: center;
   justify-content: center;
   gap: var(--sp-3);
-  padding: var(--sp-5) var(--sp-7);
+  padding: var(--sp-6) var(--sp-10);
   border-style: dashed;
   background: transparent;
   color: var(--text-secondary);
@@ -2639,7 +2625,7 @@ html[data-theme='dark'] .pc-chat-card:focus-visible {
 .pc-chat-card--new:focus-visible {
   color: var(--text-primary);
   border-color: var(--b-500);
-  background: color-mix(in srgb, var(--b-500) 5%, transparent);
+  background: color-mix(in srgb, var(--b-500) 6%, transparent);
 }
 
 .pc-chat-card__new-icon {
@@ -2651,24 +2637,25 @@ html[data-theme='dark'] .pc-chat-card:focus-visible {
 .pc-chat-card__new-label {
   font-size: var(--text-sm);
   font-weight: 600;
+  letter-spacing: 0;
 }
 
 .pc-chat-card--empty {
   flex-direction: row;
   align-items: center;
-  gap: var(--sp-5);
+  gap: var(--sp-6);
   border-style: dashed;
   background: transparent;
-  padding: var(--sp-8) var(--sp-7);
+  padding: var(--sp-12) var(--sp-10);
 }
 
 .pc-chat-card__empty-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--r-full);
   background: var(--surface-sunken);
   color: var(--text-secondary);
   flex-shrink: 0;
@@ -2677,19 +2664,20 @@ html[data-theme='dark'] .pc-chat-card:focus-visible {
 .pc-chat-card__empty-body {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--sp-2);
   min-width: 0;
 }
 
 .pc-chat-card__empty-title {
   color: var(--text-primary);
   font-size: var(--text-body);
-  font-weight: 650;
+  font-weight: 600;
 }
 
 .pc-chat-card__empty-text {
   color: var(--text-tertiary);
-  font-size: var(--text-sm);
+  font-size: var(--text-xs);
+  line-height: 1.55;
 }
 
 .pc-chat-directory__side {
@@ -2700,8 +2688,9 @@ html[data-theme='dark'] .pc-chat-card:focus-visible {
 
 .pc-chat-side-card {
   border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
   background: var(--surface);
-  padding: var(--sp-8);
+  padding: var(--sp-10);
 }
 
 .pc-chat-side-card__title {
@@ -2709,17 +2698,22 @@ html[data-theme='dark'] .pc-chat-card:focus-visible {
   align-items: center;
   gap: var(--sp-3);
   font-size: var(--text-xs);
-  font-weight: 700;
-  margin-bottom: var(--sp-5);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--sp-6);
 }
 
 .pc-chat-side-stat {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   gap: var(--sp-4);
-  padding: var(--sp-3) 0;
-  border-top: 1px dashed var(--border-subtle);
+  padding: var(--sp-4) 0;
   font-size: var(--text-xs);
+}
+
+.pc-chat-side-stat + .pc-chat-side-stat {
+  border-top: 1px dashed var(--border-subtle);
 }
 
 .pc-chat-side-stat span {
@@ -2729,6 +2723,7 @@ html[data-theme='dark'] .pc-chat-card:focus-visible {
 .pc-chat-side-stat strong {
   color: var(--text-primary);
   font-family: var(--font-mono);
+  font-weight: 600;
 }
 
 .pc-chat-loading,
@@ -6045,7 +6040,6 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
   }
 
   .home-feed-head,
-  .pc-chat-directory__head,
   .proj-chat__head,
   .proj-head__row,
   .proj-list-toolbar,
@@ -6122,15 +6116,23 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
   }
 
   .pc-chat-directory {
-    gap: var(--sp-6);
-  }
-
-  .pc-chat-directory__head .btn {
-    width: 100%;
+    gap: var(--sp-5);
   }
 
   .pc-chat-card {
-    padding: var(--sp-5) var(--sp-6);
+    padding: var(--sp-8);
+  }
+
+  .pc-chat-card--new {
+    padding: var(--sp-6) var(--sp-8);
+  }
+
+  .pc-chat-card--empty {
+    padding: var(--sp-10) var(--sp-8);
+  }
+
+  .pc-chat-side-card {
+    padding: var(--sp-8);
   }
 
   .pc-proto {


### PR DESCRIPTION
## Summary
- 채팅 카드 가로 padding이 0이던 핵심 결함 수정 (`var(--sp-7)` 미정의 → `var(--sp-10)`)
- 카드 raw value(10px radius, weight 650, translateY lift, custom shadow) 제거하고 `.proj-chat`/`.proj-card`와 같은 디자인 토큰(`--r-md`, weight 600, border-color hover)으로 정렬
- 자체 status pill 제거, 기존 `.badge.badge--dot` + `projectStatusBadgeClass()` 재사용 — 카드 메타 행으로 이동
- `.proj-head`와 중복되던 채팅 디렉토리 헤더 제거 → `Chats <count>` eyebrow만 유지
- `.pc-chat-side-card`에 `--r-md` 추가, divider 규칙을 sibling combinator로 바꿔 첫 stat 위에 잘못 그려지던 border-top 제거
- `.proj-stats` flex+wrap → auto-fit grid (`minmax(160px, 1fr)`)
- `.proj-tab` hover/focus-visible 추가, `.proj-empty-panel` radius 보강
- 모든 프로젝트에 동일 더미 텍스트로 노이즈만 깔던 `.proj-docs`(Project instructions / Project memory) 블록 제거

## 검증
- `tsc --noEmit`: ✅ clean
- `projectListSurface.test.ts`: ✅ 23/23
- 전체 vitest: 462 pass / 4 fail — 4건은 main 베이스라인과 **동일**한 사전 실패 (sessionEventsRoute, designSystemV1, designSystemV3, mobileOverflow)
- `git diff --check`: clean

## dev proxy URL
https://lawdigest.cloud/proxy/2234/

## worktree
`/home/ubuntu/project/ARIS-polish-project-cards`

## 배포 여부
production 배포 안 함 (dev proxy 확인 후 별도 지시 시 진행)