### PR TITLE
perf(deploy): scope web fingerprint to aris-web; tighten healthcheck

### DIFF
--- a/deploy/internal/web_zero_downtime.sh
+++ b/deploy/internal/web_zero_downtime.sh
@@ -174,13 +174,25 @@ wait_for_http_ready() {
 }
 
 compute_context_fingerprint() {
-  if git rev-parse HEAD >/dev/null 2>&1; then
-    git rev-parse HEAD
-    return
+  # Hash only the web service tree so changes to backend, docs, deploy scripts,
+  # or other services don't force a full web rebuild.
+  local service_rel="services/aris-web"
+  local service_abs="${ROOT_DIR}/${service_rel}"
+
+  if git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    local file_count
+    file_count="$(git -C "$ROOT_DIR" ls-files -- "$service_rel" 2>/dev/null | wc -l)"
+    if [[ "$file_count" -gt 0 ]]; then
+      ( cd "$ROOT_DIR" \
+        && git ls-files -z -- "$service_rel" \
+        | xargs -0 sha256sum \
+        | sha256sum \
+        | awk '{print $1}' )
+      return
+    fi
   fi
 
-  local service_dir="${ROOT_DIR}/services/aris-web"
-  find "$service_dir" -type f \
+  find "$service_abs" -type f \
     ! -path '*/node_modules/*' \
     ! -path '*/.next/*' \
     ! -name '.env' \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,9 +55,10 @@ x-aris-web-common: &aris_web_common
         "CMD-SHELL",
         "node -e \"fetch('http://127.0.0.1:3000/login',{redirect:'manual'}).then(r=>process.exit(r.status>=200&&r.status<400?0:1)).catch(()=>process.exit(1))\"",
       ]
-    interval: 15s
+    interval: 3s
     timeout: 5s
     retries: 20
+    start_period: 30s
   networks:
     - aris_net
 


### PR DESCRIPTION
## 변경 요약

배포 효율화 1차 — 안전한 두 가지 변경:

1. **Web fingerprint scope를 `services/aris-web`로 한정** (`deploy/internal/web_zero_downtime.sh`)
   - 기존: `git rev-parse HEAD` → 무관한 PR(backend/docs/deploy 스크립트)도 web 풀 빌드 트리거
   - 변경: `git ls-files -- services/aris-web | xargs sha256sum | sha256sum`
   - 효과: backend-only / docs-only PR에서 web 빌드 4–7분 → 0초
   - 검증: 비-web 변경 → 동일 fingerprint, web 변경 → 변경 fingerprint

2. **Web healthcheck interval 15s → 3s, `start_period: 30s` 추가** (`docker-compose.yml`)
   - cold-start 실패가 retries에 카운트되지 않도록 grace 30s 추가
   - retries 20 유지(총 윈도우 90s + grace 30s = 120s)
   - 효과: cutover 대기 −8~12초/배포

## 의도적으로 제외한 항목

- **Next.js standalone output**: `server.mjs`가 커스텀 서버(`next` + `ws` + `jose` + `node-pty` + Prisma)라 NFT 추적이 native module/dynamic require를 누락할 위험. 별도 PR에서 빌드+런타임 검증 사이클을 거쳐 적용. 이슈로 트래킹 예정.

## 기대 효과 (추정)

| 시나리오 | Before | After | 단축 |
|---|---|---|---|
| backend-only PR | 5–9분 | 1–2분 | ~80% |
| docs/deploy-only PR | 4–7분 | 0초 | ~100% |
| web-only PR (cache hit) | 4–5분 | 3.5–4.5분 | ~10–15% |

## 검증

- `bash -n deploy/internal/web_zero_downtime.sh` → OK
- `docker compose --env-file ... config` → 새 healthcheck 블록 정상 (3개 web service 모두 적용)
- fingerprint 함수 단위 테스트:
  - 비-web 파일 변경 시 fingerprint 동일 (PASS)
  - web 파일 변경 시 fingerprint 변경 (PASS)
  - 다른 cwd에서도 동일 fingerprint 산출 (worktree-safe)
- main 브랜치(443449e) 기반, 의존성·코드 변경 없음

## 후속 작업

- [ ] Next.js standalone 마이그레이션 (별도 이슈로 트래킹)
- [ ] GHA `deploy-on-main.yml`에 paths-filter 적용 (CI 단에서도 변경된 서비스만 배포)
- [ ] `WEB_PRUNE_CACHE_UNTIL=24h` 또는 inline cache (build cache 8.5GB 회전)
- [ ] `deploy_zero_downtime.sh`에 schema-change-detect → 없으면 backend/web 병렬
- [ ] dev proxy 우선 정책 강화 (UI/카피 변경의 production 배포 자체 회피)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
