### PR TITLE
refactor(runtime-core): 2.5d - extract RealtimeEventBus

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -43,6 +43,7 @@ import type {
   RuntimeCoordinationStore,
 } from './contracts/runtimeCoordinationStore.js';
 import { PermissionRouter, buildScopedPermissionKey } from './orchestration/permissionRouter.js';
+import { RealtimeEventBus } from './orchestration/realtimeEventBus.js';
 import type { ClaudeSessionLaunchMode } from './providers/claude/claudeSessionContract.js';
 import type { ClaudeActionEvent, ClaudeLaunchCommand, ClaudeResumeTarget, ClaudeTextEvent } from './providers/claude/types.js';
 import type {
@@ -174,11 +175,6 @@ type HappyRuntimeAppendInput = {
   title?: string;
   text: string;
   meta?: Record<string, unknown>;
-};
-
-type SessionRealtimeEventRecord = {
-  cursor: number;
-  event: RuntimeMessage;
 };
 
 type GeminiPartialTextState = {
@@ -1899,11 +1895,10 @@ export class HappyRuntimeStore {
   private readonly geminiSessionRegistry = new GeminiSessionRegistry();
   private readonly claudeSessionScanners = new Map<string, ClaudeSessionLogTracker>();
   private readonly codexThreads = new Map<string, string>();
-  private readonly sessionRealtimeEvents = new Map<string, SessionRealtimeEventRecord[]>();
-  private readonly sessionRealtimeCursor = new Map<string, number>();
   private readonly geminiPartialTextStates = new Map<string, GeminiPartialTextState>();
   private readonly coordinationStore: RuntimeCoordinationStore | null;
   private readonly permissionRouter: PermissionRouter;
+  private readonly realtimeEventBus: RealtimeEventBus;
 
   private readonly serverUrl: string;
   private readonly serverToken: string;
@@ -1939,6 +1934,9 @@ export class HappyRuntimeStore {
       appendRunLifecycleEvent: (sessionId, state, meta) =>
         this.appendRunLifecycleEvent(sessionId, state, meta),
     });
+    this.realtimeEventBus = new RealtimeEventBus({
+      getSession: (sessionId) => this.getSession(sessionId),
+    });
   }
 
   beginShutdownDrain(): void {
@@ -1969,18 +1967,6 @@ export class HappyRuntimeStore {
         this.codexThreads.delete(key);
       }
     }
-  }
-
-  private appendSessionRealtimeEvent(sessionId: string, event: RuntimeMessage): RuntimeMessage {
-    const nextCursor = (this.sessionRealtimeCursor.get(sessionId) ?? 0) + 1;
-    this.sessionRealtimeCursor.set(sessionId, nextCursor);
-    const bucket = this.sessionRealtimeEvents.get(sessionId) ?? [];
-    bucket.push({ cursor: nextCursor, event });
-    if (bucket.length > 500) {
-      bucket.splice(0, bucket.length - 500);
-    }
-    this.sessionRealtimeEvents.set(sessionId, bucket);
-    return event;
   }
 
   private buildGeminiPartialIdentity(input: {
@@ -2047,7 +2033,7 @@ export class HappyRuntimeStore {
 
     const isCommentary = nextState.phase === 'commentary';
 
-    this.appendSessionRealtimeEvent(input.session.id, {
+    this.realtimeEventBus.append(input.session.id, {
       id: nextState.eventId,
       sessionId: input.session.id,
       type: isCommentary ? 'tool' : 'message',
@@ -4837,7 +4823,7 @@ export class HappyRuntimeStore {
             mode: selectedGeminiMode,
             signal: controller.signal,
             onAction: async (action, meta) => {
-              this.appendSessionRealtimeEvent(session.id, {
+              this.realtimeEventBus.append(session.id, {
                 id: `gemini-action-pending:${action.callId ?? String(Date.now())}`,
                 sessionId: session.id,
                 type: 'tool',
@@ -5370,37 +5356,7 @@ export class HappyRuntimeStore {
       chatId?: string;
     } = {},
   ): Promise<{ events: RuntimeMessage[]; cursor: number }> {
-    const session = await this.getSession(sessionId);
-    if (!session) {
-      throw new Error('SESSION_NOT_FOUND');
-    }
-
-    const bucket = this.sessionRealtimeEvents.get(sessionId) ?? [];
-    const normalizedAfterCursor = Number.isFinite(options.afterCursor)
-      ? Math.max(0, Math.floor(Number(options.afterCursor)))
-      : 0;
-    const normalizedLimit = Number.isFinite(options.limit)
-      ? Math.max(1, Math.floor(Number(options.limit)))
-      : 100;
-
-    const events = bucket
-      .filter((entry) => entry.cursor > normalizedAfterCursor)
-      .filter((entry) => {
-        if (!options.chatId) {
-          return true;
-        }
-        const chatId = typeof entry.event.meta?.chatId === 'string'
-          ? entry.event.meta.chatId.trim()
-          : '';
-        return chatId === options.chatId;
-      })
-      .slice(-normalizedLimit)
-      .map((entry) => entry.event);
-
-    return {
-      events,
-      cursor: this.sessionRealtimeCursor.get(sessionId) ?? 0,
-    };
+    return this.realtimeEventBus.list(sessionId, options);
   }
 
   private async listAllMessages(sessionId: string): Promise<HappyBackendMessage[]> {

--- a/services/aris-backend/src/runtime/orchestration/realtimeEventBus.ts
+++ b/services/aris-backend/src/runtime/orchestration/realtimeEventBus.ts
@@ -1,0 +1,124 @@
+/**
+ * RealtimeEventBus — in-memory ring buffer of session realtime events.
+ *
+ * Owned by `runtime/happyClient.ts` until 2.5d, where it moves into a
+ * standalone module so the runtime core can shrink and so future
+ * subscribers (SSE polling, WebSocket fanout) can take a stable
+ * dependency on a focused surface.
+ *
+ * Buffer semantics (preserved verbatim from happyClient.ts):
+ *   - Per-session bucket capped at 500 entries; overflow drops the
+ *     oldest entries via `splice(0, bucket.length - 500)`.
+ *   - Cursor monotonically increases per session and is independent of
+ *     other sessions. Cursor `0` means "no events observed yet".
+ *   - `list()` returns events whose cursor strictly exceeds
+ *     `options.afterCursor`, optionally filtered by `chatId`, and
+ *     truncated to the most recent `options.limit` (default 100).
+ *
+ * The bus does NOT persist anything — it is a process-local cache that
+ * survives only for the lifetime of the runtime core. Long-term
+ * persistence is the responsibility of the storage layer (PrismaStore
+ * `chatEvents`).
+ */
+
+import type { RuntimeMessage, RuntimeSession } from '../../types.js';
+
+/**
+ * One entry in a session bucket. Verbatim port of the inline type that
+ * lived in happyClient.ts.
+ */
+export interface SessionRealtimeEventRecord {
+  cursor: number;
+  event: RuntimeMessage;
+}
+
+/**
+ * Options for `RealtimeEventBus.list`.
+ */
+export interface ListRealtimeEventsOptions {
+  /** Returns events whose cursor strictly exceeds this value. Defaults to 0. */
+  afterCursor?: number;
+  /** Maximum number of (most-recent) events to return. Defaults to 100. */
+  limit?: number;
+  /** Optional chat scope filter; matches against `event.meta.chatId`. */
+  chatId?: string;
+}
+
+/**
+ * Host-side callbacks the bus needs.
+ */
+export interface RealtimeEventBusDeps {
+  /** Resolves an ARIS session by id; null when session does not exist. */
+  getSession(sessionId: string): Promise<RuntimeSession | null>;
+}
+
+/** Hard cap on entries per session bucket. */
+const SESSION_BUCKET_CAP = 500;
+/** Default `list` page size. */
+const DEFAULT_LIST_LIMIT = 100;
+
+export class RealtimeEventBus {
+  private readonly events = new Map<string, SessionRealtimeEventRecord[]>();
+  private readonly cursors = new Map<string, number>();
+
+  constructor(private readonly deps: RealtimeEventBusDeps) {}
+
+  /**
+   * Append a realtime event for a session and return the event verbatim.
+   * Returning the input lets callers chain: `const e = bus.append(...)`.
+   */
+  append(sessionId: string, event: RuntimeMessage): RuntimeMessage {
+    const nextCursor = (this.cursors.get(sessionId) ?? 0) + 1;
+    this.cursors.set(sessionId, nextCursor);
+    const bucket = this.events.get(sessionId) ?? [];
+    bucket.push({ cursor: nextCursor, event });
+    if (bucket.length > SESSION_BUCKET_CAP) {
+      bucket.splice(0, bucket.length - SESSION_BUCKET_CAP);
+    }
+    this.events.set(sessionId, bucket);
+    return event;
+  }
+
+  /**
+   * List session events newer than `options.afterCursor`. Validates the
+   * session exists via `deps.getSession`; throws `SESSION_NOT_FOUND` when
+   * the session is absent (preserves the legacy contract for HTTP
+   * handlers that translate that error to 404).
+   */
+  async list(
+    sessionId: string,
+    options: ListRealtimeEventsOptions = {},
+  ): Promise<{ events: RuntimeMessage[]; cursor: number }> {
+    const session = await this.deps.getSession(sessionId);
+    if (!session) {
+      throw new Error('SESSION_NOT_FOUND');
+    }
+
+    const bucket = this.events.get(sessionId) ?? [];
+    const normalizedAfterCursor = Number.isFinite(options.afterCursor)
+      ? Math.max(0, Math.floor(Number(options.afterCursor)))
+      : 0;
+    const normalizedLimit = Number.isFinite(options.limit)
+      ? Math.max(1, Math.floor(Number(options.limit)))
+      : DEFAULT_LIST_LIMIT;
+
+    const events = bucket
+      .filter((entry) => entry.cursor > normalizedAfterCursor)
+      .filter((entry) => {
+        if (!options.chatId) {
+          return true;
+        }
+        const chatId = typeof entry.event.meta?.chatId === 'string'
+          ? entry.event.meta.chatId.trim()
+          : '';
+        return chatId === options.chatId;
+      })
+      .slice(-normalizedLimit)
+      .map((entry) => entry.event);
+
+    return {
+      events,
+      cursor: this.cursors.get(sessionId) ?? 0,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2.5 Sprint 2.5d — `HappyRuntimeStore`의 실시간 이벤트 버퍼를 `runtime/orchestration/realtimeEventBus.ts`로 분리. `runtime-core-extraction-plan.md`의 책임 ④(실시간 이벤트 버스) 추출.

## 변경

### 신규 파일

**`services/aris-backend/src/runtime/orchestration/realtimeEventBus.ts`** (~120줄)
- `RealtimeEventBus` 클래스. 다음 2개 Map을 인스턴스 필드로 보유:
  - `events: Map<string, SessionRealtimeEventRecord[]>` — 세션별 이벤트 버킷
  - `cursors: Map<string, number>` — 세션별 단조 커서
- 공개 API:
  - `append(sessionId, event)` — 버킷에 추가하고 cap 적용 후 이벤트 verbatim 반환
  - `list(sessionId, options)` — afterCursor/limit/chatId 필터링된 이벤트 + 최신 cursor 반환
- `SessionRealtimeEventRecord`, `ListRealtimeEventsOptions`, `RealtimeEventBusDeps` 타입 함께 export
- 의존성 주입: `getSession` 콜백 (세션 존재 검증용)
- 상수 `SESSION_BUCKET_CAP = 500`, `DEFAULT_LIST_LIMIT = 100` 명시

### 수정 파일

**`services/aris-backend/src/runtime/happyClient.ts`** (-58 +12 = -46 net)
- 인라인 `SessionRealtimeEventRecord` 타입 제거 (6줄)
- 2개 realtime Map 필드 제거
- `appendSessionRealtimeEvent` private 메서드 11줄 제거
- `listRealtimeEvents` public 메서드 본문(~36줄)을 `this.realtimeEventBus.list(...)` 한 줄로 축소
- 2개 내부 호출자 갱신:
  - `appendGeminiRealtimePartial` 내부의 호출
  - `runGeminiAcpTurn` 내부 onAction 콜백
- constructor에서 `RealtimeEventBus` 인스턴스화 (getSession 콜백 주입)

## 안전 검증

- ✅ `npx tsc --noEmit` clean (aris-backend).
- ✅ `npx vitest run --exclude '**/*.e2e.test.ts'` **261/261 PASS** (회귀 0).
- ✅ 버퍼 동작 보존:
  - 500 cap + FIFO eviction via `splice(0, len-500)` 동일.
  - 커서 단조 증가, 시작값 0 동일.
  - `afterCursor` strict greater-than 비교 동일.
  - `chatId` 필터(meta.chatId trim 후 일치) 동일.
  - 기본 limit 100, 음수/NaN/Infinity 처리(`Math.max(1, Math.floor(...))`) 동일.

## 작업 범위 외 (다음 sprint)

- 2.5e: `activeRunRegistry.ts` + `sessionOrchestrator.ts` 추출 (active runs Map + drain/abort lifecycle).
- 2.5f: `happyClient.ts` → `runtimeCore.ts` 리네임.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run --exclude e2e` 261/261 PASS
- [x] gemini partial text 흐름 회귀 0 (geminiStreamAdapter.test 통과)
- [x] `listRealtimeEvents` HTTP 외부 호출자 surface 동일
