### PR TITLE
refactor(runtime-core): 2.5e - extract ActiveRunRegistry

### DIFF
--- a/services/aris-backend/src/runtime/happyClient.ts
+++ b/services/aris-backend/src/runtime/happyClient.ts
@@ -44,6 +44,13 @@ import type {
 } from './contracts/runtimeCoordinationStore.js';
 import { PermissionRouter, buildScopedPermissionKey } from './orchestration/permissionRouter.js';
 import { RealtimeEventBus } from './orchestration/realtimeEventBus.js';
+import {
+  ActiveRunRegistry,
+  buildRunKey,
+  isSessionRunKey,
+  type ActiveRun,
+  type StaleRunCleanupInput,
+} from './orchestration/activeRunRegistry.js';
 import type { ClaudeSessionLaunchMode } from './providers/claude/claudeSessionContract.js';
 import type { ClaudeActionEvent, ClaudeLaunchCommand, ClaudeResumeTarget, ClaudeTextEvent } from './providers/claude/types.js';
 import type {
@@ -141,17 +148,6 @@ type PermissionState = PermissionRequest['state'];
 type SessionStatusValue = RuntimeSession['state']['status'];
 type PermissionActionType = 'exec' | 'patch';
 type JsonRpcId = string | number | null;
-type ActiveRun = {
-  controller: AbortController;
-  sessionId: string;
-  chatId?: string;
-  startedAt: number;
-  agent: RuntimeAgent;
-  model?: string;
-  modelReasoningEffort?: ModelReasoningEffort;
-  completed: Promise<void>;
-};
-
 type CodexPermissionRequest = {
   actionType: PermissionActionType;
   callId: string;
@@ -1890,7 +1886,6 @@ export const happyClientTestHooks = {
 };
 
 export class HappyRuntimeStore {
-  private readonly activeRuns = new Map<string, ActiveRun>();
   private readonly claudeSessionRegistry = new ClaudeSessionRegistry();
   private readonly geminiSessionRegistry = new GeminiSessionRegistry();
   private readonly claudeSessionScanners = new Map<string, ClaudeSessionLogTracker>();
@@ -1905,7 +1900,7 @@ export class HappyRuntimeStore {
   private readonly workspaceRoot: string;
   private readonly hostProjectsRoot: string;
   private readonly happyEventLogger: HappyEventLogger;
-  private draining = false;
+  private readonly activeRunRegistry: ActiveRunRegistry;
 
   // listSessions() 응답을 1초간 캐시하여 getSession() 호출 시 happy-server 왕복을 줄임
   private sessionListCache: { sessions: RuntimeSession[]; expiresAt: number } | null = null;
@@ -1937,24 +1932,19 @@ export class HappyRuntimeStore {
     this.realtimeEventBus = new RealtimeEventBus({
       getSession: (sessionId) => this.getSession(sessionId),
     });
+    this.activeRunRegistry = new ActiveRunRegistry({
+      claudeSessionRegistry: this.claudeSessionRegistry,
+      staleTimeoutMs: STALE_RUN_TIMEOUT_MS,
+      handleStaleRunCleanup: (input) => this.handleStaleRunCleanup(input),
+    });
   }
 
   beginShutdownDrain(): void {
-    this.draining = true;
+    this.activeRunRegistry.beginShutdownDrain();
   }
 
   async awaitDrain(timeoutMs: number): Promise<void> {
-    const deadline = Date.now() + Math.max(0, timeoutMs);
-    while (Date.now() <= deadline) {
-      if (this.getActiveRunCount() === 0) {
-        return;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 250));
-    }
-  }
-
-  private getActiveRunCount(): number {
-    return this.activeRuns.size + this.claudeSessionRegistry.activeRunCount();
+    return this.activeRunRegistry.awaitDrain(timeoutMs);
   }
 
   private resolveSessionApprovalPolicy(session: RuntimeSession): ApprovalPolicy {
@@ -2150,87 +2140,15 @@ export class HappyRuntimeStore {
     return created;
   }
 
-  private buildRunKey(sessionId: string, chatId?: string): string {
-    if (chatId && chatId.trim().length > 0) {
-      return `${sessionId}:${chatId.trim()}`;
-    }
-    return `${sessionId}:__default__`;
-  }
-
-  private isSessionRunKey(runKey: string, sessionId: string): boolean {
-    return runKey === `${sessionId}:__default__` || runKey.startsWith(`${sessionId}:`);
-  }
-
   private abortSessionRuns(sessionId: string, chatId?: string): void {
-    this.claudeSessionRegistry.abortSessionRuns({ sessionId, chatId });
-    const scopedRunKey = typeof chatId === 'string' && chatId.trim().length > 0
-      ? this.buildRunKey(sessionId, chatId)
-      : null;
-    for (const [runKey, run] of this.activeRuns.entries()) {
-      if (scopedRunKey) {
-        if (runKey !== scopedRunKey) {
-          continue;
-        }
-      } else if (!this.isSessionRunKey(runKey, sessionId)) {
-        continue;
-      }
-      if (!run.controller.signal.aborted) {
-        run.controller.abort();
-      }
-      this.activeRuns.delete(runKey);
-    }
+    this.activeRunRegistry.abortSessionRuns(sessionId, chatId);
   }
 
   private async cleanupStaleRuns(reason: string): Promise<void> {
-    await this.claudeSessionRegistry.cleanupStaleRuns(
-      STALE_RUN_TIMEOUT_MS,
-      async ({ runKey, run, ageMs }) => this.handleStaleRunCleanup({
-        sessionId: run.sessionId,
-        chatId: run.chatId,
-        model: run.model,
-        agent: 'claude',
-        runKey,
-        ageMs,
-        reason,
-      }),
-    );
-
-    const now = Date.now();
-    const staleRuns: Array<{ runKey: string; run: ActiveRun; ageMs: number }> = [];
-    for (const [runKey, run] of this.activeRuns.entries()) {
-      const ageMs = now - run.startedAt;
-      if (ageMs <= STALE_RUN_TIMEOUT_MS) {
-        continue;
-      }
-      staleRuns.push({ runKey, run, ageMs });
-    }
-
-    for (const stale of staleRuns) {
-      if (!stale.run.controller.signal.aborted) {
-        stale.run.controller.abort();
-      }
-      this.activeRuns.delete(stale.runKey);
-      await this.handleStaleRunCleanup({
-        sessionId: stale.run.sessionId,
-        chatId: stale.run.chatId,
-        model: stale.run.model,
-        agent: stale.run.agent,
-        runKey: stale.runKey,
-        ageMs: stale.ageMs,
-        reason,
-      });
-    }
+    await this.activeRunRegistry.cleanupStaleRuns(reason);
   }
 
-  private async handleStaleRunCleanup(input: {
-    sessionId: string;
-    chatId?: string;
-    model?: string;
-    agent: RuntimeAgent;
-    runKey: string;
-    ageMs: number;
-    reason: string;
-  }): Promise<void> {
+  private async handleStaleRunCleanup(input: StaleRunCleanupInput): Promise<void> {
     const channel = input.agent === 'codex' && CODEX_RUNTIME_MODE !== 'exec' ? 'app_server' : 'exec_cli';
     this.happyEventLogger.logParsed({
       sessionId: input.sessionId,
@@ -3930,7 +3848,7 @@ export class HappyRuntimeStore {
       await appendChain.catch(() => undefined);
 
       await this.permissionRouter.finalizeCodexPermissions(runtimePermissionIds, {
-        preservePending: this.draining && !signal?.aborted,
+        preservePending: this.activeRunRegistry.isDraining() && !signal?.aborted,
       });
 
       if (!turnCompleted && !signal?.aborted) {
@@ -4486,9 +4404,9 @@ export class HappyRuntimeStore {
         this.claudeSessionRegistry.finish(activeClaudeController);
       };
     } else {
-      const runKey = this.buildRunKey(session.id, scopedChatId);
+      const runKey = buildRunKey(session.id, scopedChatId);
       const activeController = new AbortController();
-      const existing = this.activeRuns.get(runKey);
+      const existing = this.activeRunRegistry.get(runKey);
       if (existing && !existing.controller.signal.aborted) {
         existing.controller.abort();
       }
@@ -4504,7 +4422,7 @@ export class HappyRuntimeStore {
       const completed = new Promise<void>((resolve) => {
         finishRun = resolve;
       });
-      this.activeRuns.set(runKey, {
+      this.activeRunRegistry.set(runKey, {
         controller: activeController,
         sessionId: session.id,
         ...(scopedChatId ? { chatId: scopedChatId } : {}),
@@ -4518,9 +4436,9 @@ export class HappyRuntimeStore {
       controller = activeController;
       finalizeRun = () => {
         finishRun();
-        const current = this.activeRuns.get(runKey);
+        const current = this.activeRunRegistry.get(runKey);
         if (current?.controller === activeController) {
-          this.activeRuns.delete(runKey);
+          this.activeRunRegistry.delete(runKey);
         }
       };
     }
@@ -5544,10 +5462,10 @@ export class HappyRuntimeStore {
       return true;
     }
     if (chatId && chatId.trim().length > 0) {
-      return this.activeRuns.has(this.buildRunKey(sessionId, chatId));
+      return this.activeRunRegistry.has(buildRunKey(sessionId, chatId));
     }
-    for (const runKey of this.activeRuns.keys()) {
-      if (this.isSessionRunKey(runKey, sessionId)) {
+    for (const runKey of this.activeRunRegistry.keys()) {
+      if (isSessionRunKey(runKey, sessionId)) {
         return true;
       }
     }

--- a/services/aris-backend/src/runtime/orchestration/activeRunRegistry.ts
+++ b/services/aris-backend/src/runtime/orchestration/activeRunRegistry.ts
@@ -1,0 +1,201 @@
+/**
+ * ActiveRunRegistry — bookkeeping for in-flight provider runs (codex/gemini)
+ * plus shutdown-drain coordination.
+ *
+ * Owned by `runtime/happyClient.ts` until 2.5e, where it moves into a
+ * standalone module to continue the runtime-core extraction track started
+ * in 2.5c (PermissionRouter) and 2.5d (RealtimeEventBus).
+ *
+ * Run-key semantics (preserved verbatim):
+ *   - `${sessionId}:__default__` when no chat scope is provided.
+ *   - `${sessionId}:${chatId.trim()}` when a non-empty chat scope exists.
+ *   - `isSessionRunKey(runKey, sessionId)` returns true for the default
+ *     scope or any run-key prefixed with `${sessionId}:`.
+ *
+ * Drain semantics (preserved verbatim):
+ *   - `beginShutdownDrain()` flips an internal flag callers can read.
+ *   - `awaitDrain(timeoutMs)` polls every 250ms until the count reaches
+ *     zero or the deadline passes. Negative timeouts are clamped to 0.
+ *
+ * The registry intentionally stays out of provider-specific concerns
+ * (codex thread cache, claude session source, etc.). It tracks generic
+ * runs keyed by `runKey` and delegates claude-specific bookkeeping to
+ * the injected `ClaudeSessionRegistry`.
+ */
+
+import type { ClaudeSessionRegistry } from '../providers/claude/claudeSessionRegistry.js';
+import type { AgentFlavor } from '../../types.js';
+
+/** A live provider run as recorded in the registry. */
+export interface ActiveRun {
+  controller: AbortController;
+  sessionId: string;
+  chatId?: string;
+  startedAt: number;
+  agent: AgentFlavor;
+  model?: string;
+  modelReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
+  completed: Promise<void>;
+}
+
+/** Input shape for the stale-run handler callback. */
+export interface StaleRunCleanupInput {
+  sessionId: string;
+  chatId?: string;
+  model?: string;
+  agent: AgentFlavor;
+  runKey: string;
+  ageMs: number;
+  reason: string;
+}
+
+/** Host-side dependencies wired into the registry at construction. */
+export interface ActiveRunRegistryDeps {
+  /** Provider-specific run bookkeeping for Claude. */
+  claudeSessionRegistry: ClaudeSessionRegistry;
+  /** Wall-clock threshold past which a run is considered stale. */
+  staleTimeoutMs: number;
+  /** Host callback invoked once per stale run during cleanup. */
+  handleStaleRunCleanup(input: StaleRunCleanupInput): Promise<void>;
+}
+
+/**
+ * Build a run-key for the (sessionId, chatId) tuple. Verbatim port of the
+ * helper that lived in happyClient.ts.
+ */
+export function buildRunKey(sessionId: string, chatId?: string): string {
+  if (chatId && chatId.trim().length > 0) {
+    return `${sessionId}:${chatId.trim()}`;
+  }
+  return `${sessionId}:__default__`;
+}
+
+/**
+ * Predicate matching run-keys that belong to `sessionId`. Returns true for
+ * the default scope or any run-key prefixed with `${sessionId}:`.
+ */
+export function isSessionRunKey(runKey: string, sessionId: string): boolean {
+  return runKey === `${sessionId}:__default__` || runKey.startsWith(`${sessionId}:`);
+}
+
+export class ActiveRunRegistry {
+  private readonly runs = new Map<string, ActiveRun>();
+  private draining = false;
+
+  constructor(private readonly deps: ActiveRunRegistryDeps) {}
+
+  // ---------------------------------------------------------------------
+  // Map accessors
+  // ---------------------------------------------------------------------
+
+  set(runKey: string, run: ActiveRun): void {
+    this.runs.set(runKey, run);
+  }
+
+  get(runKey: string): ActiveRun | undefined {
+    return this.runs.get(runKey);
+  }
+
+  has(runKey: string): boolean {
+    return this.runs.has(runKey);
+  }
+
+  delete(runKey: string): boolean {
+    return this.runs.delete(runKey);
+  }
+
+  keys(): IterableIterator<string> {
+    return this.runs.keys();
+  }
+
+  // ---------------------------------------------------------------------
+  // Drain lifecycle
+  // ---------------------------------------------------------------------
+
+  beginShutdownDrain(): void {
+    this.draining = true;
+  }
+
+  isDraining(): boolean {
+    return this.draining;
+  }
+
+  async awaitDrain(timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    while (Date.now() <= deadline) {
+      if (this.getActiveRunCount() === 0) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+
+  getActiveRunCount(): number {
+    return this.runs.size + this.deps.claudeSessionRegistry.activeRunCount();
+  }
+
+  // ---------------------------------------------------------------------
+  // Abort / cleanup
+  // ---------------------------------------------------------------------
+
+  abortSessionRuns(sessionId: string, chatId?: string): void {
+    this.deps.claudeSessionRegistry.abortSessionRuns({ sessionId, chatId });
+    const scopedRunKey = typeof chatId === 'string' && chatId.trim().length > 0
+      ? buildRunKey(sessionId, chatId)
+      : null;
+    for (const [runKey, run] of this.runs.entries()) {
+      if (scopedRunKey) {
+        if (runKey !== scopedRunKey) {
+          continue;
+        }
+      } else if (!isSessionRunKey(runKey, sessionId)) {
+        continue;
+      }
+      if (!run.controller.signal.aborted) {
+        run.controller.abort();
+      }
+      this.runs.delete(runKey);
+    }
+  }
+
+  async cleanupStaleRuns(reason: string): Promise<void> {
+    await this.deps.claudeSessionRegistry.cleanupStaleRuns(
+      this.deps.staleTimeoutMs,
+      async ({ runKey, run, ageMs }) => this.deps.handleStaleRunCleanup({
+        sessionId: run.sessionId,
+        chatId: run.chatId,
+        model: run.model,
+        agent: 'claude',
+        runKey,
+        ageMs,
+        reason,
+      }),
+    );
+
+    const now = Date.now();
+    const staleRuns: Array<{ runKey: string; run: ActiveRun; ageMs: number }> = [];
+    for (const [runKey, run] of this.runs.entries()) {
+      const ageMs = now - run.startedAt;
+      if (ageMs <= this.deps.staleTimeoutMs) {
+        continue;
+      }
+      staleRuns.push({ runKey, run, ageMs });
+    }
+
+    for (const stale of staleRuns) {
+      if (!stale.run.controller.signal.aborted) {
+        stale.run.controller.abort();
+      }
+      this.runs.delete(stale.runKey);
+      await this.deps.handleStaleRunCleanup({
+        sessionId: stale.run.sessionId,
+        chatId: stale.run.chatId,
+        model: stale.run.model,
+        agent: stale.run.agent,
+        runKey: stale.runKey,
+        ageMs: stale.ageMs,
+        reason,
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2.5 Sprint 2.5e — `HappyRuntimeStore`의 active-run 등록/추적 + drain lifecycle을 `runtime/orchestration/activeRunRegistry.ts`로 분리. `runtime-core-extraction-plan.md`의 책임 ⑤(active run / drain)의 핵심 추출.

## 변경

### 신규 파일

**`services/aris-backend/src/runtime/orchestration/activeRunRegistry.ts`** (~190줄)
- `ActiveRunRegistry` 클래스. 다음을 보유:
  - `runs: Map<string, ActiveRun>` — runKey → ActiveRun
  - `draining: boolean`
- 공개 API:
  - Map accessors: `set/get/has/delete/keys`
  - Drain: `beginShutdownDrain`, `isDraining`, `awaitDrain(timeoutMs)`, `getActiveRunCount`
  - Abort / cleanup: `abortSessionRuns(sessionId, chatId?)`, `cleanupStaleRuns(reason)`
- 모듈 레벨 pure helper:
  - `buildRunKey(sessionId, chatId?)`
  - `isSessionRunKey(runKey, sessionId)`
- 타입 export: `ActiveRun`, `StaleRunCleanupInput`, `ActiveRunRegistryDeps`
- 의존성 주입:
  - `claudeSessionRegistry: ClaudeSessionRegistry` (claude 측 active-run 카운트와 abort 위임)
  - `staleTimeoutMs: number` (host의 `STALE_RUN_TIMEOUT_MS` env값)
  - `handleStaleRunCleanup(input)` 콜백 (host의 logger/appendAgentMessage 호출하는 cleanup 핸들러)

### 수정 파일

**`services/aris-backend/src/runtime/happyClient.ts`** (-110 +25 = -85 net)
- 인라인 `ActiveRun` 타입 제거 → registry에서 import.
- `activeRuns` Map 필드 제거.
- `draining` 필드 제거.
- 5개 메서드 본체 제거 (`getActiveRunCount`, `buildRunKey`, `isSessionRunKey` 완전 제거; `beginShutdownDrain/awaitDrain/abortSessionRuns/cleanupStaleRuns`는 thin wrapper로 축소).
- `handleStaleRunCleanup`의 inline 인자 타입 → import한 `StaleRunCleanupInput`.
- constructor에서 `ActiveRunRegistry` 인스턴스화.
- finalizeCodexPermissions argument: `this.draining` → `this.activeRunRegistry.isDraining()`.
- run lifecycle 내부 활성 run 등록 로직 (runAgentCommand): `this.activeRuns`/`this.buildRunKey` → `this.activeRunRegistry`/`buildRunKey`.
- `isSessionRunning` 내부: `this.activeRuns`/`this.buildRunKey`/`this.isSessionRunKey` → registry + module helpers.

## 안전 검증

- ✅ `npx tsc --noEmit` clean (aris-backend).
- ✅ `npx vitest run --exclude '**/*.e2e.test.ts'` **261/261 PASS** (회귀 0).
- ✅ 동작 보존:
  - run-key 포맷 `${sessionId}:${chatId|__default__}` 동일.
  - `isSessionRunKey` 술어 동일 (default 또는 prefix 매치).
  - drain poll 250ms, timeout clamp 0, claude registry count 합산 동일.
  - `abortSessionRuns` 순서: claude registry abort → in-process registry sweep → deletion.
  - `cleanupStaleRuns`: claude registry 먼저 → ageMs > staleTimeoutMs 수집 → abort/delete/notify 순서.
  - ActiveRun excess-property 관대성 (`geminiMode` spread) 동일.

## 작업 범위 외 (다음 sprint)

- 2.5f: `happyClient.ts` → `runtimeCore.ts` 리네임 + `HappyRuntimeStore` → `RuntimeCore` 클래스명 변경.
- `sessionOrchestrator.ts` (drain/lifecycle 메시지 wrapper)는 본 sprint에 포함하지 않음 — `appendRunLifecycleEvent`가 happyClient에 깊이 결합돼 있어 단독 추출 시 표면이 모호. 2.5f 리네임 후 또는 후속 sprint에서 검토.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run --exclude e2e` 261/261 PASS
- [x] run lifecycle (start/abort/finalize) 회귀 0
- [x] drain 시나리오 (codex finalizeCodexPermissions 분기 isDraining 사용) 동작
- [x] isSessionRunning HTTP 외부 호출자 surface 동일
