### PR TITLE
refactor(provider-arch): phase 1 - CliProvider contracts

### DIFF
--- a/services/aris-backend/src/runtime/contracts/cliProvider.ts
+++ b/services/aris-backend/src/runtime/contracts/cliProvider.ts
@@ -1,0 +1,224 @@
+/**
+ * CliProvider — primary abstraction for plugging in coding-agent CLIs
+ * (Claude, Codex, Gemini, OpenCode, …) at the process level.
+ *
+ * Adapted from horang-labs/tessera (`src/lib/cli/providers/provider-contract.ts`).
+ *
+ * Surface scope:
+ *   - Process lifecycle (spawn, sendMessage, sendInterrupt)
+ *   - Stdout parsing (parseStdout — pure)
+ *   - Connection probing (checkStatus, isAvailable)
+ *   - Provider-side approvals / config updates / runtime controls
+ *
+ * Out of scope (handled elsewhere):
+ *   - Higher-level turn orchestration (sendTurn / abortTurn / recoverSession)
+ *     lives in `ProviderRuntime` (`./providerRuntime.ts`). During the
+ *     refactor (Phases 2–4) the two interfaces will coexist; long-term
+ *     `ProviderRuntime` will be implemented on top of `CliProvider`.
+ *   - Persistence and broadcasting are caller responsibilities — driven by
+ *     `ParsedMessageSideEffect` descriptors emitted by `parseStdout`.
+ *
+ * Phase 1 only introduces the interface. No provider implements it yet.
+ */
+
+import type { ChildProcess } from 'child_process';
+import type { ParsedMessage } from './parsedMessage.js';
+import type { CliStatusResult, CheckStatusOptions } from './cliStatus.js';
+import type { ProviderRuntimeFlavor } from './providerRuntime.js';
+
+/**
+ * Options passed to the provider when creating or resuming a CLI session.
+ *
+ * Mirrors Tessera's `SpawnOptions` but reuses ARIS's existing semantic
+ * vocabulary (ApprovalPolicy, AgentFlavor) instead of introducing new types.
+ */
+export interface CliSpawnOptions {
+  /** User id for settings-aware spawn behavior (env propagation, etc). */
+  userId?: string;
+  /** Normalized model identifier (e.g. "claude-sonnet-4-6"). */
+  model?: string;
+  /** Provider-specific reasoning effort / thinking intensity. */
+  reasoningEffort?: string | null;
+  /**
+   * Local session id (ARIS UUID). Semantics depend on `resume`:
+   *   - resume === true : ask the provider to resume an existing CLI session
+   *     (e.g. `claude --resume <id>`).
+   *   - resume falsy    : new session; the id MAY be passed as a creation
+   *     hint so the provider's session id matches the ARIS UUID.
+   */
+  sessionId?: string;
+  /** When true, resume an existing CLI session identified by sessionId. */
+  resume?: boolean;
+  /**
+   * Codex-specific: threadId from a prior thread/start response. Stored in
+   * `sessions.provider_state` as `{ threadId: "..." }`.
+   */
+  threadId?: string;
+  /**
+   * Working directory for the spawned process. Required because ARIS sessions
+   * always have a project path.
+   */
+  workDir: string;
+  /** Optional abort signal for the spawn itself (separate from turn signal). */
+  signal?: AbortSignal;
+  /** Caller-supplied environment overrides merged on top of process.env. */
+  envOverrides?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Result of `CliProvider.spawn()`.
+ */
+export interface CliSpawnResult {
+  ok: boolean;
+  /** The spawned child process (always present so callers can attach handlers
+   * even on partial-failure paths). */
+  process: ChildProcess;
+  /** Populated when ok === false. */
+  error?: Error;
+}
+
+/**
+ * Content for `sendMessage`. Either a plain string or structured content
+ * blocks; concrete shape is provider-specific. The interface stays loose so
+ * Codex (JSON-RPC), Claude (stream-json), and Gemini (ACP) can each accept
+ * what they need without coupling.
+ */
+export type CliMessageContent = string | ReadonlyArray<unknown>;
+
+/**
+ * Provider-side runtime patch sent mid-session (e.g. permission mode, model,
+ * reasoning effort).
+ */
+export interface CliRuntimeConfigPatch {
+  permissionMode?: string;
+  model?: string;
+  reasoningEffort?: string | null;
+  [key: string]: unknown;
+}
+
+/**
+ * The CliProvider interface itself.
+ *
+ * All non-optional methods MUST be implemented. Optional methods are typed
+ * as such because not every CLI supports every capability:
+ *   - Claude streamlines plan approval and AskUserQuestion.
+ *   - Codex needs raw JSON-RPC response/error sending for app-server.
+ *   - Gemini ACP needs both.
+ */
+export interface CliProvider {
+  /** Stable machine identifier matching `AgentFlavor`. */
+  getProviderId(): ProviderRuntimeFlavor;
+
+  /** Human-readable display name (UI dropdowns, log messages). */
+  getDisplayName(): string;
+
+  /**
+   * Quick boolean availability probe. Implementations SHOULD delegate to
+   * `checkStatus()` and return `result.status === 'connected'`. Kept as a
+   * convenience so callers that only care about "fully usable" don't have
+   * to destructure.
+   */
+  isAvailable(options?: CheckStatusOptions): Promise<boolean>;
+
+  /**
+   * Build CLI args for the given spawn options. Does NOT include the binary
+   * name. Pure function — useful for tests and command preview.
+   */
+  getCliArgs(options: CliSpawnOptions): string[];
+
+  /**
+   * Spawn the CLI process for a session. Implementations are responsible for
+   * arg construction, env propagation, and stdio configuration.
+   */
+  spawn(options: CliSpawnOptions): Promise<CliSpawnResult>;
+
+  /**
+   * Write a message to the CLI process stdin in the format the CLI expects.
+   * Returns false when the write was rejected (process not writable, etc.).
+   */
+  sendMessage(proc: ChildProcess, content: CliMessageContent): boolean;
+
+  /**
+   * Parse a single newline-delimited stdout line. MUST be pure: no direct
+   * calls to stores, persistence, or broadcasters. Side effects are
+   * surfaced via `ParsedMessage.sideEffect` descriptors.
+   *
+   * Returns null when the line is unparseable garbage that should be
+   * dropped silently. Returns an empty `envelopes` array when the line was
+   * understood but intentionally produces no envelope (e.g. heartbeats).
+   */
+  parseStdout(line: string): ParsedMessage | null;
+
+  /**
+   * Optional session-aware variant. Use when the provider needs the local
+   * session id to resolve parser state or correlate JSON-RPC ids across
+   * multiple lines.
+   */
+  parseSessionStdout?(sessionId: string, line: string): ParsedMessage[];
+
+  /**
+   * Optional exit hook for provider-owned cleanup (parser state flush,
+   * pending request rejection, etc.). Called once per process exit.
+   */
+  handleSessionExit?(sessionId: string, exitCode: number | null): ParsedMessage[];
+
+  /**
+   * Optional: update provider-side session configuration mid-session
+   * (permission mode, model, reasoning effort). Returns false when the
+   * patch could not be delivered.
+   */
+  updateSessionConfig?(proc: ChildProcess, patch: CliRuntimeConfigPatch): boolean;
+
+  /**
+   * Optional: respond to a pending server-initiated approval request that
+   * was surfaced via a `request_permission` side effect.
+   */
+  sendApprovalResponse?(
+    proc: ChildProcess,
+    requestId: string | number,
+    decision: 'accept' | 'decline',
+  ): void;
+
+  /**
+   * Optional: send a raw JSON-RPC result to a CLI process for a
+   * provider-specific server-initiated request (Codex app-server, Gemini ACP).
+   */
+  sendJsonRpcResponse?(
+    proc: ChildProcess,
+    requestId: string | number,
+    result: Record<string, unknown>,
+  ): void;
+
+  /**
+   * Optional: send a raw JSON-RPC error for an unsupported or failed request.
+   */
+  sendJsonRpcError?(
+    proc: ChildProcess,
+    requestId: string | number,
+    error: { code: number; message: string; data?: unknown },
+  ): void;
+
+  /**
+   * Optional: send an interrupt/cancel signal to the CLI process. Returns
+   * false when the CLI cannot be interrupted in its current state.
+   */
+  sendInterrupt?(proc: ChildProcess, sessionId: string): boolean;
+
+  /**
+   * Optional: provider-specific startup work after the process has been
+   * registered and stdio handlers attached (e.g. send `initialize` request).
+   */
+  onSessionReady?(proc: ChildProcess, sessionId: string): boolean;
+
+  /**
+   * Probe the CLI installation and authentication state.
+   *
+   * Implementations SHOULD:
+   *   - Bail out to "not_installed" when the version command fails.
+   *   - Return "needs_login" when version succeeds but auth fails.
+   *   - Enforce a 5s timeout per command.
+   *
+   * Read-only: MUST NOT persist state or write to other subsystems.
+   */
+  checkStatus(options?: CheckStatusOptions): Promise<CliStatusResult>;
+}

--- a/services/aris-backend/src/runtime/contracts/cliStatus.ts
+++ b/services/aris-backend/src/runtime/contracts/cliStatus.ts
@@ -1,0 +1,50 @@
+/**
+ * CLI provider connection status types.
+ *
+ * Three-state model adapted from horang-labs/tessera (`src/lib/cli/providers/provider-contract.ts`).
+ * Replaces the implicit boolean availability check with a richer status that
+ * distinguishes "binary missing" from "binary present but auth failing".
+ *
+ * Status semantics:
+ *  - "connected":     binary runs AND auth check succeeds.
+ *  - "needs_login":   binary runs but auth check fails (e.g. logged out).
+ *  - "not_installed": binary missing OR execution failed (ENOENT, timeout,
+ *                     non-zero exit on `--version`).
+ */
+
+export type CliConnectionStatus = 'connected' | 'needs_login' | 'not_installed';
+
+/**
+ * Result of one CLI status probe for a given environment.
+ */
+export interface CliStatusResult {
+  status: CliConnectionStatus;
+  /** Optional CLI version string (omitted when status === 'not_installed'). */
+  version?: string;
+  /**
+   * Optional free-form error message when status !== 'connected'. Shown to
+   * users in setup/diagnostics views; never fed back into CLI commands.
+   */
+  errorMessage?: string;
+}
+
+/**
+ * Input options to a status probe.
+ *
+ * Environment selection is included for forward-compatibility (Windows + WSL
+ * support). aris-backend currently runs on Linux only, so the default
+ * environment is "native".
+ */
+export interface CheckStatusOptions {
+  /**
+   * "native" — spawn the binary directly on the host.
+   * "wsl"    — spawn through wsl.exe on Windows. Currently unsupported on the
+   *            ARIS server but kept for parity with Tessera's interface so
+   *            providers don't have to re-shape later.
+   */
+  environment: 'native' | 'wsl';
+}
+
+export const DEFAULT_CHECK_STATUS_OPTIONS: CheckStatusOptions = {
+  environment: 'native',
+};

--- a/services/aris-backend/src/runtime/contracts/parsedMessage.ts
+++ b/services/aris-backend/src/runtime/contracts/parsedMessage.ts
@@ -1,0 +1,100 @@
+/**
+ * ParsedMessage — output of a pure CLI stdout parser.
+ *
+ * Adapted from horang-labs/tessera (`src/lib/cli/providers/message-types.ts`).
+ *
+ * Parsers MUST be pure: no direct calls to runtime stores, persistence layers,
+ * or WebSocket broadcasters. State mutations are described as side-effect
+ * descriptors, and the caller (e.g. happyClient) inspects each descriptor and
+ * dispatches the appropriate manager call. This split makes parsers
+ * unit-testable with fixtures and keeps protocol logic reversible.
+ *
+ * Phase 1 establishes the interface only — no provider implements this yet.
+ * Side-effect variants will be expanded as Phase 2 (Codex normalization)
+ * surfaces real parsing needs.
+ */
+
+import type { SessionProtocolEnvelope } from './sessionProtocol.js';
+import type { ProviderActionEvent, ProviderPermissionRequest } from './providerRuntime.js';
+
+/**
+ * Result of parsing a single newline-delimited stdout line from a CLI
+ * process.
+ *
+ * envelopes: zero or more canonical session-protocol envelopes the caller
+ * can broadcast or persist. An empty array means "the line was understood but
+ * intentionally produced no envelope" (e.g. heartbeats).
+ *
+ * sideEffect: an optional descriptor for state mutations the parser cannot
+ * perform itself.
+ */
+export interface ParsedMessage {
+  envelopes: SessionProtocolEnvelope[];
+  sideEffect?: ParsedMessageSideEffect;
+}
+
+/**
+ * Discriminated union of state mutations a parser can request.
+ *
+ * The set is intentionally small for Phase 1. Phase 2 (Codex) and Phase 4
+ * (Claude/Gemini migration) will extend this union as concrete provider
+ * extractions surface real needs.
+ */
+export type ParsedMessageSideEffect =
+  /** Update the live process's `isGenerating` flag (turn boundary). */
+  | { type: 'set_generating'; value: boolean }
+  /**
+   * Persist or refresh provider-side session state (e.g. Codex threadId,
+   * Gemini ACP sessionId). The shape is provider-specific and is stored in
+   * `sessions.provider_state` JSON column.
+   */
+  | { type: 'update_provider_state'; providerState: Record<string, unknown> }
+  /**
+   * Inform the runtime that the assistant emitted an action (file read/
+   * write/list, command execution). Used both for streaming UI updates and
+   * inferred-action persistence after a turn finishes.
+   */
+  | { type: 'emit_action'; action: ProviderActionEvent }
+  /**
+   * Provider has issued a permission request that needs runtime adjudication
+   * before tool execution can proceed.
+   */
+  | { type: 'request_permission'; request: ProviderPermissionRequest }
+  /**
+   * Provider has retracted a permission request (e.g. tool call cancelled
+   * before approval). The runtime should resolve any pending decision waiter
+   * with `deny` to avoid leaking promises.
+   */
+  | { type: 'cancel_permission'; callId: string; approvalId?: string }
+  /**
+   * Send a JSON-RPC response to the CLI process for a server-initiated
+   * request the parser saw on stdout. Used by Codex app-server and Gemini
+   * ACP channels where the runtime answers tool invocations over the same
+   * stream.
+   */
+  | { type: 'send_json_rpc_response'; requestId: string | number; result: Record<string, unknown> }
+  | {
+      type: 'send_json_rpc_error';
+      requestId: string | number;
+      code: number;
+      message: string;
+      data?: unknown;
+    }
+  /**
+   * Mark the turn as finished with a terminal reason. The caller is
+   * responsible for invoking persistence and resolving the turn promise.
+   */
+  | { type: 'turn_complete'; reason: 'completed' | 'aborted' | 'error' | 'timeout' };
+
+/**
+ * Type guard to narrow a ParsedMessage to a specific side-effect variant.
+ *
+ * Useful in dispatchers that switch on `sideEffect.type` and want exhaustive
+ * checking under `--strict`.
+ */
+export function hasSideEffect<T extends ParsedMessageSideEffect['type']>(
+  message: ParsedMessage,
+  type: T,
+): message is ParsedMessage & { sideEffect: Extract<ParsedMessageSideEffect, { type: T }> } {
+  return message.sideEffect?.type === type;
+}

--- a/services/aris-backend/src/runtime/contracts/providerRegistry.ts
+++ b/services/aris-backend/src/runtime/contracts/providerRegistry.ts
@@ -1,0 +1,99 @@
+/**
+ * CliProviderRegistry — singleton registry for CliProvider implementations.
+ *
+ * Adapted from horang-labs/tessera (`src/lib/cli/providers/registry.ts`).
+ *
+ * Providers are registered by their AgentFlavor id (`'claude' | 'codex' |
+ * 'gemini'`). Unknown ids throw on lookup so session creation paths fail
+ * loudly instead of silently swapping providers.
+ *
+ * The registry instance is stored on `globalThis` under a Symbol key so it
+ * survives `tsx watch` reloads and webpack module duplication on the API
+ * route side. This matters because aris-backend dev mode hot-reloads modules
+ * without restarting the process — re-registering on every reload would
+ * either thrash the registry or silently leave stale instances.
+ *
+ * Phase 1 introduces the registry. No provider is registered yet; that
+ * happens in Phase 2 (Codex) and Phase 4 (Claude/Gemini migration).
+ */
+
+import type { CliProvider } from './cliProvider.js';
+import type { ProviderRuntimeFlavor } from './providerRuntime.js';
+
+export class CliProviderRegistry {
+  private readonly providers = new Map<ProviderRuntimeFlavor, CliProvider>();
+
+  /**
+   * Register a provider under the given id. Re-registering an existing id
+   * replaces the previous implementation — useful for tests but a code smell
+   * in production code, where `registerIfAbsent` should be preferred.
+   */
+  register(id: ProviderRuntimeFlavor, provider: CliProvider): void {
+    this.providers.set(id, provider);
+  }
+
+  /**
+   * Register a provider only when the slot is still empty. Returns the
+   * existing provider when one was already registered. Idempotent — safe to
+   * call from bootstrap modules that may be re-imported under hot reload.
+   */
+  registerIfAbsent(
+    id: ProviderRuntimeFlavor,
+    createProvider: () => CliProvider,
+  ): CliProvider {
+    const existing = this.providers.get(id);
+    if (existing) {
+      return existing;
+    }
+
+    const provider = createProvider();
+    this.providers.set(id, provider);
+    return provider;
+  }
+
+  /**
+   * Returns true when a provider has been registered for the id. Does not
+   * perform any availability or status check.
+   */
+  hasProvider(id: ProviderRuntimeFlavor): boolean {
+    return this.providers.has(id);
+  }
+
+  /**
+   * Returns ids of all registered providers in registration order. Does not
+   * perform any availability check.
+   */
+  getProviderIds(): ProviderRuntimeFlavor[] {
+    return Array.from(this.providers.keys());
+  }
+
+  /**
+   * Returns the provider for the given id. Throws when the id is unknown so
+   * callers do not silently fall back to a different provider.
+   */
+  getProvider(id: ProviderRuntimeFlavor): CliProvider {
+    const provider = this.providers.get(id);
+    if (!provider) {
+      throw new Error(`CliProviderRegistry: unknown provider id="${id}"`);
+    }
+    return provider;
+  }
+
+  /**
+   * Test-only helper to wipe the registry. Public so test files can use it
+   * without reaching into internals; production code should never call this.
+   */
+  clearForTesting(): void {
+    this.providers.clear();
+  }
+}
+
+/**
+ * Singleton instance. Stored on globalThis so it survives `tsx watch` module
+ * reloads (the dev runner re-imports source files into the same process).
+ */
+const REGISTRY_KEY = Symbol.for('aris.cliProviderRegistry');
+const _global = globalThis as unknown as Record<symbol, CliProviderRegistry | undefined>;
+
+export const cliProviderRegistry: CliProviderRegistry =
+  _global[REGISTRY_KEY] ?? (_global[REGISTRY_KEY] = new CliProviderRegistry());

--- a/services/aris-backend/tests/cliProviderRegistry.test.ts
+++ b/services/aris-backend/tests/cliProviderRegistry.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  CliProviderRegistry,
+  cliProviderRegistry,
+} from '../src/runtime/contracts/providerRegistry.js';
+import type { CliProvider } from '../src/runtime/contracts/cliProvider.js';
+import type { ProviderRuntimeFlavor } from '../src/runtime/contracts/providerRuntime.js';
+
+function makeStubProvider(id: ProviderRuntimeFlavor): CliProvider {
+  return {
+    getProviderId: () => id,
+    getDisplayName: () => `Stub ${id}`,
+    isAvailable: async () => true,
+    getCliArgs: () => [],
+    spawn: async () => {
+      throw new Error('stub provider does not spawn');
+    },
+    sendMessage: () => false,
+    parseStdout: () => null,
+    generateTitle: undefined as never,
+    checkStatus: async () => ({ status: 'connected' }),
+  } as unknown as CliProvider;
+}
+
+describe('CliProviderRegistry', () => {
+  afterEach(() => {
+    cliProviderRegistry.clearForTesting();
+  });
+
+  it('registers and looks up providers by id', () => {
+    const registry = new CliProviderRegistry();
+    const provider = makeStubProvider('claude');
+
+    registry.register('claude', provider);
+
+    expect(registry.hasProvider('claude')).toBe(true);
+    expect(registry.getProvider('claude')).toBe(provider);
+  });
+
+  it('throws on unknown ids so callers do not silently fall back', () => {
+    const registry = new CliProviderRegistry();
+    expect(() => registry.getProvider('codex')).toThrow(/unknown provider id="codex"/);
+  });
+
+  it('replaces an existing registration when register() is called twice', () => {
+    const registry = new CliProviderRegistry();
+    const first = makeStubProvider('claude');
+    const second = makeStubProvider('claude');
+
+    registry.register('claude', first);
+    registry.register('claude', second);
+
+    expect(registry.getProvider('claude')).toBe(second);
+  });
+
+  it('registerIfAbsent only invokes the factory when the slot is empty', () => {
+    const registry = new CliProviderRegistry();
+    const factory = vi.fn(() => makeStubProvider('codex'));
+
+    const first = registry.registerIfAbsent('codex', factory);
+    const second = registry.registerIfAbsent('codex', factory);
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+  });
+
+  it('lists registered ids in insertion order', () => {
+    const registry = new CliProviderRegistry();
+    registry.register('claude', makeStubProvider('claude'));
+    registry.register('gemini', makeStubProvider('gemini'));
+    registry.register('codex', makeStubProvider('codex'));
+
+    expect(registry.getProviderIds()).toEqual(['claude', 'gemini', 'codex']);
+  });
+
+  it('clearForTesting wipes all registrations', () => {
+    const registry = new CliProviderRegistry();
+    registry.register('claude', makeStubProvider('claude'));
+    registry.register('codex', makeStubProvider('codex'));
+
+    registry.clearForTesting();
+
+    expect(registry.hasProvider('claude')).toBe(false);
+    expect(registry.hasProvider('codex')).toBe(false);
+    expect(registry.getProviderIds()).toEqual([]);
+  });
+
+  it('exposes a globalThis-pinned singleton', async () => {
+    const provider = makeStubProvider('claude');
+    cliProviderRegistry.registerIfAbsent('claude', () => provider);
+
+    // Re-import to simulate a second module evaluation (hot reload, separate
+    // import path). The singleton is keyed on Symbol.for('aris.cliProviderRegistry')
+    // so a fresh dynamic import must observe the same instance.
+    const reimported = await import('../src/runtime/contracts/providerRegistry.js');
+    expect(reimported.cliProviderRegistry).toBe(cliProviderRegistry);
+    expect(reimported.cliProviderRegistry.getProvider('claude')).toBe(provider);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 — `CliProvider` 인터페이스, `ParsedMessage` 사이드이펙트 모델, `CliConnectionStatus` 3-state, 그리고 globalThis 싱글턴 `CliProviderRegistry`를 도입한다. **빈 골격 PR**: 어떤 provider도 아직 새 인터페이스를 implement하지 않으며, 새 모듈은 어디서도 import되지 않는다. tessera (`src/lib/cli/providers/`)의 패턴을 ARIS의 `AgentFlavor`/`SessionProtocolEnvelope`/`ProviderActionEvent` 등 기존 vocabulary에 맞춰 정렬한 형태.

마스터 플랜: `docs/03-platform/provider-architecture-refactor-plan.md` (Phase 0 PR #282에서 머지됨).

## 추가 파일

- `services/aris-backend/src/runtime/contracts/cliStatus.ts` — `CliConnectionStatus` (`'connected' | 'needs_login' | 'not_installed'`), `CliStatusResult`, `CheckStatusOptions`.
- `services/aris-backend/src/runtime/contracts/parsedMessage.ts` — `ParsedMessage = { envelopes, sideEffect? }`, `ParsedMessageSideEffect` discriminated union, `hasSideEffect` 타입 가드.
- `services/aris-backend/src/runtime/contracts/cliProvider.ts` — 17개 메서드 인터페이스 (`getProviderId`/`getDisplayName`/`isAvailable`/`getCliArgs`/`spawn`/`sendMessage`/`parseStdout`/`parseSessionStdout?`/`handleSessionExit?`/`updateSessionConfig?`/`sendApprovalResponse?`/`sendJsonRpcResponse?`/`sendJsonRpcError?`/`sendInterrupt?`/`onSessionReady?`/`checkStatus`).
- `services/aris-backend/src/runtime/contracts/providerRegistry.ts` — `CliProviderRegistry` 클래스 + `cliProviderRegistry` 싱글턴 (Symbol.for 키로 globalThis 핀, tsx watch hot-reload 안전).
- `services/aris-backend/tests/cliProviderRegistry.test.ts` — vitest 7개 케이스: 등록/조회, 미등록 throw, register 재호출 시 교체, registerIfAbsent 멱등성, 삽입 순서, clearForTesting, globalThis 싱글턴 ID.

## 디자인 결정

- **`ProviderRuntime`(기존)와 공존** — 마이그레이션 기간 동안 두 인터페이스는 추상화 레벨이 다르다. `ProviderRuntime`은 turn 단위(sendTurn/abortTurn/recoverSession), `CliProvider`는 process 단위(spawn/sendMessage/parseStdout). 장기적으로 `ProviderRuntime`이 `CliProvider` 위에 구현되는 형태로 합쳐진다(Phase 4 종료 후 deprecation).
- **`parseStdout`은 순수 함수** — caller(happyClient)가 `ParsedMessageSideEffect`를 보고 stores/persistence/broadcaster를 호출. 단위 테스트 가능, 회귀 fixture로 보호 가능.
- **`AgentFlavor` reuse** — provider id 새 enum을 만들지 않고 `ProviderRuntimeFlavor` (= `'claude' | 'codex' | 'gemini'`)를 그대로 활용. registry/factory의 키가 1급 시민과 일치.
- **side-effect taxonomy 최소화** — Phase 1에서는 8개 variant (set_generating, update_provider_state, emit_action, request_permission, cancel_permission, send_json_rpc_response/error, turn_complete). Phase 2(Codex 추출) 진행하면서 실제 필요한 variant 추가.
- **`SkillSource`는 도입하지 않음** — ARIS는 OMC를 통해 skill을 사용하지만 backend에서 skill discovery 기능은 아직 없음. 도입 시점에 별도 PR.
- **`generateTitle`은 인터페이스에서 제외** — ARIS는 별도 title generator(`actionType.ts`/title 헬퍼)가 있어 process-layer surface와 분리. 향후 재평가.

## Test plan

- [x] `npx tsc --noEmit` clean (aris-backend)
- [x] `npx vitest run cliProviderRegistry` 7/7 PASS
- [x] 새 파일은 어디서도 import되지 않음 → 기존 동작 무영향 (gh, git diff, ripgrep으로 확인)
- [x] symbol 키(`Symbol.for('aris.cliProviderRegistry')`)로 globalThis singleton 보장 — tsx watch hot reload에서 동일 인스턴스 유지

## Definition of Done

- [x] 4개 contract 파일 + 1개 test 파일 추가
- [x] `tsc --noEmit` 통과
- [x] vitest 통과
- [x] 마스터 플랜 Phase 1의 모든 산출물 충족
- [ ] 머지 후 Phase 2 worktree(Codex 정상화) 시작
