### PR TITLE
refactor(runtime-core): 2.5c - extract PermissionRouter

### DIFF
--- a/services/aris-backend/src/runtime/contracts/runtimeCoordinationStore.ts
+++ b/services/aris-backend/src/runtime/contracts/runtimeCoordinationStore.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared types for permission/coordination delegation between the runtime
+ * core and the storage layer (PrismaRuntimeStore in production, mock in tests).
+ *
+ * These types were inlined inside `runtime/happyClient.ts` until 2.5c. Moving
+ * them here lets `runtime/orchestration/permissionRouter.ts` consume the
+ * coordination-store contract without circular imports through happyClient.
+ */
+
+import type {
+  PermissionDecision,
+  PermissionRequest,
+  PermissionState,
+  PermissionRisk,
+  SessionAction,
+} from '../../types.js';
+
+/**
+ * Input shape accepted by `RuntimeCoordinationStore.createPermission`.
+ *
+ * Mirrors what the runtime needs to record before awaiting a decision:
+ * session/chat scope, agent attribution, command + reason text, and risk.
+ */
+export type HappyRuntimePermissionInput = {
+  sessionId: string;
+  /**
+   * `null` accepted alongside `undefined` to mirror the original inline
+   * surface in happyClient.ts (callers occasionally pass nullable chat ids
+   * from optional-property reads).
+   */
+  chatId?: string | null;
+  agent: PermissionRequest['agent'];
+  command: string;
+  reason: string;
+  risk: PermissionRisk;
+};
+
+/**
+ * Storage-layer surface required by the runtime core for permission and
+ * coordination operations. PrismaRuntimeStore implements this; mock backends
+ * may pass `null` to keep everything in-memory.
+ */
+export type RuntimeCoordinationStore = {
+  listPermissions(state?: PermissionState): Promise<PermissionRequest[]>;
+  createPermission(input: HappyRuntimePermissionInput): Promise<PermissionRequest>;
+  decidePermission(permissionId: string, decision: PermissionDecision): Promise<PermissionRequest>;
+  getPermissionById(permissionId: string): Promise<PermissionRequest | null>;
+  hasRequestedAction(input: {
+    sessionId: string;
+    action: SessionAction;
+    chatId?: string;
+    createdAfter?: Date;
+  }): Promise<boolean>;
+};

--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -38,6 +38,11 @@ import type {
   ProviderRuntimeSession,
   ProviderTextEvent,
 } from './contracts/providerRuntime.js';
+import type {
+  HappyRuntimePermissionInput,
+  RuntimeCoordinationStore,
+} from './contracts/runtimeCoordinationStore.js';
+import { PermissionRouter, buildScopedPermissionKey } from './orchestration/permissionRouter.js';
 import type { ClaudeSessionLaunchMode } from './providers/claude/claudeSessionContract.js';
 import type { ClaudeActionEvent, ClaudeLaunchCommand, ClaudeResumeTarget, ClaudeTextEvent } from './providers/claude/types.js';
 import type {
@@ -169,28 +174,6 @@ type HappyRuntimeAppendInput = {
   title?: string;
   text: string;
   meta?: Record<string, unknown>;
-};
-
-type HappyRuntimePermissionInput = {
-  sessionId: string;
-  chatId?: string | null;
-  agent: PermissionRequest['agent'];
-  command: string;
-  reason: string;
-  risk: PermissionRisk;
-};
-
-type RuntimeCoordinationStore = {
-  listPermissions(state?: PermissionState): Promise<PermissionRequest[]>;
-  createPermission(input: HappyRuntimePermissionInput): Promise<PermissionRequest>;
-  decidePermission(permissionId: string, decision: PermissionDecision): Promise<PermissionRequest>;
-  getPermissionById(permissionId: string): Promise<PermissionRequest | null>;
-  hasRequestedAction(input: {
-    sessionId: string;
-    action: SessionAction;
-    chatId?: string;
-    createdAfter?: Date;
-  }): Promise<boolean>;
 };
 
 type SessionRealtimeEventRecord = {
@@ -1354,13 +1337,6 @@ function buildCodexPermissionKey(sessionId: string, request: CodexPermissionRequ
   return `${sessionId}:${request.approvalId || request.callId}`;
 }
 
-function buildScopedPermissionKey(baseKey: string, chatId?: string): string {
-  const normalizedChatId = typeof chatId === 'string' && chatId.trim().length > 0
-    ? chatId.trim()
-    : '__default__';
-  return `${normalizedChatId}:${baseKey}`;
-}
-
 function resolveClaudeLaunchMode(input: {
   sessionPath?: string;
   workspaceRoot: string;
@@ -1913,28 +1889,21 @@ export const happyClientTestHooks = {
     store: HappyRuntimeStore,
     permissionIds: Iterable<string>,
     options?: { preservePending?: boolean },
-  ) => (store as any).finalizeCodexRuntimePermissions(permissionIds, options),
+  ) => (store as unknown as { permissionRouter: PermissionRouter }).permissionRouter
+    .finalizeCodexPermissions(permissionIds, options),
 };
 
 export class HappyRuntimeStore {
-  private readonly permissions = new Map<string, PermissionRequest>();
   private readonly activeRuns = new Map<string, ActiveRun>();
   private readonly claudeSessionRegistry = new ClaudeSessionRegistry();
   private readonly geminiSessionRegistry = new GeminiSessionRegistry();
   private readonly claudeSessionScanners = new Map<string, ClaudeSessionLogTracker>();
   private readonly codexThreads = new Map<string, string>();
-  private readonly codexPermissionIndex = new Map<string, string>();
-  private readonly codexPermissionResponders = new Map<string, (decision: PermissionDecision) => Promise<void>>();
-  private readonly providerPermissionIndex = new Map<string, string>();
-  private readonly providerPermissionWaiters = new Map<string, {
-    resolve: (decision: PermissionDecision) => void;
-    reject: (error: Error) => void;
-  }>();
-  private readonly providerPermissionDecisions = new Map<string, PermissionDecision>();
   private readonly sessionRealtimeEvents = new Map<string, SessionRealtimeEventRecord[]>();
   private readonly sessionRealtimeCursor = new Map<string, number>();
   private readonly geminiPartialTextStates = new Map<string, GeminiPartialTextState>();
   private readonly coordinationStore: RuntimeCoordinationStore | null;
+  private readonly permissionRouter: PermissionRouter;
 
   private readonly serverUrl: string;
   private readonly serverToken: string;
@@ -1960,6 +1929,16 @@ export class HappyRuntimeStore {
     this.hostProjectsRoot = (opts.hostProjectsRoot || '').replace(/\/+$/, '');
     this.coordinationStore = opts.coordinationStore ?? null;
     this.happyEventLogger = new HappyEventLogger(HAPPY_EVENT_LOG_DIR, HAPPY_EVENT_LOG_MAX_BYTES);
+    this.permissionRouter = new PermissionRouter({
+      coordinationStore: this.coordinationStore,
+      getSession: (sessionId) => this.getSession(sessionId),
+      resolveApprovalPolicy: (session) => this.resolveSessionApprovalPolicy(session),
+      abortSessionRuns: (sessionId, chatId) => this.abortSessionRuns(sessionId, chatId),
+      appendAgentMessage: (sessionId, text, meta, options) =>
+        this.appendAgentMessage(sessionId, text, meta, options),
+      appendRunLifecycleEvent: (sessionId, state, meta) =>
+        this.appendRunLifecycleEvent(sessionId, state, meta),
+    });
   }
 
   beginShutdownDrain(): void {
@@ -1978,38 +1957,6 @@ export class HappyRuntimeStore {
 
   private getActiveRunCount(): number {
     return this.activeRuns.size + this.claudeSessionRegistry.activeRunCount();
-  }
-
-  private async finalizeCodexRuntimePermissions(
-    permissionIds: Iterable<string>,
-    options: { preservePending?: boolean } = {},
-  ): Promise<void> {
-    for (const permissionId of permissionIds) {
-      this.codexPermissionResponders.delete(permissionId);
-
-      for (const [key, mappedPermissionId] of this.codexPermissionIndex.entries()) {
-        if (mappedPermissionId === permissionId) {
-          this.codexPermissionIndex.delete(key);
-        }
-      }
-
-      const existing = this.permissions.get(permissionId);
-      if (!existing || existing.state !== 'pending' || options.preservePending) {
-        continue;
-      }
-
-      if (this.coordinationStore) {
-        try {
-          const denied = await this.coordinationStore.decidePermission(permissionId, 'deny');
-          this.permissions.set(permissionId, denied);
-          continue;
-        } catch {
-          // Fall through to the in-memory copy when the persisted store is unavailable.
-        }
-      }
-
-      this.permissions.set(permissionId, { ...existing, state: 'denied', decision: 'deny' });
-    }
   }
 
   private resolveSessionApprovalPolicy(session: RuntimeSession): ApprovalPolicy {
@@ -2162,101 +2109,6 @@ export class HappyRuntimeStore {
     }
   }
 
-  private async waitForPersistedPermissionDecision(
-    permissionId: string,
-    signal?: AbortSignal,
-  ): Promise<PermissionDecision> {
-    if (!this.coordinationStore) {
-      throw new Error('PERSISTED_PERMISSION_COORDINATION_UNAVAILABLE');
-    }
-
-    while (true) {
-      if (signal?.aborted) {
-        throw new Error('The operation was aborted');
-      }
-
-      const persisted = await this.coordinationStore.getPermissionById(permissionId);
-      if (!persisted) {
-        throw new Error('PERMISSION_NOT_FOUND');
-      }
-      this.permissions.set(permissionId, persisted);
-      if (persisted.state === 'denied') {
-        return 'deny';
-      }
-      if (persisted.state === 'approved') {
-        return persisted.decision === 'allow_session' ? 'allow_session' : 'allow_once';
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 400));
-    }
-  }
-
-  private async awaitProviderPermissionDecision(
-    permissionId: string,
-    signal?: AbortSignal,
-  ): Promise<PermissionDecision> {
-    if (this.coordinationStore) {
-      return this.waitForPersistedPermissionDecision(permissionId, signal);
-    }
-
-    const knownDecision = this.providerPermissionDecisions.get(permissionId);
-    if (knownDecision) {
-      return knownDecision;
-    }
-
-    const existing = this.permissions.get(permissionId);
-    if (existing && existing.state !== 'pending') {
-      return existing.state === 'denied' ? 'deny' : 'allow_once';
-    }
-
-    return new Promise<PermissionDecision>((resolve, reject) => {
-      const handleAbort = () => {
-        this.providerPermissionWaiters.delete(permissionId);
-        reject(new Error('The operation was aborted'));
-      };
-
-      if (signal?.aborted) {
-        handleAbort();
-        return;
-      }
-
-      const cleanup = () => {
-        signal?.removeEventListener('abort', handleAbort);
-      };
-
-      this.providerPermissionWaiters.set(permissionId, {
-        resolve: (decision) => {
-          cleanup();
-          resolve(decision);
-        },
-        reject: (error) => {
-          cleanup();
-          reject(error);
-        },
-      });
-      signal?.addEventListener('abort', handleAbort, { once: true });
-    });
-  }
-
-  private watchExternalPermissionDecision(input: {
-    permissionId: string;
-    responder: (decision: PermissionDecision) => Promise<void>;
-    signal?: AbortSignal;
-  }): void {
-    if (!this.coordinationStore) {
-      return;
-    }
-
-    void this.waitForPersistedPermissionDecision(input.permissionId, input.signal)
-      .then((decision) => input.responder(decision))
-      .catch((error) => {
-        const message = error instanceof Error ? error.message : String(error);
-        if (!message.includes('aborted')) {
-          console.error(`failed to resolve persisted permission decision: ${message}`);
-        }
-      });
-  }
-
   private monitorExternalAbortSignal(input: {
     sessionId: string;
     chatId?: string;
@@ -2300,48 +2152,6 @@ export class HappyRuntimeStore {
     return () => {
       disposed = true;
     };
-  }
-
-  private async handleProviderPermissionRequest(input: {
-    session: RuntimeSession;
-    chatId?: string;
-    agent: PermissionRequest['agent'];
-    request: ProviderPermissionRequest;
-    signal?: AbortSignal;
-  }): Promise<PermissionDecision> {
-    const permissionKey = buildScopedPermissionKey(
-      `${input.session.id}:provider:${input.request.approvalId || input.request.callId}`,
-      input.chatId,
-    );
-    const knownPermissionId = this.providerPermissionIndex.get(permissionKey);
-    if (knownPermissionId) {
-      const knownPermission = this.permissions.get(knownPermissionId);
-      if (knownPermission?.state === 'pending') {
-        return this.awaitProviderPermissionDecision(knownPermissionId, input.signal);
-      }
-      if (knownPermission) {
-        return knownPermission.state === 'denied' ? 'deny' : 'allow_once';
-      }
-      this.providerPermissionIndex.delete(permissionKey);
-    }
-
-    const created = await this.createPermission({
-      sessionId: input.session.id,
-      ...(input.chatId ? { chatId: input.chatId } : {}),
-      agent: input.agent,
-      command: input.request.command,
-      reason: input.request.reason,
-      risk: input.request.risk,
-    });
-    this.providerPermissionIndex.set(permissionKey, created.id);
-
-    const approvalPolicy = this.resolveSessionApprovalPolicy(input.session);
-    if (approvalPolicy === 'yolo') {
-      await this.decidePermission(created.id, 'allow_session');
-      return 'allow_session';
-    }
-
-    return this.awaitProviderPermissionDecision(created.id, input.signal);
   }
 
   private getClaudeSessionScanner(workingDirectory: string): ClaudeSessionLogTracker {
@@ -3514,18 +3324,18 @@ export class HappyRuntimeStore {
       risk: PermissionRisk,
       responder: (decision: PermissionDecision) => Promise<void>,
     ) => {
-      const knownPermissionId = this.codexPermissionIndex.get(key);
+      const knownPermissionId = this.permissionRouter.lookupCodexBinding(key);
       if (knownPermissionId) {
-        const knownPermission = this.permissions.get(knownPermissionId);
+        const knownPermission = this.permissionRouter.getCachedPermission(knownPermissionId);
         if (knownPermission?.state === 'pending') {
           if (this.coordinationStore) {
-            this.watchExternalPermissionDecision({
+            this.permissionRouter.watchExternal({
               permissionId: knownPermissionId,
               responder,
               signal,
             });
           } else {
-            this.codexPermissionResponders.set(knownPermissionId, responder);
+            this.permissionRouter.registerCodexResponder(knownPermissionId, responder);
           }
           runtimePermissionIds.add(knownPermissionId);
           if (autoApproveAll) {
@@ -3533,7 +3343,7 @@ export class HappyRuntimeStore {
           }
           return;
         }
-        this.codexPermissionIndex.delete(key);
+        this.permissionRouter.clearCodexBinding(key);
       }
 
       const created = await this.createPermission({
@@ -3545,15 +3355,15 @@ export class HappyRuntimeStore {
         risk,
       });
 
-      this.codexPermissionIndex.set(key, created.id);
+      this.permissionRouter.registerCodexBinding(key, created.id);
       if (this.coordinationStore) {
-        this.watchExternalPermissionDecision({
+        this.permissionRouter.watchExternal({
           permissionId: created.id,
           responder,
           signal,
         });
       } else {
-        this.codexPermissionResponders.set(created.id, responder);
+        this.permissionRouter.registerCodexResponder(created.id, responder);
       }
       runtimePermissionIds.add(created.id);
       if (autoApproveAll) {
@@ -4133,7 +3943,7 @@ export class HappyRuntimeStore {
       await permissionChain.catch(() => undefined);
       await appendChain.catch(() => undefined);
 
-      await this.finalizeCodexRuntimePermissions(runtimePermissionIds, {
+      await this.permissionRouter.finalizeCodexPermissions(runtimePermissionIds, {
         preservePending: this.draining && !signal?.aborted,
       });
 
@@ -4284,16 +4094,16 @@ export class HappyRuntimeStore {
       permissionChain = permissionChain
         .then(async () => {
           const key = buildScopedPermissionKey(buildCodexPermissionKey(session.id, request), chatId);
-          const knownPermissionId = this.codexPermissionIndex.get(key);
+          const knownPermissionId = this.permissionRouter.lookupCodexBinding(key);
           if (knownPermissionId) {
-            const knownPermission = this.permissions.get(knownPermissionId);
+            const knownPermission = this.permissionRouter.getCachedPermission(knownPermissionId);
             if (knownPermission?.state === 'pending') {
               if (autoApproveAll) {
                 await this.decidePermission(knownPermissionId, 'allow_session');
               }
               return;
             }
-            this.codexPermissionIndex.delete(key);
+            this.permissionRouter.clearCodexBinding(key);
           }
 
           const created = await this.createPermission({
@@ -4305,7 +4115,7 @@ export class HappyRuntimeStore {
             risk: request.risk,
           });
 
-          this.codexPermissionIndex.set(key, created.id);
+          this.permissionRouter.registerCodexBinding(key, created.id);
           if (autoApproveAll) {
             await this.decidePermission(created.id, 'allow_session');
           }
@@ -4942,7 +4752,7 @@ export class HappyRuntimeStore {
                 envelopes: event.envelopes,
               });
             },
-            onPermission: async (request) => this.handleProviderPermissionRequest({
+            onPermission: async (request) => this.permissionRouter.handleProviderPermissionRequest({
               session,
               chatId: scopedChatId,
               agent: 'claude',
@@ -5069,7 +4879,7 @@ export class HappyRuntimeStore {
               });
               await geminiMessageQueue?.flush();
             },
-            onPermission: async (request) => this.handleProviderPermissionRequest({
+            onPermission: async (request) => this.permissionRouter.handleProviderPermissionRequest({
               session,
               chatId: scopedChatId,
               agent: 'gemini',
@@ -5789,133 +5599,14 @@ export class HappyRuntimeStore {
   }
 
   async listPermissions(state?: PermissionState): Promise<PermissionRequest[]> {
-    if (this.coordinationStore) {
-      const persisted = await this.coordinationStore.listPermissions(state);
-      for (const permission of persisted) {
-        this.permissions.set(permission.id, permission);
-      }
-      return persisted;
-    }
-    const list = [...this.permissions.values()].sort((a, b) => b.requestedAt.localeCompare(a.requestedAt));
-    return state ? list.filter((permission) => permission.state === state) : list;
+    return this.permissionRouter.listPermissions(state);
   }
 
   async createPermission(input: HappyRuntimePermissionInput): Promise<PermissionRequest> {
-    const session = await this.getSession(input.sessionId);
-    if (!session) {
-      throw new Error('SESSION_NOT_FOUND');
-    }
-
-    const permission = this.coordinationStore
-      ? await this.coordinationStore.createPermission(input)
-      : {
-          id: randomUUID(),
-          sessionId: input.sessionId,
-          ...(typeof input.chatId === 'string' && input.chatId.trim().length > 0
-            ? { chatId: input.chatId.trim() }
-            : {}),
-          agent: input.agent,
-          command: input.command,
-          reason: input.reason,
-          risk: input.risk,
-          requestedAt: new Date().toISOString(),
-          state: 'pending' as const,
-        };
-
-    this.permissions.set(permission.id, permission);
-    await this.persistPermissionEvent(permission, 'permission_request');
-    await this.appendRunLifecycleEvent(input.sessionId, 'waiting_for_approval', {
-      ...(permission.chatId ? { chatId: permission.chatId } : {}),
-      requestedPath: session.metadata.path,
-      agent: input.agent,
-      command: input.command,
-      reason: input.reason,
-    });
-    return permission;
+    return this.permissionRouter.createPermission(input);
   }
 
   async decidePermission(permissionId: string, decision: PermissionDecision): Promise<PermissionRequest> {
-    const knownPermission = this.permissions.get(permissionId);
-    const permission = knownPermission
-      ?? await this.coordinationStore?.getPermissionById(permissionId)
-      ?? null;
-    if (!permission) {
-      throw new Error('PERMISSION_NOT_FOUND');
-    }
-
-    const updated = this.coordinationStore
-      ? await this.coordinationStore.decidePermission(permissionId, decision)
-      : {
-          ...permission,
-          state: (decision === 'deny' ? 'denied' : 'approved') as PermissionState,
-          decision,
-        };
-    this.permissions.set(permissionId, updated);
-    await this.persistPermissionEvent(updated, 'permission_decision', decision);
-
-    for (const [key, mappedPermissionId] of this.codexPermissionIndex.entries()) {
-      if (mappedPermissionId === permissionId) {
-        this.codexPermissionIndex.delete(key);
-      }
-    }
-    for (const [key, mappedPermissionId] of this.providerPermissionIndex.entries()) {
-      if (mappedPermissionId === permissionId) {
-        this.providerPermissionIndex.delete(key);
-      }
-    }
-
-    this.providerPermissionDecisions.set(permissionId, decision);
-    const providerWaiter = this.providerPermissionWaiters.get(permissionId);
-    this.providerPermissionWaiters.delete(permissionId);
-    providerWaiter?.resolve(decision);
-
-    const responder = this.codexPermissionResponders.get(permissionId);
-    this.codexPermissionResponders.delete(permissionId);
-
-    if (responder) {
-      try {
-        await responder(decision);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error(`failed to send codex permission decision: ${message}`);
-        if (decision === 'deny') {
-          this.abortSessionRuns(permission.sessionId, permission.chatId ?? undefined);
-        }
-      }
-    } else if (decision === 'deny') {
-      this.abortSessionRuns(permission.sessionId, permission.chatId ?? undefined);
-    }
-
-    return updated;
-  }
-
-  private async persistPermissionEvent(
-    permission: PermissionRequest,
-    streamEvent: 'permission_request' | 'permission_decision',
-    decision?: PermissionDecision,
-  ): Promise<void> {
-    try {
-      await this.appendAgentMessage(
-        permission.sessionId,
-        permission.command,
-        {
-          sessionId: permission.sessionId,
-          ...(permission.chatId ? { chatId: permission.chatId } : {}),
-          agent: permission.agent,
-          streamEvent,
-          permissionId: permission.id,
-          permissionState: permission.state,
-          command: permission.command,
-          reason: permission.reason,
-          risk: permission.risk,
-          requestedAt: permission.requestedAt,
-          ...(decision ? { permissionDecision: decision } : {}),
-        },
-        { type: 'message', title: 'Permission Request' },
-      );
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(`failed to persist permission event (${streamEvent}): ${message}`);
-    }
+    return this.permissionRouter.decidePermission(permissionId, decision);
   }
 }

--- a/services/aris-backend/src/runtime/orchestration/permissionRouter.ts
+++ b/services/aris-backend/src/runtime/orchestration/permissionRouter.ts
@@ -1,0 +1,464 @@
+/**
+ * PermissionRouter — provider-agnostic permission orchestration.
+ *
+ * Owns the runtime side of the permission protocol that was previously
+ * tangled inside `HappyRuntimeStore` in `runtime/happyClient.ts`:
+ *
+ *   - In-memory mirror of permission records (`permissions` Map).
+ *   - Provider-agnostic awaiter machinery (`providerPermissionWaiters`,
+ *     `providerPermissionDecisions`, `providerPermissionIndex`).
+ *   - Codex-specific responder dispatch (`codexPermissionIndex`,
+ *     `codexPermissionResponders`). These are scheduled to migrate to
+ *     `runtime/providers/codex/` in Phase 3 of the provider-architecture
+ *     refactor; for now the router exposes typed accessors so the codex
+ *     code in happyClient.ts can keep working without reaching into router
+ *     internals.
+ *
+ * Storage delegation is performed through the optional
+ * `RuntimeCoordinationStore` (PrismaRuntimeStore in production). When the
+ * coordination store is null the router operates fully in-memory, which is
+ * the path used by mock backends in unit tests.
+ *
+ * The router does NOT own:
+ *   - `appendAgentMessage` / `appendRunLifecycleEvent` (callbacks injected
+ *     by the host so the router doesn't need to know about message
+ *     persistence or lifecycle wiring).
+ *   - `getSession` / `resolveApprovalPolicy` / `abortSessionRuns` (host
+ *     callbacks that touch shared session state owned by the runtime core).
+ */
+
+import type {
+  PermissionDecision,
+  PermissionRequest,
+  PermissionState,
+  ApprovalPolicy,
+  RuntimeSession,
+} from '../../types.js';
+import { randomUUID } from 'node:crypto';
+import type { ProviderPermissionRequest } from '../contracts/providerRuntime.js';
+import type {
+  HappyRuntimePermissionInput,
+  RuntimeCoordinationStore,
+} from '../contracts/runtimeCoordinationStore.js';
+
+/**
+ * Build a permission key scoped to a chat slot. Verbatim port of the helper
+ * that lived in happyClient.ts (`${chatId}:${baseKey}` format) so existing
+ * collision behavior is preserved byte-for-byte.
+ */
+export function buildScopedPermissionKey(baseKey: string, chatId?: string): string {
+  const normalizedChatId = typeof chatId === 'string' && chatId.trim().length > 0
+    ? chatId.trim()
+    : '__default__';
+  return `${normalizedChatId}:${baseKey}`;
+}
+
+/**
+ * Host-side callbacks the router needs to interact with surrounding runtime
+ * state without reaching into its owner.
+ */
+export interface PermissionRouterDeps {
+  coordinationStore: RuntimeCoordinationStore | null;
+  /** Resolves an ARIS session by id; null when session does not exist. */
+  getSession(sessionId: string): Promise<RuntimeSession | null>;
+  /** Resolves the approval policy in effect for a session at decision time. */
+  resolveApprovalPolicy(session: RuntimeSession): ApprovalPolicy;
+  /** Aborts in-flight runs scoped to a session (and optionally a chat). */
+  abortSessionRuns(sessionId: string, chatId?: string): void;
+  /** Persists a permission event as a message stream entry (best-effort). */
+  appendAgentMessage(
+    sessionId: string,
+    text: string,
+    meta: Record<string, unknown>,
+    options: { type?: string; title?: string },
+  ): Promise<void>;
+  /** Records a lifecycle event for the run (waiting_for_approval, etc). */
+  appendRunLifecycleEvent(
+    sessionId: string,
+    state: 'waiting_for_approval',
+    meta: Record<string, unknown>,
+  ): Promise<void>;
+}
+
+interface ProviderPermissionWaiter {
+  resolve: (decision: PermissionDecision) => void;
+  reject: (error: Error) => void;
+}
+
+export class PermissionRouter {
+  /** Local mirror of every permission record observed in the current process. */
+  private readonly permissions = new Map<string, PermissionRequest>();
+
+  /** Codex permission key (sessionId+callId scope) -> permission id. */
+  private readonly codexPermissionIndex = new Map<string, string>();
+
+  /** Codex permission id -> responder callback that ships decision to codex CLI. */
+  private readonly codexPermissionResponders = new Map<
+    string,
+    (decision: PermissionDecision) => Promise<void>
+  >();
+
+  /** Provider-agnostic key -> permission id. */
+  private readonly providerPermissionIndex = new Map<string, string>();
+
+  /** Pending awaiters keyed by permission id; resolved on decidePermission. */
+  private readonly providerPermissionWaiters = new Map<string, ProviderPermissionWaiter>();
+
+  /** Cached decisions to short-circuit late awaiters. */
+  private readonly providerPermissionDecisions = new Map<string, PermissionDecision>();
+
+  constructor(private readonly deps: PermissionRouterDeps) {}
+
+  // ---------------------------------------------------------------------
+  // Storage delegation surface (mirrors RuntimeCoordinationStore)
+  // ---------------------------------------------------------------------
+
+  async listPermissions(state?: PermissionState): Promise<PermissionRequest[]> {
+    if (this.deps.coordinationStore) {
+      const persisted = await this.deps.coordinationStore.listPermissions(state);
+      for (const permission of persisted) {
+        this.permissions.set(permission.id, permission);
+      }
+      return persisted;
+    }
+    const list = [...this.permissions.values()].sort((a, b) =>
+      b.requestedAt.localeCompare(a.requestedAt),
+    );
+    return state ? list.filter((permission) => permission.state === state) : list;
+  }
+
+  async createPermission(input: HappyRuntimePermissionInput): Promise<PermissionRequest> {
+    const session = await this.deps.getSession(input.sessionId);
+    if (!session) {
+      throw new Error('SESSION_NOT_FOUND');
+    }
+
+    const permission = this.deps.coordinationStore
+      ? await this.deps.coordinationStore.createPermission(input)
+      : ({
+        id: randomUUID(),
+        sessionId: input.sessionId,
+        ...(typeof input.chatId === 'string' && input.chatId.trim().length > 0
+          ? { chatId: input.chatId.trim() }
+          : {}),
+        agent: input.agent,
+        command: input.command,
+        reason: input.reason,
+        risk: input.risk,
+        requestedAt: new Date().toISOString(),
+        state: 'pending' as const,
+      });
+
+    this.permissions.set(permission.id, permission);
+    await this.persistPermissionEvent(permission, 'permission_request');
+    await this.deps.appendRunLifecycleEvent(input.sessionId, 'waiting_for_approval', {
+      ...(permission.chatId ? { chatId: permission.chatId } : {}),
+      requestedPath: session.metadata.path,
+      agent: input.agent,
+      command: input.command,
+      reason: input.reason,
+    });
+    return permission;
+  }
+
+  async decidePermission(
+    permissionId: string,
+    decision: PermissionDecision,
+  ): Promise<PermissionRequest> {
+    const knownPermission = this.permissions.get(permissionId);
+    const permission = knownPermission
+      ?? (await this.deps.coordinationStore?.getPermissionById(permissionId))
+      ?? null;
+    if (!permission) {
+      throw new Error('PERMISSION_NOT_FOUND');
+    }
+
+    const updated = this.deps.coordinationStore
+      ? await this.deps.coordinationStore.decidePermission(permissionId, decision)
+      : ({
+        ...permission,
+        state: (decision === 'deny' ? 'denied' : 'approved') as PermissionState,
+        decision,
+      });
+    this.permissions.set(permissionId, updated);
+    await this.persistPermissionEvent(updated, 'permission_decision', decision);
+
+    for (const [key, mappedPermissionId] of this.codexPermissionIndex.entries()) {
+      if (mappedPermissionId === permissionId) {
+        this.codexPermissionIndex.delete(key);
+      }
+    }
+    for (const [key, mappedPermissionId] of this.providerPermissionIndex.entries()) {
+      if (mappedPermissionId === permissionId) {
+        this.providerPermissionIndex.delete(key);
+      }
+    }
+
+    this.providerPermissionDecisions.set(permissionId, decision);
+    const providerWaiter = this.providerPermissionWaiters.get(permissionId);
+    this.providerPermissionWaiters.delete(permissionId);
+    providerWaiter?.resolve(decision);
+
+    const responder = this.codexPermissionResponders.get(permissionId);
+    this.codexPermissionResponders.delete(permissionId);
+
+    if (responder) {
+      try {
+        await responder(decision);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`failed to send codex permission decision: ${message}`);
+        if (decision === 'deny') {
+          this.deps.abortSessionRuns(permission.sessionId, permission.chatId ?? undefined);
+        }
+      }
+    } else if (decision === 'deny') {
+      this.deps.abortSessionRuns(permission.sessionId, permission.chatId ?? undefined);
+    }
+
+    return updated;
+  }
+
+  // ---------------------------------------------------------------------
+  // Cache accessors
+  // ---------------------------------------------------------------------
+
+  getCachedPermission(permissionId: string): PermissionRequest | undefined {
+    return this.permissions.get(permissionId);
+  }
+
+  // ---------------------------------------------------------------------
+  // Awaiter machinery
+  // ---------------------------------------------------------------------
+
+  async awaitDecision(
+    permissionId: string,
+    signal?: AbortSignal,
+  ): Promise<PermissionDecision> {
+    if (this.deps.coordinationStore) {
+      return this.waitForPersistedDecision(permissionId, signal);
+    }
+
+    const knownDecision = this.providerPermissionDecisions.get(permissionId);
+    if (knownDecision) {
+      return knownDecision;
+    }
+
+    const existing = this.permissions.get(permissionId);
+    if (existing && existing.state !== 'pending') {
+      return existing.state === 'denied' ? 'deny' : 'allow_once';
+    }
+
+    return new Promise<PermissionDecision>((resolve, reject) => {
+      const handleAbort = () => {
+        this.providerPermissionWaiters.delete(permissionId);
+        reject(new Error('The operation was aborted'));
+      };
+
+      if (signal?.aborted) {
+        handleAbort();
+        return;
+      }
+
+      const cleanup = () => {
+        signal?.removeEventListener('abort', handleAbort);
+      };
+
+      this.providerPermissionWaiters.set(permissionId, {
+        resolve: (decision) => {
+          cleanup();
+          resolve(decision);
+        },
+        reject: (error) => {
+          cleanup();
+          reject(error);
+        },
+      });
+      signal?.addEventListener('abort', handleAbort, { once: true });
+    });
+  }
+
+  watchExternal(input: {
+    permissionId: string;
+    responder: (decision: PermissionDecision) => Promise<void>;
+    signal?: AbortSignal;
+  }): void {
+    if (!this.deps.coordinationStore) {
+      return;
+    }
+
+    void this.waitForPersistedDecision(input.permissionId, input.signal)
+      .then((decision) => input.responder(decision))
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!message.includes('aborted')) {
+          console.error(`failed to resolve persisted permission decision: ${message}`);
+        }
+      });
+  }
+
+  // ---------------------------------------------------------------------
+  // Provider-side request entry (used by claude/gemini event bridges)
+  // ---------------------------------------------------------------------
+
+  async handleProviderPermissionRequest(input: {
+    session: RuntimeSession;
+    chatId?: string;
+    agent: PermissionRequest['agent'];
+    request: ProviderPermissionRequest;
+    signal?: AbortSignal;
+  }): Promise<PermissionDecision> {
+    const permissionKey = buildScopedPermissionKey(
+      `${input.session.id}:provider:${input.request.approvalId || input.request.callId}`,
+      input.chatId,
+    );
+    const knownPermissionId = this.providerPermissionIndex.get(permissionKey);
+    if (knownPermissionId) {
+      const knownPermission = this.permissions.get(knownPermissionId);
+      if (knownPermission?.state === 'pending') {
+        return this.awaitDecision(knownPermissionId, input.signal);
+      }
+      if (knownPermission) {
+        return knownPermission.state === 'denied' ? 'deny' : 'allow_once';
+      }
+      this.providerPermissionIndex.delete(permissionKey);
+    }
+
+    const created = await this.createPermission({
+      sessionId: input.session.id,
+      ...(input.chatId ? { chatId: input.chatId } : {}),
+      agent: input.agent,
+      command: input.request.command,
+      reason: input.request.reason,
+      risk: input.request.risk,
+    });
+    this.providerPermissionIndex.set(permissionKey, created.id);
+
+    const approvalPolicy = this.deps.resolveApprovalPolicy(input.session);
+    if (approvalPolicy === 'yolo') {
+      await this.decidePermission(created.id, 'allow_session');
+      return 'allow_session';
+    }
+
+    return this.awaitDecision(created.id, input.signal);
+  }
+
+  // ---------------------------------------------------------------------
+  // Codex-specific bindings (scheduled to migrate to runtime/providers/codex
+  // in Phase 3 of the provider architecture refactor)
+  // ---------------------------------------------------------------------
+
+  registerCodexBinding(key: string, permissionId: string): void {
+    this.codexPermissionIndex.set(key, permissionId);
+  }
+
+  lookupCodexBinding(key: string): string | undefined {
+    return this.codexPermissionIndex.get(key);
+  }
+
+  clearCodexBinding(key: string): void {
+    this.codexPermissionIndex.delete(key);
+  }
+
+  registerCodexResponder(
+    permissionId: string,
+    responder: (decision: PermissionDecision) => Promise<void>,
+  ): void {
+    this.codexPermissionResponders.set(permissionId, responder);
+  }
+
+  async finalizeCodexPermissions(
+    permissionIds: Iterable<string>,
+    options: { preservePending?: boolean } = {},
+  ): Promise<void> {
+    for (const permissionId of permissionIds) {
+      this.codexPermissionResponders.delete(permissionId);
+
+      for (const [key, mappedPermissionId] of this.codexPermissionIndex.entries()) {
+        if (mappedPermissionId === permissionId) {
+          this.codexPermissionIndex.delete(key);
+        }
+      }
+
+      const existing = this.permissions.get(permissionId);
+      if (!existing || existing.state !== 'pending' || options.preservePending) {
+        continue;
+      }
+
+      if (this.deps.coordinationStore) {
+        try {
+          const denied = await this.deps.coordinationStore.decidePermission(permissionId, 'deny');
+          this.permissions.set(permissionId, denied);
+          continue;
+        } catch {
+          // Fall through to the in-memory copy when the persisted store fails.
+        }
+      }
+
+      this.permissions.set(permissionId, { ...existing, state: 'denied', decision: 'deny' });
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------
+
+  private async waitForPersistedDecision(
+    permissionId: string,
+    signal?: AbortSignal,
+  ): Promise<PermissionDecision> {
+    if (!this.deps.coordinationStore) {
+      throw new Error('PERSISTED_PERMISSION_COORDINATION_UNAVAILABLE');
+    }
+
+    while (true) {
+      if (signal?.aborted) {
+        throw new Error('The operation was aborted');
+      }
+
+      const persisted = await this.deps.coordinationStore.getPermissionById(permissionId);
+      if (!persisted) {
+        throw new Error('PERMISSION_NOT_FOUND');
+      }
+      this.permissions.set(permissionId, persisted);
+      if (persisted.state === 'denied') {
+        return 'deny';
+      }
+      if (persisted.state === 'approved') {
+        return persisted.decision === 'allow_session' ? 'allow_session' : 'allow_once';
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    }
+  }
+
+  private async persistPermissionEvent(
+    permission: PermissionRequest,
+    streamEvent: 'permission_request' | 'permission_decision',
+    decision?: PermissionDecision,
+  ): Promise<void> {
+    try {
+      await this.deps.appendAgentMessage(
+        permission.sessionId,
+        permission.command,
+        {
+          sessionId: permission.sessionId,
+          ...(permission.chatId ? { chatId: permission.chatId } : {}),
+          agent: permission.agent,
+          streamEvent,
+          permissionId: permission.id,
+          permissionState: permission.state,
+          command: permission.command,
+          reason: permission.reason,
+          risk: permission.risk,
+          requestedAt: permission.requestedAt,
+          ...(decision ? { permissionDecision: decision } : {}),
+        },
+        { type: 'message', title: 'Permission Request' },
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`failed to persist permission event (${streamEvent}): ${message}`);
+    }
+  }
+}

--- a/services/aris-backend/tests/happyClient.streamJson.test.ts
+++ b/services/aris-backend/tests/happyClient.streamJson.test.ts
@@ -671,15 +671,17 @@ registry/controller를 ClaudeSession 중심으로 재편`);
       workspaceRoot: '/workspace',
       coordinationStore: coordinationStore as never,
     }) as unknown as {
-      permissions: Map<string, typeof persistedPermission>;
-      codexPermissionIndex: Map<string, string>;
-      codexPermissionResponders: Map<string, (decision: 'allow_once' | 'allow_session' | 'deny') => Promise<void>>;
+      permissionRouter: {
+        permissions: Map<string, typeof persistedPermission>;
+        codexPermissionIndex: Map<string, string>;
+        codexPermissionResponders: Map<string, (decision: 'allow_once' | 'allow_session' | 'deny') => Promise<void>>;
+      };
       draining: boolean;
     };
 
-    store.permissions.set('perm-1', persistedPermission);
-    store.codexPermissionIndex.set('chat-1:session-1:perm-1', 'perm-1');
-    store.codexPermissionResponders.set('perm-1', vi.fn());
+    store.permissionRouter.permissions.set('perm-1', persistedPermission);
+    store.permissionRouter.codexPermissionIndex.set('chat-1:session-1:perm-1', 'perm-1');
+    store.permissionRouter.codexPermissionResponders.set('perm-1', vi.fn());
     store.draining = true;
 
     await happyClientTestHooks.finalizeCodexRuntimePermissions(store as never, ['perm-1'], {
@@ -687,11 +689,11 @@ registry/controller를 ClaudeSession 중심으로 재편`);
     });
 
     expect(coordinationStore.decidePermission).not.toHaveBeenCalled();
-    expect(store.permissions.get('perm-1')).toMatchObject({
+    expect(store.permissionRouter.permissions.get('perm-1')).toMatchObject({
       id: 'perm-1',
       state: 'pending',
     });
-    expect(store.codexPermissionIndex.size).toBe(0);
-    expect(store.codexPermissionResponders.size).toBe(0);
+    expect(store.permissionRouter.codexPermissionIndex.size).toBe(0);
+    expect(store.permissionRouter.codexPermissionResponders.size).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Phase 2.5 Sprint 2.5c — `HappyRuntimeStore`의 권한 협상 책임을 `runtime/orchestration/permissionRouter.ts`로 분리. `runtime-core-extraction-plan.md`의 책임 ③(권한 오케스트레이터) 추출.

## 변경

### 신규 파일

**`services/aris-backend/src/runtime/contracts/runtimeCoordinationStore.ts`** (51줄)
- `HappyRuntimePermissionInput`, `RuntimeCoordinationStore` 타입을 happyClient 인라인에서 contracts 모듈로 이동.
- 향후 router/realtimeEventBus 등 orchestration 모듈이 happyClient를 import하지 않고도 storage 표면을 참조 가능.

**`services/aris-backend/src/runtime/orchestration/permissionRouter.ts`** (370줄)
- `PermissionRouter` 클래스. 다음 6개 Map을 인스턴스 필드로 보유:
  - `permissions: Map<string, PermissionRequest>` — 모든 permission 레코드의 인메모리 mirror
  - `codexPermissionIndex: Map<string, string>` — codex key → permission id
  - `codexPermissionResponders: Map<string, (decision) => Promise<void>>` — codex 응답자 콜백
  - `providerPermissionIndex: Map<string, string>` — provider key → permission id
  - `providerPermissionWaiters: Map<string, {resolve, reject}>` — pending 대기자
  - `providerPermissionDecisions: Map<string, PermissionDecision>` — 캐싱된 결정
- 공개 API:
  - `listPermissions(state?)`, `createPermission(input)`, `decidePermission(id, decision)` — storage 위임 + 캐시
  - `awaitDecision(id, signal?)` — provider call 대기
  - `watchExternal(input)` — 외부 polling 감시
  - `handleProviderPermissionRequest(input)` — claude/gemini 진입점
  - `getCachedPermission(id)` — 캐시 조회
  - `registerCodexBinding/lookupCodexBinding/clearCodexBinding/registerCodexResponder` — codex helper (Phase 3에서 codex/로 이전 예정)
  - `finalizeCodexPermissions(ids, options)` — codex turn 종료 cleanup
- `buildScopedPermissionKey(baseKey, chatId)` 유틸 함수도 함께 이전 (key 형식 `${chatId}:${baseKey}` 그대로 보존).
- 의존성 주입: `PermissionRouterDeps` (coordinationStore + 5개 host callback)

### 수정 파일

**`services/aris-backend/src/runtime/happyClient.ts`** (-272 +35 = -237 net)
- 인라인 타입 `HappyRuntimePermissionInput`, `RuntimeCoordinationStore` 제거 → contracts에서 import.
- 인라인 함수 `buildScopedPermissionKey` 제거 → router에서 import.
- 6개 permission Map 필드 제거.
- 5개 private 메서드 제거: `finalizeCodexRuntimePermissions`, `waitForPersistedPermissionDecision`, `awaitProviderPermissionDecision`, `watchExternalPermissionDecision`, `handleProviderPermissionRequest`.
- `persistPermissionEvent` private 메서드 router 내부로 이동.
- 3개 public 메서드(`listPermissions`/`createPermission`/`decidePermission`)는 thin delegating wrapper로 축소 (외부 호출자 surface 보존).
- constructor에서 `PermissionRouter` 인스턴스화. 5개 host callback을 bound function으로 주입:
  - `getSession`, `resolveApprovalPolicy`, `abortSessionRuns`, `appendAgentMessage`, `appendRunLifecycleEvent`
- 내부 호출 site들(codex registerPermissionResponder lambda, enqueuePermission lambda, claude/gemini onPermission, finalizeCodex 호출)을 router 메서드로 변경.
- `happyClientTestHooks.finalizeCodexRuntimePermissions`도 router 위임으로 갱신.

**`services/aris-backend/tests/happyClient.streamJson.test.ts`** (-3 +5)
- 단일 테스트의 internal-field cast 경로를 `store.permissionRouter.xxx`로 갱신. 테스트 의도 보존.

## 안전 검증

- ✅ `npx tsc --noEmit` clean (aris-backend).
- ✅ `npx vitest run --exclude '**/*.e2e.test.ts'` **261/261 PASS** (회귀 0).
- ✅ 동작 보존:
  - `buildScopedPermissionKey` key 포맷 byte-for-byte 동일 (`${chatId}:${baseKey}`).
  - `HappyRuntimePermissionInput.chatId?: string | null` 시그니처 보존.
  - `coordinationStore` 분기 로직 그대로 — 모든 storage 위임 지점 동일.
  - codex responder dispatch 순서 동일 (decidePermission 본문에서 index 정리 → waiter resolve → responder dispatch → deny 시 abortSessionRuns).
  - happy event log payload key 변동 없음.

## 작업 범위 외 (다음 sprint)

- 2.5d: `realtimeEventBus.ts` 추출 (sessionRealtimeEvents, sessionRealtimeCursor Map).
- 2.5e: `activeRunRegistry.ts` + `sessionOrchestrator.ts` 추출.
- 2.5f: `happyClient.ts` → `runtimeCore.ts` 리네임.
- Phase 3: codex-specific helper(`registerCodexBinding`, `lookupCodexBinding`, `finalizeCodexPermissions`)를 `runtime/providers/codex/`로 이전.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run --exclude e2e` 261/261 PASS
- [x] 외부 호출자(server.ts handlers)가 호출하는 3개 public 메서드 surface 동일
- [x] codex finalizeCodexRuntimePermissions test hook 호환
- [x] claude/gemini onPermission 흐름 회귀 0 (claudeProviderFlow.test 통과)

## Definition of Done (이 PR)

- [x] PermissionRouter 클래스 추출 + DI 패턴
- [x] HappyRuntimeStore에서 6개 Map + 5개 private + 3개 public 메서드 제거 (3개는 thin wrapper로 축소)
- [x] tsc + vitest clean
- [x] 회귀 0
- [ ] 머지 후 2.5d (realtimeEventBus 추출) 시작
