### PR TITLE
refactor(runtime-core): 2.5f - rename happyClient.ts to runtimeCore.ts

### DIFF
--- a/services/aris-backend/src/runtime/contracts/runtimeCoordinationStore.ts
+++ b/services/aris-backend/src/runtime/contracts/runtimeCoordinationStore.ts
@@ -2,7 +2,7 @@
  * Shared types for permission/coordination delegation between the runtime
  * core and the storage layer (PrismaRuntimeStore in production, mock in tests).
  *
- * These types were inlined inside `runtime/happyClient.ts` until 2.5c. Moving
+ * These types were inlined inside `runtime/runtimeCore.ts` until 2.5c. Moving
  * them here lets `runtime/orchestration/permissionRouter.ts` consume the
  * coordination-store contract without circular imports through happyClient.
  */
@@ -25,7 +25,7 @@ export type HappyRuntimePermissionInput = {
   sessionId: string;
   /**
    * `null` accepted alongside `undefined` to mirror the original inline
-   * surface in happyClient.ts (callers occasionally pass nullable chat ids
+   * surface in runtimeCore.ts (callers occasionally pass nullable chat ids
    * from optional-property reads).
    */
   chatId?: string | null;

--- a/services/aris-backend/src/runtime/orchestration/activeRunRegistry.ts
+++ b/services/aris-backend/src/runtime/orchestration/activeRunRegistry.ts
@@ -2,7 +2,7 @@
  * ActiveRunRegistry — bookkeeping for in-flight provider runs (codex/gemini)
  * plus shutdown-drain coordination.
  *
- * Owned by `runtime/happyClient.ts` until 2.5e, where it moves into a
+ * Owned by `runtime/runtimeCore.ts` until 2.5e, where it moves into a
  * standalone module to continue the runtime-core extraction track started
  * in 2.5c (PermissionRouter) and 2.5d (RealtimeEventBus).
  *
@@ -61,7 +61,7 @@ export interface ActiveRunRegistryDeps {
 
 /**
  * Build a run-key for the (sessionId, chatId) tuple. Verbatim port of the
- * helper that lived in happyClient.ts.
+ * helper that lived in runtimeCore.ts.
  */
 export function buildRunKey(sessionId: string, chatId?: string): string {
   if (chatId && chatId.trim().length > 0) {

--- a/services/aris-backend/src/runtime/orchestration/permissionRouter.ts
+++ b/services/aris-backend/src/runtime/orchestration/permissionRouter.ts
@@ -2,7 +2,7 @@
  * PermissionRouter — provider-agnostic permission orchestration.
  *
  * Owns the runtime side of the permission protocol that was previously
- * tangled inside `HappyRuntimeStore` in `runtime/happyClient.ts`:
+ * tangled inside `RuntimeCore` in `runtime/runtimeCore.ts`:
  *
  *   - In-memory mirror of permission records (`permissions` Map).
  *   - Provider-agnostic awaiter machinery (`providerPermissionWaiters`,
@@ -11,7 +11,7 @@
  *     `codexPermissionResponders`). These are scheduled to migrate to
  *     `runtime/providers/codex/` in Phase 3 of the provider-architecture
  *     refactor; for now the router exposes typed accessors so the codex
- *     code in happyClient.ts can keep working without reaching into router
+ *     code in runtimeCore.ts can keep working without reaching into router
  *     internals.
  *
  * Storage delegation is performed through the optional
@@ -43,7 +43,7 @@ import type {
 
 /**
  * Build a permission key scoped to a chat slot. Verbatim port of the helper
- * that lived in happyClient.ts (`${chatId}:${baseKey}` format) so existing
+ * that lived in runtimeCore.ts (`${chatId}:${baseKey}` format) so existing
  * collision behavior is preserved byte-for-byte.
  */
 export function buildScopedPermissionKey(baseKey: string, chatId?: string): string {

--- a/services/aris-backend/src/runtime/orchestration/realtimeEventBus.ts
+++ b/services/aris-backend/src/runtime/orchestration/realtimeEventBus.ts
@@ -1,12 +1,12 @@
 /**
  * RealtimeEventBus — in-memory ring buffer of session realtime events.
  *
- * Owned by `runtime/happyClient.ts` until 2.5d, where it moves into a
+ * Owned by `runtime/runtimeCore.ts` until 2.5d, where it moves into a
  * standalone module so the runtime core can shrink and so future
  * subscribers (SSE polling, WebSocket fanout) can take a stable
  * dependency on a focused surface.
  *
- * Buffer semantics (preserved verbatim from happyClient.ts):
+ * Buffer semantics (preserved verbatim from runtimeCore.ts):
  *   - Per-session bucket capped at 500 entries; overflow drops the
  *     oldest entries via `splice(0, bucket.length - 500)`.
  *   - Cursor monotonically increases per session and is independent of
@@ -25,7 +25,7 @@ import type { RuntimeMessage, RuntimeSession } from '../../types.js';
 
 /**
  * One entry in a session bucket. Verbatim port of the inline type that
- * lived in happyClient.ts.
+ * lived in runtimeCore.ts.
  */
 export interface SessionRealtimeEventRecord {
   cursor: number;

--- a/services/aris-backend/src/runtime/providers/codex/codexAdapter.ts
+++ b/services/aris-backend/src/runtime/providers/codex/codexAdapter.ts
@@ -6,7 +6,7 @@
  * `isAvailable`, `checkStatus`) are functional. Process-lifecycle methods
  * (`spawn`, `sendMessage`, `parseStdout`, …) throw `NotYetWiredError` —
  * Sprint 6 will replace those throws with extracted logic from
- * `happyClient.ts`.
+ * `runtimeCore.ts`.
  *
  * The adapter is registered with `cliProviderRegistry` via
  * `./bootstrap.ts`, but bootstrap is not imported anywhere in production
@@ -34,7 +34,7 @@ class NotYetWiredError extends Error {
   constructor(method: string) {
     super(
       `CodexAdapter.${method}() is not wired yet. Phase 2 Sprint 2 ships only the structural slot; ` +
-        'Sprint 6 will extract the implementation from happyClient.ts.',
+        'Sprint 6 will extract the implementation from runtimeCore.ts.',
     );
     this.name = 'NotYetWiredError';
   }

--- a/services/aris-backend/src/runtime/providers/codex/codexLauncher.ts
+++ b/services/aris-backend/src/runtime/providers/codex/codexLauncher.ts
@@ -6,8 +6,8 @@
  * name, args, and channel selection (`app-server` vs `exec`).
  *
  * The exec-mode args returned here are byte-equivalent to the inline spawn
- * at `services/aris-backend/src/runtime/happyClient.ts:4198-4221` as of the
- * Phase 2 baseline. happyClient.ts is NOT yet routed through this builder;
+ * at `services/aris-backend/src/runtime/runtimeCore.ts:4198-4221` as of the
+ * Phase 2 baseline. runtimeCore.ts is NOT yet routed through this builder;
  * Sprint 6 will perform that wiring with a fixture-locked regression check.
  *
  * App-server-mode commands are also returned here, even though the
@@ -98,7 +98,7 @@ function appendReasoningEffort(args: string[], reasoningEffort?: CodexReasoningE
 /**
  * Build a CodexLaunchCommand.
  *
- * exec channel args (matches `happyClient.ts:4198` baseline):
+ * exec channel args (matches `runtimeCore.ts:4198` baseline):
  *   codex
  *     -a <approvalPolicy>
  *     -s <sandboxMode>

--- a/services/aris-backend/src/runtime/providers/codex/codexSessionRegistry.ts
+++ b/services/aris-backend/src/runtime/providers/codex/codexSessionRegistry.ts
@@ -3,7 +3,7 @@
  *
  * Mirrors the Claude/Gemini precedent (`claudeSessionRegistry.ts`,
  * `geminiSessionRegistry.ts`). Sprint 6 will fill this with the threadId
- * cache currently held in `happyClient.ts` (see `buildCodexThreadCacheKey`
+ * cache currently held in `runtimeCore.ts` (see `buildCodexThreadCacheKey`
  * around line 1357 of that file) and any per-session app-server connection
  * state that needs to outlive a single turn.
  *

--- a/services/aris-backend/src/runtime/providers/codex/types.ts
+++ b/services/aris-backend/src/runtime/providers/codex/types.ts
@@ -8,7 +8,7 @@
  * Phase 2 Sprint 2 introduces this file as part of the codex/ skeleton.
  * Subsequent sprints will extend it with codex-specific subtypes (thread
  * cache key, app-server failure kinds, etc.) as logic is extracted from
- * happyClient.ts.
+ * runtimeCore.ts.
  */
 
 import type { SessionProtocolEnvelope } from '../../contracts/sessionProtocol.js';

--- a/services/aris-backend/src/runtime/runtimeCore.ts
+++ b/services/aris-backend/src/runtime/runtimeCore.ts
@@ -1855,7 +1855,7 @@ function createCodexAppServerAbortPromise(input: {
   };
 }
 
-export const happyClientTestHooks = {
+export const runtimeCoreTestHooks = {
   parseAgentStreamLine,
   parseAgentStreamOutput,
   looksLikeActionTranscript,
@@ -1878,14 +1878,14 @@ export const happyClientTestHooks = {
   resolveAgentCommandTimeoutMs,
   resolveGeminiStreamBackendV2Enabled,
   finalizeCodexRuntimePermissions: (
-    store: HappyRuntimeStore,
+    store: RuntimeCore,
     permissionIds: Iterable<string>,
     options?: { preservePending?: boolean },
   ) => (store as unknown as { permissionRouter: PermissionRouter }).permissionRouter
     .finalizeCodexPermissions(permissionIds, options),
 };
 
-export class HappyRuntimeStore {
+export class RuntimeCore {
   private readonly claudeSessionRegistry = new ClaudeSessionRegistry();
   private readonly geminiSessionRegistry = new GeminiSessionRegistry();
   private readonly claudeSessionScanners = new Map<string, ClaudeSessionLogTracker>();

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -12,7 +12,7 @@ import type {
   SessionAction,
   SessionStatus,
 } from './types.js';
-import { HappyRuntimeStore } from './runtime/happyClient.js';
+import { RuntimeCore } from './runtime/runtimeCore.js';
 import { PrismaRuntimeStore } from './runtime/prismaStore.js';
 import { computeWorktreePath, ensureWorktree } from './runtime/worktreeManager.js';
 
@@ -127,7 +127,7 @@ interface RuntimeStoreBackend {
 }
 
 type RuntimeExecutor = Pick<
-  HappyRuntimeStore,
+  RuntimeCore,
   | 'triggerPersistedUserMessage'
   | 'listRealtimeEvents'
   | 'applySessionAction'
@@ -516,7 +516,7 @@ export class RuntimeStore {
       const internalRuntimeUrl = typeof runtimeApiUrl === 'string' && runtimeApiUrl.trim().length > 0
         ? runtimeApiUrl.trim()
         : 'http://127.0.0.1:4080';
-      this.runtimeExecutor = new HappyRuntimeStore({
+      this.runtimeExecutor = new RuntimeCore({
         serverUrl: internalRuntimeUrl,
         token: runtimeApiToken ?? '',
         workspaceRoot: defaultProjectPath,

--- a/services/aris-backend/tests/geminiAlignment.e2e.test.ts
+++ b/services/aris-backend/tests/geminiAlignment.e2e.test.ts
@@ -1,6 +1,6 @@
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, expect, it } from 'vitest';
-import { HappyRuntimeStore } from '../src/runtime/happyClient.js';
+import { RuntimeCore } from '../src/runtime/runtimeCore.js';
 
 type FakeHappySession = {
   id: string;
@@ -33,7 +33,7 @@ async function waitFor<T>(read: () => Promise<T>, predicate: (value: T) => boole
 }
 
 function createFakeGeminiStore(options: { emitAction?: boolean; emitCommentary?: boolean; requirePermission?: boolean } = {}) {
-  const store = new HappyRuntimeStore({
+  const store = new RuntimeCore({
     serverUrl: 'http://fake-happy',
     token: 'fake-token',
     workspaceRoot: '/workspace',

--- a/services/aris-backend/tests/happyAlignment.e2e.test.ts
+++ b/services/aris-backend/tests/happyAlignment.e2e.test.ts
@@ -1,6 +1,6 @@
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, expect, it } from 'vitest';
-import { HappyRuntimeStore } from '../src/runtime/happyClient.js';
+import { RuntimeCore } from '../src/runtime/runtimeCore.js';
 import type { PermissionRequest } from '../src/types.js';
 
 type FakeHappySession = {
@@ -35,7 +35,7 @@ async function waitFor<T>(read: () => Promise<T>, predicate: (value: T) => boole
 
 describe('happy alignment E2E', () => {
   it('runs a remote Claude turn through permission wait, tool ordering, and final text persistence', async () => {
-    const store = new HappyRuntimeStore({
+    const store = new RuntimeCore({
       serverUrl: 'http://fake-happy',
       token: 'fake-token',
       workspaceRoot: '/workspace',
@@ -240,7 +240,7 @@ describe('happy alignment E2E', () => {
   });
 
   it('persists Claude intermediate commentary before streamed actions and final text', async () => {
-    const store = new HappyRuntimeStore({
+    const store = new RuntimeCore({
       serverUrl: 'http://fake-happy',
       token: 'fake-token',
       workspaceRoot: '/workspace',

--- a/services/aris-backend/tests/runtimeCore.streamJson.test.ts
+++ b/services/aris-backend/tests/runtimeCore.streamJson.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { HappyRuntimeStore, happyClientTestHooks } from '../src/runtime/happyClient.js';
+import { RuntimeCore, runtimeCoreTestHooks } from '../src/runtime/runtimeCore.js';
 import { parseGeminiStreamLine } from '../src/runtime/providers/gemini/geminiProtocolMapper.js';
 
 afterEach(() => {
@@ -24,11 +24,11 @@ describe('happyClient stream-json parsing', () => {
       }),
     ].join('\n');
 
-    const parsed = happyClientTestHooks.parseAgentStreamOutput(streamOutput);
+    const parsed = runtimeCoreTestHooks.parseAgentStreamOutput(streamOutput);
     expect(parsed.output).toBe('');
     expect(parsed.actions.length).toBeGreaterThan(0);
     expect(parsed.actions[0]?.command).toContain('ls -la');
-    expect(happyClientTestHooks.looksLikeActionTranscript('$ ls -la\nexit code: 0')).toBe(true);
+    expect(runtimeCoreTestHooks.looksLikeActionTranscript('$ ls -la\nexit code: 0')).toBe(true);
   });
 
   it('parses Gemini stream-json sample into both action and assistant message', () => {
@@ -51,7 +51,7 @@ describe('happyClient stream-json parsing', () => {
       }),
     ].join('\n');
 
-    const parsed = happyClientTestHooks.parseAgentStreamOutput(streamOutput);
+    const parsed = runtimeCoreTestHooks.parseAgentStreamOutput(streamOutput);
     expect(parsed.output).toBe('README 내용을 확인했고 핵심만 요약했습니다.');
     expect(parsed.actions.length).toBeGreaterThan(0);
     expect(parsed.actions[0]?.command).toContain('cat README.md');
@@ -85,14 +85,14 @@ describe('happyClient stream-json parsing', () => {
       },
     });
 
-    expect(happyClientTestHooks.extractGeminiStreamTextEvent(parseGeminiStreamLine(commentaryLine))).toMatchObject({
+    expect(runtimeCoreTestHooks.extractGeminiStreamTextEvent(parseGeminiStreamLine(commentaryLine))).toMatchObject({
       text: '먼저 코드를 살펴보겠습니다.',
       source: 'assistant',
       threadId: 'gemini-thread',
       turnId: 'turn-1',
       itemId: 'msg-commentary',
     });
-    expect(happyClientTestHooks.extractGeminiStreamTextEvent(parseGeminiStreamLine(finalLine))).toMatchObject({
+    expect(runtimeCoreTestHooks.extractGeminiStreamTextEvent(parseGeminiStreamLine(finalLine))).toMatchObject({
       text: '최종 답변입니다.',
       source: 'assistant',
       threadId: 'gemini-thread',
@@ -116,7 +116,7 @@ describe('happyClient stream-json parsing', () => {
       },
     });
 
-    expect(happyClientTestHooks.extractGeminiStreamTextEvent(parseGeminiStreamLine(deltaLine))).toMatchObject({
+    expect(runtimeCoreTestHooks.extractGeminiStreamTextEvent(parseGeminiStreamLine(deltaLine))).toMatchObject({
       text: '실시간 ',
       source: 'assistant',
       threadId: 'gemini-thread',
@@ -137,7 +137,7 @@ describe('happyClient stream-json parsing', () => {
       },
     });
 
-    expect(happyClientTestHooks.extractGeminiStreamTextEvent(parseGeminiStreamLine(deltaLine))).toMatchObject({
+    expect(runtimeCoreTestHooks.extractGeminiStreamTextEvent(parseGeminiStreamLine(deltaLine))).toMatchObject({
       text: '중간 코멘터리 ',
       source: 'assistant',
       threadId: 'gemini-thread',
@@ -148,14 +148,14 @@ describe('happyClient stream-json parsing', () => {
   });
 
   it('skips Gemini final fallback persistence when the same text was already streamed', () => {
-    expect(happyClientTestHooks.shouldPersistFinalAgentOutput({
+    expect(runtimeCoreTestHooks.shouldPersistFinalAgentOutput({
       flavor: 'gemini',
       streamedPersisted: false,
       agentMessagePersisted: true,
       finalAgentOutput: '최종 답변',
     })).toBe(false);
 
-    expect(happyClientTestHooks.shouldPersistFinalAgentOutput({
+    expect(runtimeCoreTestHooks.shouldPersistFinalAgentOutput({
       flavor: 'gemini',
       streamedPersisted: false,
       agentMessagePersisted: false,
@@ -178,7 +178,7 @@ status: pending`,
       }),
     ].join('\n');
 
-    const parsed = happyClientTestHooks.parseAgentStreamOutput(streamOutput);
+    const parsed = runtimeCoreTestHooks.parseAgentStreamOutput(streamOutput);
     expect(parsed.output).toBe(`Sprint 2 구현 계획은 이렇습니다.
 
 ClaudeSession 객체 추가
@@ -202,7 +202,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
       }),
     ].join('\n');
 
-    const parsed = happyClientTestHooks.parseAgentStreamOutput(streamOutput);
+    const parsed = runtimeCoreTestHooks.parseAgentStreamOutput(streamOutput);
     expect(parsed.actions.length).toBe(1);
     expect(parsed.actions[0]?.callId).toBe('call-123');
     expect(parsed.actions[0]?.command).toBe('git status');
@@ -217,7 +217,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
       output: 'total 12',
     });
 
-    const parsed = happyClientTestHooks.parseAgentStreamLine(line);
+    const parsed = runtimeCoreTestHooks.parseAgentStreamLine(line);
     expect(parsed.action?.actionType).toBe('file_list');
     expect(parsed.action?.callId).toBe('call-line-1');
     expect(parsed.action?.command).toBe('ls -la');
@@ -225,13 +225,13 @@ registry/controller를 ClaudeSession 중심으로 재편`);
   });
 
   it('builds session hint meta for text and tool-call events', () => {
-    const textMeta = happyClientTestHooks.buildSessionHintMeta({
+    const textMeta = runtimeCoreTestHooks.buildSessionHintMeta({
       eventType: 'text',
     });
     expect((textMeta.sessionEvent as { ev: { t: string } }).ev.t).toBe('text');
     expect(textMeta.sessionEventType).toBe('text');
 
-    const toolMeta = happyClientTestHooks.buildSessionHintMeta({
+    const toolMeta = runtimeCoreTestHooks.buildSessionHintMeta({
       eventType: 'tool-call-end',
       callId: 'call-9',
     });
@@ -250,14 +250,14 @@ registry/controller를 ClaudeSession 중심으로 재편`);
       }),
     };
 
-    const parsed = happyClientTestHooks.parseMessagePayloadText(wrappedPayload);
+    const parsed = runtimeCoreTestHooks.parseMessagePayloadText(wrappedPayload);
     expect(parsed.role).toBe('agent');
     expect(parsed.title).toBe('Text Reply');
     expect(parsed.text).toBe('wrapped content from happy');
   });
 
   it('falls back to raw payload text when happy payload parsing fails', () => {
-    const parsed = happyClientTestHooks.parseMessagePayloadText({
+    const parsed = runtimeCoreTestHooks.parseMessagePayloadText({
       unknownShape: { foo: 'bar' },
     });
     expect(parsed.text).toContain('[UNPARSED HAPPY PAYLOAD]');
@@ -267,16 +267,16 @@ registry/controller를 ClaudeSession 중심으로 재편`);
   it('skips duplicate agent messages for the same turn only', () => {
     const seen = new Set<string>();
 
-    expect(happyClientTestHooks.shouldSkipDuplicateAgentMessage(seen, 'turn-1', 'same reply')).toBe(false);
-    expect(happyClientTestHooks.shouldSkipDuplicateAgentMessage(seen, 'turn-1', 'same reply')).toBe(true);
-    expect(happyClientTestHooks.shouldSkipDuplicateAgentMessage(seen, 'turn-1', 'different reply')).toBe(false);
-    expect(happyClientTestHooks.shouldSkipDuplicateAgentMessage(seen, 'turn-2', 'same reply')).toBe(false);
+    expect(runtimeCoreTestHooks.shouldSkipDuplicateAgentMessage(seen, 'turn-1', 'same reply')).toBe(false);
+    expect(runtimeCoreTestHooks.shouldSkipDuplicateAgentMessage(seen, 'turn-1', 'same reply')).toBe(true);
+    expect(runtimeCoreTestHooks.shouldSkipDuplicateAgentMessage(seen, 'turn-1', 'different reply')).toBe(false);
+    expect(runtimeCoreTestHooks.shouldSkipDuplicateAgentMessage(seen, 'turn-2', 'same reply')).toBe(false);
   });
 
   it('builds a stable Claude session id per session and chat', () => {
-    const first = happyClientTestHooks.buildClaudeSessionId('session-1', 'chat-1');
-    const second = happyClientTestHooks.buildClaudeSessionId('session-1', 'chat-1');
-    const otherChat = happyClientTestHooks.buildClaudeSessionId('session-1', 'chat-2');
+    const first = runtimeCoreTestHooks.buildClaudeSessionId('session-1', 'chat-1');
+    const second = runtimeCoreTestHooks.buildClaudeSessionId('session-1', 'chat-1');
+    const otherChat = runtimeCoreTestHooks.buildClaudeSessionId('session-1', 'chat-2');
 
     expect(first).toBe(second);
     expect(otherChat).not.toBe(first);
@@ -284,7 +284,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
   });
 
   it('treats workspace-root Claude paths as remote launch mode when host mapping exists', () => {
-    const launchMode = happyClientTestHooks.resolveClaudeLaunchMode({
+    const launchMode = runtimeCoreTestHooks.resolveClaudeLaunchMode({
       sessionPath: '/workspace/ARIS',
       workspaceRoot: '/workspace',
       hostProjectsRoot: '/home/ubuntu/project',
@@ -294,7 +294,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
   });
 
   it('keeps Claude launch mode local when no host mapping is configured', () => {
-    const launchMode = happyClientTestHooks.resolveClaudeLaunchMode({
+    const launchMode = runtimeCoreTestHooks.resolveClaudeLaunchMode({
       sessionPath: '/workspace/ARIS',
       workspaceRoot: '/workspace',
       hostProjectsRoot: '',
@@ -304,28 +304,28 @@ registry/controller를 ClaudeSession 중심으로 재편`);
   });
 
   it('uses a longer timeout budget for Claude turns than generic CLI agents', () => {
-    expect(happyClientTestHooks.resolveAgentCommandTimeoutMs('claude')).toBeGreaterThan(
-      happyClientTestHooks.resolveAgentCommandTimeoutMs('gemini'),
+    expect(runtimeCoreTestHooks.resolveAgentCommandTimeoutMs('claude')).toBeGreaterThan(
+      runtimeCoreTestHooks.resolveAgentCommandTimeoutMs('gemini'),
     );
   });
 
   it('uses a longer timeout budget for Gemini turns than generic CLI agents', () => {
-    expect(happyClientTestHooks.resolveAgentCommandTimeoutMs('gemini')).toBeGreaterThan(
-      happyClientTestHooks.resolveAgentCommandTimeoutMs('unknown'),
+    expect(runtimeCoreTestHooks.resolveAgentCommandTimeoutMs('gemini')).toBeGreaterThan(
+      runtimeCoreTestHooks.resolveAgentCommandTimeoutMs('unknown'),
     );
   });
 
   it('enables Gemini stream backend v2 by default and supports explicit rollback values', () => {
-    expect(happyClientTestHooks.resolveGeminiStreamBackendV2Enabled()).toBe(true);
-    expect(happyClientTestHooks.resolveGeminiStreamBackendV2Enabled('1')).toBe(true);
-    expect(happyClientTestHooks.resolveGeminiStreamBackendV2Enabled('false')).toBe(false);
-    expect(happyClientTestHooks.resolveGeminiStreamBackendV2Enabled('off')).toBe(false);
-    expect(happyClientTestHooks.resolveGeminiStreamBackendV2Enabled('0')).toBe(false);
+    expect(runtimeCoreTestHooks.resolveGeminiStreamBackendV2Enabled()).toBe(true);
+    expect(runtimeCoreTestHooks.resolveGeminiStreamBackendV2Enabled('1')).toBe(true);
+    expect(runtimeCoreTestHooks.resolveGeminiStreamBackendV2Enabled('false')).toBe(false);
+    expect(runtimeCoreTestHooks.resolveGeminiStreamBackendV2Enabled('off')).toBe(false);
+    expect(runtimeCoreTestHooks.resolveGeminiStreamBackendV2Enabled('0')).toBe(false);
   });
 
   it('does not inject --session-id for Claude when given a synthetic target', () => {
-    const sessionId = happyClientTestHooks.buildClaudeSessionId('session-2', 'chat-2');
-    const command = happyClientTestHooks.buildAgentCommand(
+    const sessionId = runtimeCoreTestHooks.buildClaudeSessionId('session-2', 'chat-2');
+    const command = runtimeCoreTestHooks.buildAgentCommand(
       'claude',
       'Reply with OK',
       'on-request',
@@ -340,7 +340,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
   });
 
   it('uses --resume for stored Claude session ids', () => {
-    const command = happyClientTestHooks.buildAgentCommand(
+    const command = runtimeCoreTestHooks.buildAgentCommand(
       'claude',
       'Reply with OK',
       'on-request',
@@ -368,7 +368,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
       }),
     ].join('\n');
 
-    const parsed = happyClientTestHooks.parseAgentStreamOutput(streamOutput);
+    const parsed = runtimeCoreTestHooks.parseAgentStreamOutput(streamOutput);
     expect(parsed.sessionId).toBe('stream-session-abc');
     expect(parsed.output).toBe('응답 완료');
   });
@@ -390,13 +390,13 @@ registry/controller를 ClaudeSession 중심으로 재편`);
       }),
     ].join('\n');
 
-    const parsed = happyClientTestHooks.parseAgentStreamOutput(streamOutput);
+    const parsed = runtimeCoreTestHooks.parseAgentStreamOutput(streamOutput);
     expect(parsed.sessionId).toBe('gemini-session-lower');
     expect(parsed.output).toBe('Gemini 응답 완료');
   });
 
   it('spawns codex app-server in its own detached process group', () => {
-    const options = happyClientTestHooks.buildCodexAppServerSpawnOptions({
+    const options = runtimeCoreTestHooks.buildCodexAppServerSpawnOptions({
       cwd: '/tmp/aris-redeploy-stream-fix',
       env: { PATH: '/usr/bin' },
       signal: undefined,
@@ -413,7 +413,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
   it('kills the detached codex app-server process group when closing', () => {
     const killMock = vi.fn();
 
-    happyClientTestHooks.terminateCodexAppServerProcess(
+    runtimeCoreTestHooks.terminateCodexAppServerProcess(
       {
         pid: 4321,
         killed: false,
@@ -426,12 +426,12 @@ registry/controller를 ClaudeSession 중심으로 재편`);
   });
 
   it('uses a loopback websocket transport URL for codex app-server', () => {
-    expect(happyClientTestHooks.buildCodexAppServerListenUrl(38991)).toBe('ws://127.0.0.1:38991');
+    expect(runtimeCoreTestHooks.buildCodexAppServerListenUrl(38991)).toBe('ws://127.0.0.1:38991');
   });
 
   it('classifies context-window app-server failures as fresh-thread retry candidates', () => {
     expect(
-      happyClientTestHooks.classifyCodexAppServerFailure(
+      runtimeCoreTestHooks.classifyCodexAppServerFailure(
         new Error("Codex ran out of room in the model's context window"),
       ),
     ).toMatchObject({
@@ -444,7 +444,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
 
   it('classifies websocket turn closures separately from startup connection failures', () => {
     expect(
-      happyClientTestHooks.classifyCodexAppServerFailure(
+      runtimeCoreTestHooks.classifyCodexAppServerFailure(
         new Error('codex app-server websocket closed before turn completion'),
       ),
     ).toMatchObject({
@@ -453,7 +453,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
     });
 
     expect(
-      happyClientTestHooks.classifyCodexAppServerFailure(
+      runtimeCoreTestHooks.classifyCodexAppServerFailure(
         new Error('codex app-server websocket connection failed'),
       ),
     ).toMatchObject({
@@ -473,7 +473,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
     ]);
     const onAbort = vi.fn();
 
-    const abortState = happyClientTestHooks.createCodexAppServerAbortPromise({
+    const abortState = runtimeCoreTestHooks.createCodexAppServerAbortPromise({
       signal: abortController.signal,
       pendingRequests,
       onAbort,
@@ -502,7 +502,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
     ]);
     const onAbort = vi.fn();
 
-    const abortState = happyClientTestHooks.createCodexAppServerAbortPromise({
+    const abortState = runtimeCoreTestHooks.createCodexAppServerAbortPromise({
       signal: abortController.signal,
       pendingRequests,
       onAbort,
@@ -525,7 +525,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
       lastActivityAt = Date.now();
     }, 100);
 
-    const waitPromise = happyClientTestHooks.waitForStableActivity({
+    const waitPromise = runtimeCoreTestHooks.waitForStableActivity({
       getActivityTick: () => activityTick,
       getLastActivityAt: () => lastActivityAt,
       quietMs: 200,
@@ -553,7 +553,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
       lastActivityAt = Date.now();
     }, 40);
 
-    const waitPromise = happyClientTestHooks.waitForStableActivity({
+    const waitPromise = runtimeCoreTestHooks.waitForStableActivity({
       getActivityTick: () => activityTick,
       getLastActivityAt: () => lastActivityAt,
       quietMs: 200,
@@ -575,7 +575,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const store = new HappyRuntimeStore({
+    const store = new RuntimeCore({
       serverUrl: 'http://runtime.test',
       token: 'token',
       workspaceRoot: '/workspace',
@@ -623,7 +623,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
       });
     vi.stubGlobal('fetch', fetchMock);
 
-    const store = new HappyRuntimeStore({
+    const store = new RuntimeCore({
       serverUrl: 'http://runtime.test',
       token: 'token',
       workspaceRoot: '/workspace',
@@ -665,7 +665,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
     const coordinationStore = {
       decidePermission: vi.fn(),
     };
-    const store = new HappyRuntimeStore({
+    const store = new RuntimeCore({
       serverUrl: 'http://runtime.test',
       token: 'token',
       workspaceRoot: '/workspace',
@@ -684,7 +684,7 @@ registry/controller를 ClaudeSession 중심으로 재편`);
     store.permissionRouter.codexPermissionResponders.set('perm-1', vi.fn());
     store.draining = true;
 
-    await happyClientTestHooks.finalizeCodexRuntimePermissions(store as never, ['perm-1'], {
+    await runtimeCoreTestHooks.finalizeCodexRuntimePermissions(store as never, ['perm-1'], {
       preservePending: true,
     });
 


### PR DESCRIPTION
## Summary

Phase 2.5 Sprint 2.5f — `happyClient.ts` → `runtimeCore.ts` 리네임 + `HappyRuntimeStore` → `RuntimeCore` 클래스명 변경. Phase 2.5의 마지막 구조적 단계.

2.5c (PermissionRouter), 2.5d (RealtimeEventBus), 2.5e (ActiveRunRegistry) 추출을 거치며 happyClient는 더 이상 "happy server HTTP client"가 아니라 ARIS 런타임 코어를 오케스트레이션하는 역할만 남았다. 이름과 책임을 일치시킨다.

## 변경

### 파일 리네임 (git mv)
- `services/aris-backend/src/runtime/happyClient.ts` → `runtimeCore.ts`
- `services/aris-backend/tests/happyClient.streamJson.test.ts` → `runtimeCore.streamJson.test.ts`

### 식별자 리네임
- `HappyRuntimeStore` 클래스 → `RuntimeCore`
- `happyClientTestHooks` export → `runtimeCoreTestHooks`

### import 경로 갱신
- `services/aris-backend/src/store.ts`
- `services/aris-backend/tests/runtimeCore.streamJson.test.ts`
- `services/aris-backend/tests/happyAlignment.e2e.test.ts`
- `services/aris-backend/tests/geminiAlignment.e2e.test.ts`

### docstring 정리
- `runtime/orchestration/{permissionRouter,realtimeEventBus,activeRunRegistry}.ts` 내 `happyClient.ts` / `HappyRuntimeStore` 참조 → 새 이름.
- `runtime/contracts/{runtimeCoordinationStore,parsedMessage}.ts` 동일.
- `runtime/providers/codex/*` 동일.
- Phase 2 Sprint 2 시점에 작성된 codex 모듈의 line-range 참조는 이미 stale 상태였고 그대로 유지(Phase 3 codex 추출 시점에 재앵커링).

## 작업 범위 외 (이 sprint에서 제외)

- **`HappyEventLogger` / `runtime/happyEventLogger.ts`** — logger는 별도 파일/테스트를 가지며, 리네임 시 로그 payload key 사용처 다수에 영향. 별도 후속 PR로 분리하는 게 깔끔.
- **`HappyBackendMessage` / `HappyMessageResponse` / `HappyRuntime*Input` 타입 별칭** — happy-server HTTP wire format을 기술. 잔존 HTTP self-fetch 메서드들이 참조 중. 2.5c-e의 후속 self-fetch 제거 작업이 마무리될 때 함께 정리.

## 안전 검증

- ✅ `npx tsc --noEmit` clean (aris-backend).
- ✅ `npx vitest run --exclude '**/*.e2e.test.ts'` **261/261 PASS** (회귀 0).
- ✅ `git mv`로 두 파일 모두 GitHub rename detection 가능 (blame history 보존).
- ✅ 13 files changed (1 RM + 12 M), 순수 mechanical rename — 동작 변경 0건.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run --exclude e2e` 261/261 PASS
- [x] 잔존 `HappyRuntimeStore` 참조 0 (`grep -r "HappyRuntimeStore" src/ tests/`)
- [x] 잔존 `happyClientTestHooks` 참조 0
- [x] 잔존 `from './runtime/happyClient.js'` import 0

## Phase 2.5 누적 결과

| Sprint | PR | 내용 |
|---|---|---|
| 2.5a | #287 | plan 문서 |
| 2.5b.1 | #288 | `'happy'` backend dead branch 제거 |
| 2.5b.2 | #289 | backend `HAPPY_SERVER_*` env 정리 |
| 2.5c | #291 | PermissionRouter 추출 |
| 2.5d | #293 | RealtimeEventBus 추출 |
| 2.5e | #294 | ActiveRunRegistry 추출 |
| **2.5f** | **이 PR** | **runtimeCore.ts 리네임** |

남은 sprint:
- 2.5g: aris-web `HAPPY_SERVER_*` fallback 제거 + `RUNTIME_API_URL` 명시 + dev/run_web_dev_hot_reload 정리.
- 2.5h: `rebuild-happy-server-bundle.sh` 삭제 + 외부 happy-server 컨테이너 cleanup (운영 단계).
- (선택) `happyEventLogger.ts` → `runtimeEventLogger.ts` 별도 PR.
- (선택) self-fetch HTTP 메서드 제거 (orchestration 추출이 완료된 시점이라 별도 PR로 가능).
