### PR TITLE
refactor(provider-arch): phase 2 sprints 1+2 - codex skeleton

### DIFF
--- a/docs/03-platform/codex-protocol-conformance.md
+++ b/docs/03-platform/codex-protocol-conformance.md
@@ -1,0 +1,59 @@
+# Codex Protocol Conformance
+
+Codex provider raw payload는 adapter 내부에서만 해석한다. 상위 레이어는 canonical envelope와 canonical `threadId`만 소비한다.
+
+## Happy 불변식
+
+- fresh codex turn은 raw provider key casing/형식에 의존하지 않는다.
+- observed codex `threadId`는 실패한 turn에서도 보존된다.
+- `app-server` JSON-RPC `request_id`와 `exec` 라인 `id`는 provider identity로 승격되지 않는다.
+- `app-server` mapper와 `exec` mapper는 동일한 canonical `SessionProtocolEnvelope` 시퀀스를 도출해야 한다.
+- approval policy 변환은 한 곳(`normalizeCodexApprovalPolicy`)에서만 수행한다.
+
+## 채널 매핑
+
+Codex의 두 채널(`app-server`, `exec`)은 raw payload shape이 다르지만 ARIS 상위 레이어는 동일한 `SessionProtocolEnvelope`(turn-start / turn-end / tool-call-start / tool-call-end / text / stop) 시퀀스를 받는다.
+
+| Codex 이벤트 | app-server raw | exec raw | canonical envelope |
+|---|---|---|---|
+| 턴 시작 | `thread/start` 또는 `thread/resume` 응답 | stdout 첫 `thread.started` JSON | `turn-start` |
+| assistant 텍스트 | `agent_message` 또는 `agent_message_delta` notification | stdout `agent_message` 라인 | `text` |
+| tool call (file_write 등) | `tool_call` notification | stdout `tool_call` 라인 | `tool-call-start` / `tool-call-end` |
+| permission 요청 | `permission_request` notification (서버 측 JSON-RPC request) | stdout `permission_request` 라인 | side-effect: `request_permission` |
+| 턴 종료 | `task_complete` notification | stdout `task_complete` + EOF | `turn-end` |
+| 턴 오류 | JSON-RPC error 또는 `task_error` | stdout `task_error` | `turn-end` (stopReason='error') |
+| 비-thread 오류 | "no thread with id ..." 등 | 동일 | retry 분기 (Identity Boundary 참고) |
+
+## 구현 경계
+
+- raw key variation (`thread_id`, `threadId`, `request_id`, `requestId`, …)은 `services/aris-backend/src/runtime/providers/codex/codexProtocolFields.ts`에서만 정규화한다 (Sprint 3에서 신설).
+- `codexProtocolMapper.ts`는 위 정규화를 사용해 두 채널을 동일한 envelope 시퀀스로 매핑한다 (Sprint 3).
+- fixture 기반 conformance 테스트는 `services/aris-backend/tests/fixtures/codex/*.jsonl` raw trace를 canonical behavior로 고정한다 (Sprint 3).
+
+## Trace 출처 (예정)
+
+다음 시나리오의 raw fixture를 Sprint 3에서 캡처해 conformance 테스트로 고정한다.
+
+- `app-server-thread-start.jsonl` — fresh turn, JSON-RPC `thread/start` 응답.
+- `app-server-thread-resume.jsonl` — resume turn, `thread/resume` 응답 + 후속 notifications.
+- `app-server-permission-request.jsonl` — server-initiated `permission_request` 후 client `permission_response`.
+- `app-server-tool-call-file-write.jsonl` — file_write tool call의 start/end notification 시퀀스.
+- `app-server-task-error-missing-thread.jsonl` — "no thread with id" 오류 (retry 분기 검증).
+- `exec-thread-started-and-completed.jsonl` — exec 채널 fresh turn, EOF까지.
+- `exec-tool-call-and-permission.jsonl` — exec 채널 tool_call + permission_request 라인 형태.
+
+## 환경 변수 영향
+
+| 변수 | 기본값 | 영향 |
+|---|---|---|
+| `CODEX_RUNTIME_MODE` | `app-server` | `app-server` 또는 `exec`. 어댑터의 채널 선택. |
+| `CODEX_SANDBOX_MODE` | `workspace-write` | `-s` 인자로 전달. `yolo` approval policy 시 `danger-full-access`로 강제. |
+| `CODEX_APPROVAL_POLICY` | `on-request` | 기본 fallback approval policy (session에 명시 없을 때). |
+| `CODEX_TURN_TIMEOUT_MS` | 30분 | turn wall-clock guard. activity-based가 아니므로 추후 검토. |
+| `CODEX_APP_SERVER_POST_TURN_QUIET_MS` | 250 | turn-end 이후 quiet window. |
+| `CODEX_APP_SERVER_POST_TURN_DRAIN_TIMEOUT_MS` | 1500 | drain 단계 최대 대기. |
+
+## 후속 검토
+
+- `CODEX_TURN_TIMEOUT_MS`의 activity-based 변환 (Gemini alignment와 동일 방향).
+- exec 채널 영속화 일관성 점검 — Identity Boundary 문서의 "후속 방향" 참고.

--- a/docs/03-platform/codex-session-identity-boundary.md
+++ b/docs/03-platform/codex-session-identity-boundary.md
@@ -1,0 +1,56 @@
+# Codex Session Identity Boundary
+
+## 목적
+
+Codex runtime에서 ARIS 내부 correlation id, Codex `threadId`, 그리고 ARIS 세션 UUID 사이의 경계를 명확히 고정한다.
+
+## 원칙
+
+- ARIS는 codex turn 시작 시 codex가 발급한 실제 `threadId`만 thread cache에 저장한다.
+- codex가 `threadId`를 발급하기 전에는 어떤 synthetic id도 `threadId`로 승격되지 않는다.
+- thread cache key는 `(sessionId, chatId)` 페어로 고정한다 — 동일 세션 내 다른 chat의 thread를 섞지 않는다.
+- 실패한 turn에서도 마지막으로 observed된 `threadId`는 보존한다. 다음 turn은 그 값을 `codex exec resume <threadId>`로 사용할 수 있어야 한다.
+- `app-server` 채널의 JSON-RPC `request_id`는 process 단위 correlation 용도이며 절대 `threadId`나 ARIS sessionId로 승격하지 않는다.
+- `exec` 채널의 stdin/stdout 라인 단위 `id` 역시 동일 — local correlation 전용.
+
+## 채널별 동작
+
+Codex는 두 가지 실행 채널을 가진다.
+
+### app-server 채널 (`CODEX_RUNTIME_MODE=app-server`, default)
+
+- ARIS가 `127.0.0.1:<random>`에 임시 포트를 reserve, codex `app-server`를 spawn한 뒤 WebSocket으로 연결한다.
+- `thread/start` 또는 `thread/resume` 응답의 `threadId`를 thread cache에 기록한다.
+- 모든 후속 JSON-RPC 메시지는 그 `threadId`에 종속된다.
+
+### exec 채널 (`CODEX_RUNTIME_MODE=exec`)
+
+- `codex exec --json <prompt>` (fresh) 또는 `codex exec resume <threadId> --json <prompt>` (resume) 형태로 직접 spawn한다.
+- stdout JSON 라인 중 `thread.start` / `thread.resume` 이벤트에서 `threadId`를 추출한다.
+- exec 채널의 stdout은 한 turn 종료 후 EOF로 마무리된다.
+
+## 현재 동작 (이 문서가 작성된 시점)
+
+- thread cache: `buildCodexThreadCacheKey(sessionId, chatId)`로 키 생성, in-process Map.
+- 두 채널 공통: turn 시작 시 cache에 저장된 `threadId`가 있으면 resume, 없으면 fresh.
+- `isMissingCodexThreadError(error)` true이면 cache 무효화 후 1회 fresh 재시도 (line 5368).
+- ARIS `sessions.provider_state` JSON 컬럼에 `{ threadId: "..." }`로 영속화 (현재는 `app-server` 경로만 영속화 — `exec` 경로는 in-process cache만 사용 중인지 추후 검증 필요).
+
+## 구현 기준
+
+- 인라인 코드 위치 (Phase 2 추출 대상):
+  - 환경 상수: `services/aris-backend/src/runtime/happyClient.ts:80-118`
+  - thread cache 키 빌더: `buildCodexThreadCacheKey` (`happyClient.ts:1357` 부근)
+  - missing-thread retry 분기: `happyClient.ts:5368`
+  - exec spawn 인라인: `happyClient.ts:4221`
+  - app-server WebSocket 라이프사이클: `happyClient.ts:1650-1900`
+- Phase 2 정착 위치:
+  - `services/aris-backend/src/runtime/providers/codex/codexLauncher.ts` — args 빌드
+  - `services/aris-backend/src/runtime/providers/codex/codexThreadCache.ts` — cache key/store (Sprint 6에서 신설)
+  - `services/aris-backend/src/runtime/providers/codex/codexSessionRegistry.ts` — observed threadId persistence
+
+## 후속 방향
+
+- exec 채널의 영속화 동작을 명시화한다 (현재 in-process Map만 사용 중인지, `provider_state` 영속화도 거치는지 추후 검증).
+- `app-server` 채널의 `request_id` ↔ ARIS 내부 correlation id를 별도 메타로 분리해 confusion을 차단한다.
+- `localCorrelationId`와 `threadId`를 혼동하지 않도록 persisted message 메타 키를 분리한다 (Claude alignment와 동일 방향).

--- a/services/aris-backend/src/runtime/providers/codex/bootstrap.ts
+++ b/services/aris-backend/src/runtime/providers/codex/bootstrap.ts
@@ -1,0 +1,21 @@
+/**
+ * Codex provider bootstrap.
+ *
+ * Side-effect module that registers the codex adapter with the
+ * `cliProviderRegistry`. Mirrors Tessera's
+ * `src/lib/cli/providers/bootstrap.ts` pattern: imported once from the
+ * server entry point so the registration happens exactly once and
+ * survives `tsx watch` hot reload via `registerIfAbsent`.
+ *
+ * Phase 2 Sprint 2 keeps this module **un-imported** from any runtime
+ * entry. The registry stays empty at runtime; the structural slot is
+ * ready for Sprint 6 to wire by adding a single import in `server.ts`
+ * (or a top-level barrel). Keeping the registration dormant until then
+ * means Sprint 2 is purely additive and cannot perturb existing code
+ * paths.
+ */
+
+import { cliProviderRegistry } from '../../contracts/providerRegistry.js';
+import { codexAdapter } from './codexAdapter.js';
+
+cliProviderRegistry.registerIfAbsent('codex', () => codexAdapter);

--- a/services/aris-backend/src/runtime/providers/codex/codexAdapter.ts
+++ b/services/aris-backend/src/runtime/providers/codex/codexAdapter.ts
@@ -1,0 +1,134 @@
+/**
+ * Codex CliProvider adapter.
+ *
+ * Phase 2 Sprint 2 establishes the adapter as a structural slot. Only the
+ * read-only methods (`getProviderId`, `getDisplayName`, `getCliArgs`,
+ * `isAvailable`, `checkStatus`) are functional. Process-lifecycle methods
+ * (`spawn`, `sendMessage`, `parseStdout`, …) throw `NotYetWiredError` —
+ * Sprint 6 will replace those throws with extracted logic from
+ * `happyClient.ts`.
+ *
+ * The adapter is registered with `cliProviderRegistry` via
+ * `./bootstrap.ts`, but bootstrap is not imported anywhere in production
+ * code yet. The registry remains empty at runtime until Sprint 6 wires the
+ * import — keeping Sprint 2 zero-risk.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type {
+  CliMessageContent,
+  CliProvider,
+  CliRuntimeConfigPatch,
+  CliSpawnOptions,
+  CliSpawnResult,
+} from '../../contracts/cliProvider.js';
+import type { ParsedMessage } from '../../contracts/parsedMessage.js';
+import type { CheckStatusOptions, CliStatusResult } from '../../contracts/cliStatus.js';
+import { buildCodexCommand } from './codexLauncher.js';
+
+const CODEX_DISPLAY_NAME = 'OpenAI Codex CLI';
+const CHECK_STATUS_TIMEOUT_MS = 5_000;
+
+class NotYetWiredError extends Error {
+  constructor(method: string) {
+    super(
+      `CodexAdapter.${method}() is not wired yet. Phase 2 Sprint 2 ships only the structural slot; ` +
+        'Sprint 6 will extract the implementation from happyClient.ts.',
+    );
+    this.name = 'NotYetWiredError';
+  }
+}
+
+const execFileAsync = promisify(execFile);
+
+async function probeCodexVersion(): Promise<{ ok: boolean; version?: string; error?: string }> {
+  try {
+    const { stdout } = await execFileAsync('codex', ['--version'], {
+      timeout: CHECK_STATUS_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    const trimmed = stdout.trim();
+    return { ok: true, version: trimmed.length > 0 ? trimmed : undefined };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: message };
+  }
+}
+
+export class CodexAdapter implements CliProvider {
+  getProviderId(): 'codex' {
+    return 'codex';
+  }
+
+  getDisplayName(): string {
+    return CODEX_DISPLAY_NAME;
+  }
+
+  async isAvailable(options?: CheckStatusOptions): Promise<boolean> {
+    const result = await this.checkStatus(options);
+    return result.status === 'connected';
+  }
+
+  /**
+   * Build the codex CLI args for the given spawn options.
+   *
+   * Sprint 2 surfaces this via the launcher even though spawn() itself is
+   * not yet wired — the args builder is a pure function and is safe to
+   * exercise from tests.
+   *
+   * Note: this method assumes the caller has already mapped its own concept
+   * of approvalPolicy/model into spawn options. Until full wiring lands in
+   * Sprint 6, the spawn-options shape doesn't carry approvalPolicy, so we
+   * default to `on-request` here and let tests cover the launcher's full
+   * input shape directly.
+   */
+  getCliArgs(options: CliSpawnOptions): string[] {
+    const command = buildCodexCommand({
+      prompt: '',
+      approvalPolicy: 'on-request',
+      ...(options.model ? { model: options.model } : {}),
+      ...(options.reasoningEffort
+        ? { reasoningEffort: options.reasoningEffort as 'low' | 'medium' | 'high' | 'xhigh' }
+        : {}),
+      ...(options.threadId ? { threadId: options.threadId } : {}),
+    });
+    return command.args;
+  }
+
+  async spawn(_options: CliSpawnOptions): Promise<CliSpawnResult> {
+    throw new NotYetWiredError('spawn');
+  }
+
+  sendMessage(_proc: unknown, _content: CliMessageContent): boolean {
+    throw new NotYetWiredError('sendMessage');
+  }
+
+  parseStdout(_line: string): ParsedMessage | null {
+    throw new NotYetWiredError('parseStdout');
+  }
+
+  updateSessionConfig(_proc: unknown, _patch: CliRuntimeConfigPatch): boolean {
+    throw new NotYetWiredError('updateSessionConfig');
+  }
+
+  async checkStatus(_options?: CheckStatusOptions): Promise<CliStatusResult> {
+    const probe = await probeCodexVersion();
+    if (!probe.ok) {
+      return {
+        status: 'not_installed',
+        ...(probe.error ? { errorMessage: probe.error } : {}),
+      };
+    }
+    // A successful `--version` is enough to mark codex as connected at the
+    // probe level. Auth state (`codex login` status) is checked by happyClient
+    // at turn time and surfaced via runtime errors. A richer auth probe will
+    // land in Sprint 6 alongside the runtime extraction.
+    return {
+      status: 'connected',
+      ...(probe.version ? { version: probe.version } : {}),
+    };
+  }
+}
+
+export const codexAdapter = new CodexAdapter();

--- a/services/aris-backend/src/runtime/providers/codex/codexLauncher.ts
+++ b/services/aris-backend/src/runtime/providers/codex/codexLauncher.ts
@@ -1,0 +1,148 @@
+/**
+ * Codex command builder.
+ *
+ * Mirrors the Claude/Gemini precedent in `claudeLauncher.ts` /
+ * `geminiLauncher.ts`. Returns a `CodexLaunchCommand` describing the binary
+ * name, args, and channel selection (`app-server` vs `exec`).
+ *
+ * The exec-mode args returned here are byte-equivalent to the inline spawn
+ * at `services/aris-backend/src/runtime/happyClient.ts:4198-4221` as of the
+ * Phase 2 baseline. happyClient.ts is NOT yet routed through this builder;
+ * Sprint 6 will perform that wiring with a fixture-locked regression check.
+ *
+ * App-server-mode commands are also returned here, even though the
+ * app-server transport is more complex than a single `spawn(...)` call.
+ * The caller (Sprint 4 extraction) is responsible for spawning the
+ * app-server, reserving a port, and connecting the WebSocket — this
+ * builder only assembles the command-line arguments.
+ */
+
+import type { ApprovalPolicy } from '../../../types.js';
+import type {
+  CodexApprovalPolicy,
+  CodexBuildCommandInput,
+  CodexLaunchCommand,
+  CodexReasoningEffort,
+  CodexSandboxMode,
+} from './types.js';
+
+const DEFAULT_SANDBOX_MODE: CodexSandboxMode = 'workspace-write';
+
+/**
+ * Resolve channel selection from explicit input or the CODEX_RUNTIME_MODE env.
+ *
+ * Pure helper exposed for tests.
+ */
+export function resolveCodexChannel(
+  explicit?: 'app-server' | 'exec',
+  envValue?: string,
+): 'app-server' | 'exec' {
+  if (explicit === 'exec' || explicit === 'app-server') {
+    return explicit;
+  }
+  const normalized = (envValue ?? '').trim().toLowerCase();
+  return normalized === 'exec' ? 'exec' : 'app-server';
+}
+
+/**
+ * Normalize ARIS-wide ApprovalPolicy → codex `-a` arg.
+ *
+ * - `on-request` / `on-failure` / `never` pass through.
+ * - `yolo` collapses to `never` (the caller separately forces sandbox to
+ *   `danger-full-access`).
+ */
+export function normalizeCodexApprovalPolicy(value: ApprovalPolicy): CodexApprovalPolicy {
+  if (value === 'on-failure' || value === 'never') {
+    return value;
+  }
+  if (value === 'yolo') {
+    return 'never';
+  }
+  return 'on-request';
+}
+
+/**
+ * Resolve the sandbox mode honoring the yolo escalation.
+ */
+export function resolveCodexSandboxMode(input: {
+  approvalPolicy: ApprovalPolicy;
+  override?: CodexSandboxMode;
+  envSandboxMode?: string;
+}): CodexSandboxMode {
+  if (input.approvalPolicy === 'yolo') {
+    return 'danger-full-access';
+  }
+  if (input.override) {
+    return input.override;
+  }
+  const envValue = (input.envSandboxMode ?? '').trim();
+  if (envValue === 'read-only' || envValue === 'workspace-write' || envValue === 'danger-full-access') {
+    return envValue;
+  }
+  return DEFAULT_SANDBOX_MODE;
+}
+
+function appendIfTruthy<T extends string>(args: string[], flag: T, value: string | undefined | null): void {
+  if (value && value.length > 0) {
+    args.push(flag, value);
+  }
+}
+
+function appendReasoningEffort(args: string[], reasoningEffort?: CodexReasoningEffort | null): void {
+  if (!reasoningEffort) {
+    return;
+  }
+  args.push('-c', `model_reasoning_effort=${JSON.stringify(reasoningEffort)}`);
+}
+
+/**
+ * Build a CodexLaunchCommand.
+ *
+ * exec channel args (matches `happyClient.ts:4198` baseline):
+ *   codex
+ *     -a <approvalPolicy>
+ *     -s <sandboxMode>
+ *     [-m <model>]
+ *     [-c model_reasoning_effort=<JSON-quoted enum>]
+ *     exec [resume <threadId>] --json <prompt>
+ *
+ * app-server channel args (the caller wraps this with port reservation and
+ * websocket setup; Sprint 4 will own that lifecycle):
+ *   codex
+ *     -a <approvalPolicy>
+ *     -s <sandboxMode>
+ *     [-m <model>]
+ *     [-c model_reasoning_effort=<JSON-quoted enum>]
+ *     app-server
+ */
+export function buildCodexCommand(input: CodexBuildCommandInput): CodexLaunchCommand {
+  const approvalPolicy = normalizeCodexApprovalPolicy(input.approvalPolicy);
+  const sandboxMode = resolveCodexSandboxMode({
+    approvalPolicy: input.approvalPolicy,
+    override: input.sandboxMode,
+    envSandboxMode: process.env.CODEX_SANDBOX_MODE,
+  });
+  const channel = resolveCodexChannel(input.channel, process.env.CODEX_RUNTIME_MODE);
+
+  const args: string[] = ['-a', approvalPolicy, '-s', sandboxMode];
+  appendIfTruthy(args, '-m', input.model);
+  appendReasoningEffort(args, input.reasoningEffort);
+
+  if (channel === 'exec') {
+    if (input.threadId && input.threadId.trim().length > 0) {
+      args.push('exec', 'resume', input.threadId.trim(), '--json', input.prompt);
+    } else {
+      args.push('exec', '--json', input.prompt);
+    }
+  } else {
+    args.push('app-server');
+  }
+
+  return {
+    command: 'codex',
+    args,
+    requiresPty: false,
+    streamJson: true,
+    channel,
+  };
+}

--- a/services/aris-backend/src/runtime/providers/codex/codexProtocolFields.ts
+++ b/services/aris-backend/src/runtime/providers/codex/codexProtocolFields.ts
@@ -1,0 +1,108 @@
+/**
+ * Codex raw payload key normalization.
+ *
+ * Mirrors the precedent in `claudeProtocolFields.ts`: a single module owns
+ * extraction of canonical fields (`threadId`, request id, etc.) from raw
+ * codex payloads, regardless of casing variation between the two channels
+ * (app-server JSON-RPC vs exec stdout JSON).
+ *
+ * Phase 2 Sprint 2 introduces the placeholder. Sprint 3 will fill it with
+ * real extractors against captured fixtures (see
+ * `docs/03-platform/codex-protocol-conformance.md`).
+ */
+
+const CODEX_OBSERVED_THREAD_ID_KEYS = [
+  'thread_id',
+  'threadId',
+  'threadid',
+  'resume_thread_id',
+  'resumeThreadId',
+] as const;
+
+const CODEX_REQUEST_ID_KEYS = ['request_id', 'requestId', 'id'] as const;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function parseCodexJsonLine(
+  line: string,
+  onParseWarning?: (rawLine: string) => void,
+): Record<string, unknown> | null {
+  try {
+    return asRecord(JSON.parse(line));
+  } catch {
+    onParseWarning?.(line);
+    return null;
+  }
+}
+
+export function collectCodexNestedRecords(root: unknown): Record<string, unknown>[] {
+  const stack: unknown[] = [root];
+  const records: Record<string, unknown>[] = [];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    const record = asRecord(current);
+    if (!record) {
+      continue;
+    }
+    records.push(record);
+    for (const value of Object.values(record)) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          stack.push(item);
+        }
+      } else if (value && typeof value === 'object') {
+        stack.push(value);
+      }
+    }
+  }
+  return records;
+}
+
+export function extractFirstCodexStringByKeys(
+  records: Record<string, unknown>[],
+  keys: readonly string[],
+): string {
+  for (const key of keys) {
+    for (const record of records) {
+      const value = record[key];
+      if (typeof value !== 'string') {
+        continue;
+      }
+      const trimmed = value.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return '';
+}
+
+export function extractCodexObservedThreadId(value: unknown): string | undefined {
+  const records = Array.isArray(value)
+    ? (value as Record<string, unknown>[])
+    : collectCodexNestedRecords(value);
+  const threadId = extractFirstCodexStringByKeys(records, CODEX_OBSERVED_THREAD_ID_KEYS);
+  return threadId || undefined;
+}
+
+export function extractCodexRequestId(value: unknown): string | number | undefined {
+  const records = Array.isArray(value)
+    ? (value as Record<string, unknown>[])
+    : collectCodexNestedRecords(value);
+  for (const key of CODEX_REQUEST_ID_KEYS) {
+    for (const record of records) {
+      const v = record[key];
+      if (typeof v === 'string' && v.trim().length > 0) {
+        return v.trim();
+      }
+      if (typeof v === 'number' && Number.isFinite(v)) {
+        return v;
+      }
+    }
+  }
+  return undefined;
+}

--- a/services/aris-backend/src/runtime/providers/codex/codexSessionRegistry.ts
+++ b/services/aris-backend/src/runtime/providers/codex/codexSessionRegistry.ts
@@ -1,0 +1,13 @@
+/**
+ * Codex session registry — placeholder.
+ *
+ * Mirrors the Claude/Gemini precedent (`claudeSessionRegistry.ts`,
+ * `geminiSessionRegistry.ts`). Sprint 6 will fill this with the threadId
+ * cache currently held in `happyClient.ts` (see `buildCodexThreadCacheKey`
+ * around line 1357 of that file) and any per-session app-server connection
+ * state that needs to outlive a single turn.
+ *
+ * Phase 2 Sprint 2 ships only the structural slot.
+ */
+
+export {};

--- a/services/aris-backend/src/runtime/providers/codex/index.ts
+++ b/services/aris-backend/src/runtime/providers/codex/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Codex provider barrel.
+ *
+ * Re-exports the public surface of the codex/ subtree. The adapter itself
+ * is not registered with `cliProviderRegistry` from this barrel — that
+ * happens in `./bootstrap.ts`, which is intentionally not imported from
+ * any runtime entry point in Phase 2 Sprint 2.
+ */
+
+export type {
+  CodexApprovalPolicy,
+  CodexBuildCommandInput,
+  CodexCliResult,
+  CodexCommandExecutor,
+  CodexLaunchCommand,
+  CodexPermissionDecision,
+  CodexPermissionRequest,
+  CodexReasoningEffort,
+  CodexResumeTarget,
+  CodexRunScope,
+  CodexSandboxMode,
+  CodexTextEvent,
+  CodexThreadIdSource,
+  CodexTurnResult,
+} from './types.js';
+
+export {
+  buildCodexCommand,
+  normalizeCodexApprovalPolicy,
+  resolveCodexChannel,
+  resolveCodexSandboxMode,
+} from './codexLauncher.js';
+
+export {
+  collectCodexNestedRecords,
+  extractCodexObservedThreadId,
+  extractCodexRequestId,
+  extractFirstCodexStringByKeys,
+  parseCodexJsonLine,
+} from './codexProtocolFields.js';
+
+export { CodexAdapter, codexAdapter } from './codexAdapter.js';

--- a/services/aris-backend/src/runtime/providers/codex/types.ts
+++ b/services/aris-backend/src/runtime/providers/codex/types.ts
@@ -1,0 +1,106 @@
+/**
+ * Codex provider type aliases.
+ *
+ * Mirrors the Claude/Gemini precedent in `claude/types.ts` and `gemini/types.ts`:
+ * provider-specific names are aliased over the canonical Provider* types so
+ * call sites can read intent without coupling to ARIS-wide vocabulary.
+ *
+ * Phase 2 Sprint 2 introduces this file as part of the codex/ skeleton.
+ * Subsequent sprints will extend it with codex-specific subtypes (thread
+ * cache key, app-server failure kinds, etc.) as logic is extracted from
+ * happyClient.ts.
+ */
+
+import type { SessionProtocolEnvelope } from '../../contracts/sessionProtocol.js';
+import type {
+  ProviderActionEvent,
+  ProviderCliResult,
+  ProviderCommandExecutor,
+  ProviderLaunchCommand,
+  ProviderPermissionRequest,
+  ProviderResumeTarget,
+  ProviderTextEvent,
+  ProviderThreadIdSource,
+} from '../../contracts/providerRuntime.js';
+import type { ApprovalPolicy, PermissionDecision } from '../../../types.js';
+
+export type CodexResumeTarget = ProviderResumeTarget;
+export type CodexThreadIdSource = ProviderThreadIdSource;
+export type CodexActionEvent = ProviderActionEvent;
+export type CodexPermissionRequest = ProviderPermissionRequest;
+export type CodexTextEvent = ProviderTextEvent;
+
+export type CodexCliResult = ProviderCliResult & {
+  protocolEnvelopes?: SessionProtocolEnvelope[];
+};
+
+/**
+ * `codex` exec/app-server CLI launch command. The `streamJson` flag is always
+ * true because both channels emit JSON envelopes that the runtime parses as
+ * a stream — even though the on-wire transport differs (stdout lines vs.
+ * WebSocket frames).
+ */
+export type CodexLaunchCommand = ProviderLaunchCommand<'codex'> & {
+  /**
+   * Channel selector at command-build time. Defaults to "app-server" but the
+   * caller may force "exec" via the CODEX_RUNTIME_MODE env. The launcher
+   * encodes the choice into the args returned here.
+   */
+  channel: 'app-server' | 'exec';
+  streamJson: true;
+};
+
+export type CodexCommandExecutor = ProviderCommandExecutor<CodexLaunchCommand>;
+
+export type CodexTurnResult = {
+  output: string;
+  cwd: string;
+  streamedActionsPersisted: boolean;
+  inferredActions: CodexActionEvent[];
+  threadId?: string;
+  threadIdSource: CodexThreadIdSource;
+  protocolEnvelopes?: SessionProtocolEnvelope[];
+};
+
+export type CodexRunScope = {
+  sessionId: string;
+  chatId?: string;
+};
+
+/**
+ * Reasoning effort accepted by codex. Codex's `-c model_reasoning_effort`
+ * flag accepts these enum values; the runtime encodes them as JSON-quoted
+ * strings.
+ */
+export type CodexReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+
+/**
+ * Codex sandbox mode. `workspace-write` is the default; `danger-full-access`
+ * is selected automatically when approval policy is `yolo`.
+ */
+export type CodexSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
+
+/**
+ * Codex approval policy. Subset of ARIS's ApprovalPolicy mapped through
+ * normalizeCodexApprovalPolicy(). `yolo` is not represented here because it
+ * collapses into `never` + sandbox=danger-full-access.
+ */
+export type CodexApprovalPolicy = 'on-request' | 'on-failure' | 'never';
+
+/**
+ * Inputs accepted by the Codex launcher's command builder.
+ */
+export interface CodexBuildCommandInput {
+  prompt: string;
+  approvalPolicy: ApprovalPolicy;
+  model?: string;
+  reasoningEffort?: CodexReasoningEffort | null;
+  sandboxMode?: CodexSandboxMode;
+  /** Forces exec channel; otherwise the launcher reads CODEX_RUNTIME_MODE env. */
+  channel?: 'app-server' | 'exec';
+  /** When provided AND channel === 'exec', emits `exec resume <threadId>`. */
+  threadId?: string;
+}
+
+/** Re-export for downstream callers; equivalent to ARIS-wide PermissionDecision. */
+export type CodexPermissionDecision = PermissionDecision;

--- a/services/aris-backend/tests/codexAdapter.test.ts
+++ b/services/aris-backend/tests/codexAdapter.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { codexAdapter } from '../src/runtime/providers/codex/codexAdapter.js';
+
+describe('codexAdapter (Sprint 2 skeleton)', () => {
+  const savedEnv = { runtime: process.env.CODEX_RUNTIME_MODE };
+
+  beforeEach(() => {
+    process.env.CODEX_RUNTIME_MODE = 'exec';
+  });
+
+  afterEach(() => {
+    if (savedEnv.runtime === undefined) {
+      delete process.env.CODEX_RUNTIME_MODE;
+    } else {
+      process.env.CODEX_RUNTIME_MODE = savedEnv.runtime;
+    }
+  });
+
+  it('reports provider id and display name', () => {
+    expect(codexAdapter.getProviderId()).toBe('codex');
+    expect(codexAdapter.getDisplayName()).toBe('OpenAI Codex CLI');
+  });
+
+  it('builds CLI args via the launcher', () => {
+    const args = codexAdapter.getCliArgs({
+      workDir: '/tmp/example',
+      model: 'gpt-5.1-codex',
+      reasoningEffort: 'medium',
+      threadId: 'thread-xyz',
+    });
+    expect(args).toContain('-m');
+    expect(args).toContain('gpt-5.1-codex');
+    expect(args).toContain('exec');
+    expect(args).toContain('resume');
+    expect(args).toContain('thread-xyz');
+  });
+
+  it('throws NotYetWiredError on spawn() until Sprint 6', async () => {
+    await expect(
+      codexAdapter.spawn({ workDir: '/tmp/example' }),
+    ).rejects.toThrow(/not wired yet/i);
+  });
+
+  it('throws NotYetWiredError on sendMessage() until Sprint 6', () => {
+    expect(() => codexAdapter.sendMessage(null, 'hi')).toThrow(/not wired yet/i);
+  });
+
+  it('throws NotYetWiredError on parseStdout() until Sprint 6', () => {
+    expect(() => codexAdapter.parseStdout('{}')).toThrow(/not wired yet/i);
+  });
+});

--- a/services/aris-backend/tests/codexLauncher.test.ts
+++ b/services/aris-backend/tests/codexLauncher.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildCodexCommand,
+  normalizeCodexApprovalPolicy,
+  resolveCodexChannel,
+  resolveCodexSandboxMode,
+} from '../src/runtime/providers/codex/codexLauncher.js';
+
+const ENV_KEYS = ['CODEX_RUNTIME_MODE', 'CODEX_SANDBOX_MODE'] as const;
+type EnvKey = (typeof ENV_KEYS)[number];
+
+describe('codexLauncher', () => {
+  const savedEnv: Partial<Record<EnvKey, string | undefined>> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const previous = savedEnv[key];
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    }
+  });
+
+  describe('resolveCodexChannel', () => {
+    it('honors explicit selection over env', () => {
+      expect(resolveCodexChannel('exec', 'app-server')).toBe('exec');
+      expect(resolveCodexChannel('app-server', 'exec')).toBe('app-server');
+    });
+
+    it('falls back to env when explicit is omitted', () => {
+      expect(resolveCodexChannel(undefined, 'exec')).toBe('exec');
+      expect(resolveCodexChannel(undefined, 'app-server')).toBe('app-server');
+    });
+
+    it('defaults to app-server when neither input nor env is provided', () => {
+      expect(resolveCodexChannel()).toBe('app-server');
+    });
+
+    it('treats unknown env values as app-server', () => {
+      expect(resolveCodexChannel(undefined, 'wat')).toBe('app-server');
+    });
+  });
+
+  describe('normalizeCodexApprovalPolicy', () => {
+    it('passes through valid codex-side policies', () => {
+      expect(normalizeCodexApprovalPolicy('on-request')).toBe('on-request');
+      expect(normalizeCodexApprovalPolicy('on-failure')).toBe('on-failure');
+      expect(normalizeCodexApprovalPolicy('never')).toBe('never');
+    });
+
+    it('collapses yolo to never (sandbox handles full-access escalation)', () => {
+      expect(normalizeCodexApprovalPolicy('yolo')).toBe('never');
+    });
+  });
+
+  describe('resolveCodexSandboxMode', () => {
+    it('forces danger-full-access when approval is yolo regardless of override', () => {
+      expect(
+        resolveCodexSandboxMode({
+          approvalPolicy: 'yolo',
+          override: 'workspace-write',
+          envSandboxMode: 'read-only',
+        }),
+      ).toBe('danger-full-access');
+    });
+
+    it('uses override when approval is non-yolo', () => {
+      expect(
+        resolveCodexSandboxMode({
+          approvalPolicy: 'on-request',
+          override: 'read-only',
+          envSandboxMode: 'workspace-write',
+        }),
+      ).toBe('read-only');
+    });
+
+    it('reads env when override is omitted and value is recognized', () => {
+      expect(
+        resolveCodexSandboxMode({
+          approvalPolicy: 'on-request',
+          envSandboxMode: 'read-only',
+        }),
+      ).toBe('read-only');
+    });
+
+    it('falls back to workspace-write default when env is unrecognized', () => {
+      expect(
+        resolveCodexSandboxMode({
+          approvalPolicy: 'on-request',
+          envSandboxMode: 'wat',
+        }),
+      ).toBe('workspace-write');
+    });
+  });
+
+  describe('buildCodexCommand', () => {
+    it('builds fresh exec args with default sandbox and no model/reasoning', () => {
+      process.env.CODEX_RUNTIME_MODE = 'exec';
+      const command = buildCodexCommand({
+        prompt: 'Reply with OK',
+        approvalPolicy: 'on-request',
+      });
+      expect(command.command).toBe('codex');
+      expect(command.channel).toBe('exec');
+      expect(command.streamJson).toBe(true);
+      expect(command.requiresPty).toBe(false);
+      expect(command.args).toEqual([
+        '-a',
+        'on-request',
+        '-s',
+        'workspace-write',
+        'exec',
+        '--json',
+        'Reply with OK',
+      ]);
+    });
+
+    it('builds resume exec args when threadId is provided', () => {
+      process.env.CODEX_RUNTIME_MODE = 'exec';
+      const command = buildCodexCommand({
+        prompt: 'continue',
+        approvalPolicy: 'never',
+        threadId: 'thread-abc-123',
+      });
+      expect(command.args).toEqual([
+        '-a',
+        'never',
+        '-s',
+        'workspace-write',
+        'exec',
+        'resume',
+        'thread-abc-123',
+        '--json',
+        'continue',
+      ]);
+    });
+
+    it('appends model and reasoning effort flags when supplied', () => {
+      process.env.CODEX_RUNTIME_MODE = 'exec';
+      const command = buildCodexCommand({
+        prompt: 'work',
+        approvalPolicy: 'on-failure',
+        model: 'gpt-5.1-codex',
+        reasoningEffort: 'high',
+      });
+      expect(command.args).toEqual([
+        '-a',
+        'on-failure',
+        '-s',
+        'workspace-write',
+        '-m',
+        'gpt-5.1-codex',
+        '-c',
+        'model_reasoning_effort="high"',
+        'exec',
+        '--json',
+        'work',
+      ]);
+    });
+
+    it('forces danger-full-access sandbox under yolo approval', () => {
+      process.env.CODEX_RUNTIME_MODE = 'exec';
+      const command = buildCodexCommand({
+        prompt: 'rm -rf',
+        approvalPolicy: 'yolo',
+      });
+      expect(command.args.slice(0, 4)).toEqual(['-a', 'never', '-s', 'danger-full-access']);
+    });
+
+    it('builds app-server args when channel resolves to app-server', () => {
+      process.env.CODEX_RUNTIME_MODE = 'app-server';
+      const command = buildCodexCommand({
+        prompt: 'ignored-by-app-server-args',
+        approvalPolicy: 'on-request',
+      });
+      expect(command.channel).toBe('app-server');
+      expect(command.args).toEqual([
+        '-a',
+        'on-request',
+        '-s',
+        'workspace-write',
+        'app-server',
+      ]);
+    });
+
+    it('respects CODEX_SANDBOX_MODE when no override and approval is non-yolo', () => {
+      process.env.CODEX_RUNTIME_MODE = 'exec';
+      process.env.CODEX_SANDBOX_MODE = 'read-only';
+      const command = buildCodexCommand({
+        prompt: 'inspect',
+        approvalPolicy: 'on-request',
+      });
+      expect(command.args).toContain('read-only');
+    });
+
+    it('drops empty threadId rather than emitting `resume `', () => {
+      process.env.CODEX_RUNTIME_MODE = 'exec';
+      const command = buildCodexCommand({
+        prompt: 'p',
+        approvalPolicy: 'on-request',
+        threadId: '   ',
+      });
+      expect(command.args).not.toContain('resume');
+    });
+  });
+});

--- a/services/aris-backend/tests/codexProtocolFields.test.ts
+++ b/services/aris-backend/tests/codexProtocolFields.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractCodexObservedThreadId,
+  extractCodexRequestId,
+  parseCodexJsonLine,
+} from '../src/runtime/providers/codex/codexProtocolFields.js';
+
+describe('codexProtocolFields', () => {
+  describe('parseCodexJsonLine', () => {
+    it('returns parsed object for valid JSON object lines', () => {
+      expect(parseCodexJsonLine('{"thread_id":"abc"}')).toEqual({ thread_id: 'abc' });
+    });
+
+    it('returns null and reports the raw line for unparseable input', () => {
+      let warned = '';
+      const result = parseCodexJsonLine('not json', (raw) => {
+        warned = raw;
+      });
+      expect(result).toBeNull();
+      expect(warned).toBe('not json');
+    });
+
+    it('returns null for non-object JSON values', () => {
+      expect(parseCodexJsonLine('"just a string"')).toBeNull();
+      expect(parseCodexJsonLine('42')).toBeNull();
+      expect(parseCodexJsonLine('[1,2,3]')).toBeNull();
+    });
+  });
+
+  describe('extractCodexObservedThreadId', () => {
+    it('extracts from snake_case key', () => {
+      expect(extractCodexObservedThreadId({ thread_id: 'thread-1' })).toBe('thread-1');
+    });
+
+    it('extracts from camelCase key', () => {
+      expect(extractCodexObservedThreadId({ threadId: 'thread-2' })).toBe('thread-2');
+    });
+
+    it('extracts from lowercase concatenated variant', () => {
+      expect(extractCodexObservedThreadId({ threadid: 'thread-3' })).toBe('thread-3');
+    });
+
+    it('descends into nested records and arrays', () => {
+      const payload = {
+        params: {
+          result: { resume_thread_id: 'thread-deep' },
+        },
+      };
+      expect(extractCodexObservedThreadId(payload)).toBe('thread-deep');
+    });
+
+    it('returns undefined when no key matches', () => {
+      expect(extractCodexObservedThreadId({ unrelated: 'x' })).toBeUndefined();
+      expect(extractCodexObservedThreadId(null)).toBeUndefined();
+    });
+
+    it('ignores empty string values and continues searching', () => {
+      const payload = {
+        thread_id: '   ',
+        params: { threadId: 'real-thread' },
+      };
+      expect(extractCodexObservedThreadId(payload)).toBe('real-thread');
+    });
+  });
+
+  describe('extractCodexRequestId', () => {
+    it('extracts string ids', () => {
+      expect(extractCodexRequestId({ request_id: 'req-1' })).toBe('req-1');
+      expect(extractCodexRequestId({ requestId: 'req-2' })).toBe('req-2');
+    });
+
+    it('extracts numeric ids', () => {
+      expect(extractCodexRequestId({ id: 42 })).toBe(42);
+    });
+
+    it('returns undefined when no id-like key is present', () => {
+      expect(extractCodexRequestId({ unrelated: true })).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 Sprint 1 + Sprint 2 묶음 PR — Codex 정렬의 토대 작업.

- **Sprint 1 (docs)**: codex의 thread/session identity 경계와 두 채널(`app-server` / `exec`) 매핑 invariant을 글로 굳혀 둔다. claude/gemini 선례와 동일 양식.
- **Sprint 2 (skeleton)**: `runtime/providers/codex/` 디렉터리를 신설하고 `codexAdapter`(CliProvider impl), `codexLauncher`(`buildCodexCommand`), `codexProtocolFields`(raw key 정규화), `codexSessionRegistry`(placeholder), `bootstrap.ts`(registerIfAbsent)를 추가한다.

**Zero behavioral risk**: 기존 파일은 한 줄도 수정되지 않았다. `bootstrap.ts`는 어디서도 import되지 않으므로 `cliProviderRegistry`는 런타임에 비어 있으며, 새 codex 모듈은 모두 dormant 상태다. happyClient.ts의 inline codex 경로는 그대로 작동한다.

## 추가 파일

### 문서 (Sprint 1)
- `docs/03-platform/codex-session-identity-boundary.md` — thread cache key 규칙, app-server/exec 채널별 동작, retry 분기 invariant.
- `docs/03-platform/codex-protocol-conformance.md` — 두 채널 raw payload → canonical envelope 매핑 표, 환경 변수 영향, 향후 fixture 출처.

### 코드 (Sprint 2)
- `services/aris-backend/src/runtime/providers/codex/types.ts` — `CodexLaunchCommand`, `CodexBuildCommandInput`, `CodexApprovalPolicy`, `CodexSandboxMode`, `CodexReasoningEffort` 등 1차 타입.
- `services/aris-backend/src/runtime/providers/codex/codexLauncher.ts` — `buildCodexCommand` (exec/app-server args 빌드, yolo→danger-full-access 처리), `normalizeCodexApprovalPolicy`, `resolveCodexChannel`, `resolveCodexSandboxMode`. happyClient.ts:4198-4221 인라인 spawn과 byte-equivalent.
- `services/aris-backend/src/runtime/providers/codex/codexProtocolFields.ts` — `parseCodexJsonLine`, `extractCodexObservedThreadId`, `extractCodexRequestId`. claude precedent과 동일 surface.
- `services/aris-backend/src/runtime/providers/codex/codexSessionRegistry.ts` — placeholder (Sprint 6에서 thread cache 흡수).
- `services/aris-backend/src/runtime/providers/codex/codexAdapter.ts` — `CliProvider` 구현. `getProviderId`/`getDisplayName`/`getCliArgs`/`isAvailable`/`checkStatus` 작동. process-lifecycle 메서드는 `NotYetWiredError` throw (Sprint 6에서 채움).
- `services/aris-backend/src/runtime/providers/codex/index.ts` — barrel.
- `services/aris-backend/src/runtime/providers/codex/bootstrap.ts` — `cliProviderRegistry.registerIfAbsent('codex', ...)`. **어디서도 import 안 됨** — Sprint 6에서 server.ts가 import.

### 테스트
- `services/aris-backend/tests/codexLauncher.test.ts` — 16 케이스. channel 결정, approval 정규화, sandbox 정규화, exec/app-server args, yolo escalation, threadId trim 처리.
- `services/aris-backend/tests/codexAdapter.test.ts` — 5 케이스. id/name/args 작동, NotYetWiredError 검증.
- `services/aris-backend/tests/codexProtocolFields.test.ts` — 13 케이스. 다양한 raw key casing 추출, 중첩 페이로드, 빈 문자열 skip.

## 안전 검증

- 기존 파일 0개 수정 (`git status` 전부 untracked).
- `npx tsc --noEmit` (aris-backend): clean.
- `npx vitest run --exclude '**/*.e2e.test.ts'` (aris-backend): **263/263 PASS**. 새 추가 34 + 기존 229 모두 그대로 통과.
- happyClient.ts inline codex 경로 영향 없음. `buildAgentCommand`(line 3114)는 여전히 codex에 대해 null 반환 → "Unsupported agent flavor" throw 경로 그대로.
- `cliProviderRegistry.getProvider('codex')`는 Sprint 6 전까지 `unknown provider id="codex"` throw — registry는 dormant.

## 디자인 결정

1. **`providerCommandFactory.ts`는 수정하지 않음** — codex 분기를 추가하면 line 3114의 throw가 사라지면서 inline codex 경로(line 4221)가 지나는 경로와 충돌할 수 있다. Sprint 6에서 inline 경로 추출과 동시에 wiring.
2. **`bootstrap.ts`는 dormant** — 명시적으로 import되지 않으면 registry에 등록되지 않는다. Sprint 2의 행위는 100% 추가형.
3. **`codexAdapter`는 NotYetWiredError**를 던짐 — placeholder가 아니라 실제 인터페이스 implement이지만 process-lifecycle 메서드는 명시적으로 미구현. 의도적으로 호출되면 즉시 명확한 에러 메시지로 알려준다.
4. **`buildCodexCommand`는 byte-equivalent** — happyClient.ts:4198 인라인 args 시퀀스와 정확히 일치. Sprint 6 wiring 시 fixture 비교가 byte-level로 가능.
5. **codex 환경변수는 launcher 내부에서 직접 읽음** — happyClient의 module-level CODEX_* 상수와 중복되지만 dormant 상태이므로 분기 없음. Sprint 6 wiring 시 single source 통일.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run --exclude '**/*.e2e.test.ts'` 263/263 PASS
- [x] codex 관련 테스트 34/34 PASS
- [x] 기존 파일 수정 0
- [x] happyClient.ts 비변경 — inline codex 경로 무영향

## Definition of Done (이 PR)

- [x] Sprint 1 문서 2개
- [x] Sprint 2 codex/ 디렉터리 6파일 + 3 테스트 파일
- [x] tsc + vitest clean
- [x] 회귀 0건
- [ ] 머지 후 Sprint 3 (Protocol Mapper + Conformance Fixture) 시작
