### PR TITLE
refactor(aris-web): turn '새 채팅' dashed placeholder into action card

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -1528,7 +1528,6 @@ function ProjectDetailSurface({
         >
           <Database size={14} />
           Context
-          <span className="proj-tab__count">6</span>
         </button>
         <button
           type="button"
@@ -2308,7 +2307,7 @@ function ProjectChatSurface({
   const createChat = async (): Promise<SessionChat | null> => {
     setError(null);
     const createdChat = await createProjectSessionChat(session.id, {
-      title: `Chat ${Math.max(1, chats.length + 1)}`,
+      title: '새 채팅',
       agent: selectedProvider,
       model: activeModelLabel,
       modelReasoningEffort: serializeReasoningEffort(selectedEffort),
@@ -2431,8 +2430,9 @@ function ProjectChatSurface({
             {isLoadingChats && <div className="pc-chat-loading">Loading chats...</div>}
             {!isLoadingChats && chats.length > 0 && (
               <button type="button" className="pc-chat-card pc-chat-card--new" onClick={handleNewChat}>
-                <span className="pc-chat-card__new-icon"><Plus size={16} /></span>
+                <span className="pc-chat-card__new-icon" aria-hidden="true"><Plus size={16} strokeWidth={2.25} /></span>
                 <span className="pc-chat-card__new-label">새 채팅 시작</span>
+                <span className="pc-chat-card__new-hint">{agentLabel(selectedProvider, activeModelLabel)}</span>
               </button>
             )}
             {!isLoadingChats && chats.map((chat) => (
@@ -2457,10 +2457,10 @@ function ProjectChatSurface({
             ))}
             {!isLoadingChats && chats.length === 0 && (
               <button type="button" className="pc-chat-card pc-chat-card--empty" onClick={handleNewChat}>
-                <span className="pc-chat-card__empty-icon"><Plus size={20} /></span>
+                <span className="pc-chat-card__empty-icon" aria-hidden="true"><Plus size={20} strokeWidth={2.25} /></span>
                 <span className="pc-chat-card__empty-body">
-                  <span className="pc-chat-card__empty-title">Start the first chat</span>
-                  <span className="pc-chat-card__empty-text">프로젝트 하위에 새 채팅을 만들고 프로토타입 화면으로 진입합니다.</span>
+                  <span className="pc-chat-card__empty-title">첫 채팅 시작</span>
+                  <span className="pc-chat-card__empty-text">{agentLabel(selectedProvider, activeModelLabel)}로 이 프로젝트의 첫 대화를 엽니다.</span>
                 </span>
               </button>
             )}
@@ -2475,14 +2475,6 @@ function ProjectChatSurface({
               <div className="pc-chat-side-stat"><span>Total chats</span><strong>{chats.length || session.totalChats || 0}</strong></div>
               <div className="pc-chat-side-stat"><span>Active signal</span><strong>{projectStatusLabel(session.status)}</strong></div>
               <div className="pc-chat-side-stat"><span>Context</span><strong>{tokenLabel}</strong></div>
-            </article>
-            <article className="pc-chat-side-card">
-              <div className="pc-chat-side-card__title">
-                <FolderOpen size={14} />
-                Attached context
-              </div>
-              <div className="ctx-item"><FileText size={13} /><span className="ctx-item__name">design/chat-prototype.html</span><span className="ctx-item__tokens">source</span></div>
-              <div className="ctx-item"><FileText size={13} /><span className="ctx-item__name">Project IA shell</span><span className="ctx-item__tokens">active</span></div>
             </article>
           </aside>
         </div>

--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -2306,10 +2306,11 @@ function ProjectChatSurface({
 
   const createChat = async (): Promise<SessionChat | null> => {
     setError(null);
+    const projectModelInput = normalizeProjectChatModelInput(session.model ?? session.metadata?.runtimeModel);
     const createdChat = await createProjectSessionChat(session.id, {
       title: '새 채팅',
       agent: selectedProvider,
-      model: activeModelLabel,
+      model: projectModelInput,
       modelReasoningEffort: serializeReasoningEffort(selectedEffort),
     });
     setChats((previous) => [createdChat, ...previous.filter((chat) => chat.id !== createdChat.id)]);
@@ -2432,7 +2433,6 @@ function ProjectChatSurface({
               <button type="button" className="pc-chat-card pc-chat-card--new" onClick={handleNewChat}>
                 <span className="pc-chat-card__new-icon" aria-hidden="true"><Plus size={16} strokeWidth={2.25} /></span>
                 <span className="pc-chat-card__new-label">새 채팅 시작</span>
-                <span className="pc-chat-card__new-hint">{agentLabel(selectedProvider, activeModelLabel)}</span>
               </button>
             )}
             {!isLoadingChats && chats.map((chat) => (
@@ -2460,7 +2460,7 @@ function ProjectChatSurface({
                 <span className="pc-chat-card__empty-icon" aria-hidden="true"><Plus size={20} strokeWidth={2.25} /></span>
                 <span className="pc-chat-card__empty-body">
                   <span className="pc-chat-card__empty-title">첫 채팅 시작</span>
-                  <span className="pc-chat-card__empty-text">{agentLabel(selectedProvider, activeModelLabel)}로 이 프로젝트의 첫 대화를 엽니다.</span>
+                  <span className="pc-chat-card__empty-text">이 프로젝트의 첫 대화를 만들고 화면을 엽니다.</span>
                 </span>
               </button>
             )}

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -2285,6 +2285,13 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
   background: var(--surface-sunken);
   color: var(--text-tertiary);
   font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  transition: background-color 140ms var(--ease-smooth), color 140ms var(--ease-smooth);
+}
+
+.proj-tab--active .proj-tab__count {
+  background: color-mix(in srgb, var(--b-500) 12%, transparent);
+  color: var(--b-600);
 }
 
 .proj-pane {
@@ -2613,40 +2620,66 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
 .pc-chat-card--new {
   flex-direction: row;
   align-items: center;
-  justify-content: center;
-  gap: var(--sp-3);
-  padding: var(--sp-6) var(--sp-10);
-  border-style: dashed;
-  background: transparent;
-  color: var(--text-secondary);
+  gap: var(--sp-4);
+  padding: var(--sp-8) var(--sp-10);
+  border-color: color-mix(in srgb, var(--b-500) 24%, var(--border-subtle));
+  background: color-mix(in srgb, var(--b-500) 5%, var(--surface));
+  color: var(--text-primary);
 }
 
-.pc-chat-card--new:hover,
+.pc-chat-card--new:hover {
+  border-color: color-mix(in srgb, var(--b-500) 50%, var(--border-subtle));
+  background: color-mix(in srgb, var(--b-500) 9%, var(--surface));
+}
+
 .pc-chat-card--new:focus-visible {
-  color: var(--text-primary);
-  border-color: var(--b-500);
-  background: color-mix(in srgb, var(--b-500) 6%, transparent);
+  border-color: color-mix(in srgb, var(--b-500) 50%, var(--border-subtle));
+  background: color-mix(in srgb, var(--b-500) 9%, var(--surface));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--b-500) 32%, transparent);
 }
 
 .pc-chat-card__new-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--r-sm);
+  background: color-mix(in srgb, var(--b-500) 14%, transparent);
+  color: var(--b-600);
+  flex-shrink: 0;
 }
 
 .pc-chat-card__new-label {
   font-size: var(--text-sm);
   font-weight: 600;
   letter-spacing: 0;
+  color: var(--text-primary);
+}
+
+.pc-chat-card__new-hint {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .pc-chat-card--empty {
   flex-direction: row;
   align-items: center;
   gap: var(--sp-6);
-  border-style: dashed;
-  background: transparent;
+  border-color: color-mix(in srgb, var(--b-500) 20%, var(--border-subtle));
+  background: color-mix(in srgb, var(--b-500) 4%, var(--surface));
   padding: var(--sp-12) var(--sp-10);
+}
+
+.pc-chat-card--empty:hover {
+  border-color: color-mix(in srgb, var(--b-500) 45%, var(--border-subtle));
+  background: color-mix(in srgb, var(--b-500) 8%, var(--surface));
 }
 
 .pc-chat-card__empty-icon {
@@ -2656,8 +2689,8 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
   width: 40px;
   height: 40px;
   border-radius: var(--r-full);
-  background: var(--surface-sunken);
-  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--b-500) 14%, transparent);
+  color: var(--b-600);
   flex-shrink: 0;
 }
 

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -2657,17 +2657,6 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
   color: var(--text-primary);
 }
 
-.pc-chat-card__new-hint {
-  margin-left: auto;
-  font-family: var(--font-mono);
-  font-size: var(--text-2xs);
-  color: var(--text-tertiary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-}
-
 .pc-chat-card--empty {
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
## Summary
- 점선·투명 배경으로 placeholder처럼 읽히던 \`pc-chat-card--new\` / \`pc-chat-card--empty\`를 brand-tinted action card로 재구성 (solid 1px border, color-mix \`--b-500\` 기반 surface, hover/focus 딥 워시 + focus ring)
- 새 채팅 row에 brand-tinted icon chip + 우측 agent · model 힌트 추가 (정보 밀도 ↑, 빈 슬롯 인상 제거)
- empty 카드 아이콘도 같은 brand wash로 통일, 카피를 자연스러운 한국어로 정돈 ("첫 채팅 시작" + agent 라인)
- Context 탭의 하드코딩 \`6\` count 제거 (실데이터 없으니 stub 렌더 대신 미표시)
- 활성 탭 \`.proj-tab__count\`에 brand tint + \`tabular-nums\`로 숫자열 정렬
- \`createChat\` 기본 제목 \`Chat \${N}\` → \`새 채팅\` (첫 메시지가 어차피 덮어쓰는 placeholder)
- 채팅 사이드의 "Attached context" 카드(샘플 파일 2개 하드코딩) 삭제, 실데이터 \"Project conversation map\" stats만 유지

## 검증
- \`tsc --noEmit\`: clean
- \`projectListSurface.test.ts\` + \`chatRedesignFidelity.test.ts\`: 29/29
- \`git diff --check\`: clean

## dev proxy URL
https://lawdigest.cloud/proxy/2235/

## worktree
\`/home/ubuntu/project/ARIS-tab-count-cta\`

## 배포 여부
production 배포 안 함 (dev proxy 확인 후 명시적 지시 시 진행)