### PR TITLE
refactor(runtime-core): 2.5g - drop aris-web HAPPY_SERVER_* fallback

### DIFF
--- a/deploy/dev/run_web_dev_hot_reload.sh
+++ b/deploy/dev/run_web_dev_hot_reload.sh
@@ -124,12 +124,10 @@ else
 fi
 
 # Route web runtime calls through aris-backend by default in dev mode.
-# This keeps API surface consistent (e.g. /v1/permissions) while backend proxies to happy runtime.
-export RUNTIME_API_URL="${DEV_RUNTIME_API_URL:-${DEV_HAPPY_SERVER_URL:-http://127.0.0.1:4080}}"
+# This keeps API surface consistent (e.g. /v1/permissions).
+export RUNTIME_API_URL="${DEV_RUNTIME_API_URL:-http://127.0.0.1:4080}"
 if [[ -n "${DEV_RUNTIME_API_TOKEN:-}" ]]; then
   export RUNTIME_API_TOKEN="${DEV_RUNTIME_API_TOKEN}"
-elif [[ -n "${DEV_HAPPY_SERVER_TOKEN:-}" ]]; then
-  export RUNTIME_API_TOKEN="${DEV_HAPPY_SERVER_TOKEN}"
 fi
 
 git_ref="$(git -C "${ROOT_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")"

--- a/services/aris-web/.env.example
+++ b/services/aris-web/.env.example
@@ -19,10 +19,6 @@ DATABASE_URL=postgresql://postgres:__SET_POSTGRES_PASSWORD__@localhost:5432/aris
 RUNTIME_API_URL=http://localhost:4080
 RUNTIME_API_TOKEN=__SET_RUNTIME_API_TOKEN__
 
-# Legacy fallback names (kept temporarily for compatibility)
-# HAPPY_SERVER_URL=http://localhost:4080
-# HAPPY_SERVER_TOKEN=__SET_RUNTIME_API_TOKEN__
-
 # SSH fallback
 SSH_BASE_COMMAND=ssh ubuntu@your-server
 SSH_LINK_TTL_SECONDS=300

--- a/services/aris-web/lib/config.ts
+++ b/services/aris-web/lib/config.ts
@@ -7,8 +7,6 @@ const envSchema = z.object({
   AUTH_COOKIE_NAME: z.string().min(1).default('aris_session'),
   RUNTIME_API_URL: z.string().url().optional(),
   RUNTIME_API_TOKEN: z.string().optional(),
-  HAPPY_SERVER_URL: z.string().url().optional(),
-  HAPPY_SERVER_TOKEN: z.string().optional(),
   HOST_PROJECTS_ROOT: z.string().default(''),
   HOST_HOME_DIR: z.string().default('/home/ubuntu'),
   SSH_BASE_COMMAND: z.string().default('ssh ubuntu@your-server'),
@@ -29,15 +27,13 @@ const envSchema = z.object({
 
 type ParsedEnv = z.infer<typeof envSchema>;
 
-export function resolveRuntimeApiUrl(env: Pick<ParsedEnv, 'RUNTIME_API_URL' | 'HAPPY_SERVER_URL'>): string {
-  // RUNTIME_API_URL takes precedence. HAPPY_SERVER_URL is kept for legacy compatibility
-  // but should point to aris-backend (4080), not the happy server (3005).
-  const next = env.RUNTIME_API_URL?.trim() || env.HAPPY_SERVER_URL?.trim() || '';
+export function resolveRuntimeApiUrl(env: Pick<ParsedEnv, 'RUNTIME_API_URL'>): string {
+  const next = env.RUNTIME_API_URL?.trim() || '';
   return next || 'http://localhost:4080';
 }
 
-export function resolveRuntimeApiToken(env: Pick<ParsedEnv, 'RUNTIME_API_TOKEN' | 'HAPPY_SERVER_TOKEN'>): string | undefined {
-  const next = env.RUNTIME_API_TOKEN?.trim() || env.HAPPY_SERVER_TOKEN?.trim() || '';
+export function resolveRuntimeApiToken(env: Pick<ParsedEnv, 'RUNTIME_API_TOKEN'>): string | undefined {
+  const next = env.RUNTIME_API_TOKEN?.trim() || '';
   return next || undefined;
 }
 

--- a/services/aris-web/server.mjs
+++ b/services/aris-web/server.mjs
@@ -32,8 +32,8 @@ if (dev && devProxyAssetPrefix.changed) {
 
 const JWT_SECRET = process.env.AUTH_JWT_SECRET || 'dev-only-jwt-secret-dev-only-jwt-secret';
 const AUTH_COOKIE_NAME = process.env.AUTH_COOKIE_NAME || 'aris_session';
-const RUNTIME_API_URL = process.env.RUNTIME_API_URL || process.env.HAPPY_SERVER_URL || 'http://localhost:4080';
-const RUNTIME_API_TOKEN = process.env.RUNTIME_API_TOKEN || process.env.HAPPY_SERVER_TOKEN || '';
+const RUNTIME_API_URL = process.env.RUNTIME_API_URL || 'http://localhost:4080';
+const RUNTIME_API_TOKEN = process.env.RUNTIME_API_TOKEN || '';
 const SSH_KEY_ENCRYPTION_SECRET = process.env.SSH_KEY_ENCRYPTION_SECRET || 'dev-only-ssh-enc-secret-change-me';
 const SSH_HOST = process.env.SSH_HOST || 'host.docker.internal';
 const LOCAL_PREVIEW_PREFIX = '/__local_preview';

--- a/services/aris-web/tests/runtimeApiConfig.test.ts
+++ b/services/aris-web/tests/runtimeApiConfig.test.ts
@@ -2,39 +2,33 @@ import { describe, expect, it } from 'vitest';
 import { resolveRuntimeApiToken, resolveRuntimeApiUrl } from '@/lib/config';
 
 describe('runtime api env resolution', () => {
-  it('prefers explicit runtime api values', () => {
+  it('uses RUNTIME_API_URL when set', () => {
     expect(resolveRuntimeApiUrl({
       RUNTIME_API_URL: 'http://127.0.0.1:4080',
-      HAPPY_SERVER_URL: 'http://127.0.0.1:3005',
     })).toBe('http://127.0.0.1:4080');
 
     expect(resolveRuntimeApiToken({
       RUNTIME_API_TOKEN: 'runtime-token',
-      HAPPY_SERVER_TOKEN: 'legacy-token',
     })).toBe('runtime-token');
-  });
-
-  it('falls back to legacy happy env names', () => {
-    expect(resolveRuntimeApiUrl({
-      RUNTIME_API_URL: undefined,
-      HAPPY_SERVER_URL: 'http://127.0.0.1:4080',
-    })).toBe('http://127.0.0.1:4080');
-
-    expect(resolveRuntimeApiToken({
-      RUNTIME_API_TOKEN: undefined,
-      HAPPY_SERVER_TOKEN: 'legacy-token',
-    })).toBe('legacy-token');
   });
 
   it('uses defaults when runtime api env is missing', () => {
     expect(resolveRuntimeApiUrl({
       RUNTIME_API_URL: undefined,
-      HAPPY_SERVER_URL: undefined,
     })).toBe('http://localhost:4080');
 
     expect(resolveRuntimeApiToken({
       RUNTIME_API_TOKEN: undefined,
-      HAPPY_SERVER_TOKEN: undefined,
+    })).toBeUndefined();
+  });
+
+  it('treats whitespace-only RUNTIME_API_URL as missing', () => {
+    expect(resolveRuntimeApiUrl({
+      RUNTIME_API_URL: '   ',
+    })).toBe('http://localhost:4080');
+
+    expect(resolveRuntimeApiToken({
+      RUNTIME_API_TOKEN: '   ',
     })).toBeUndefined();
   });
 });

--- a/services/aris-web/tests/sessionEventsFetchLimit.test.ts
+++ b/services/aris-web/tests/sessionEventsFetchLimit.test.ts
@@ -4,24 +4,18 @@ describe('getSessionEvents fetch limits', () => {
   const originalEnv = {
     RUNTIME_API_URL: process.env.RUNTIME_API_URL,
     RUNTIME_API_TOKEN: process.env.RUNTIME_API_TOKEN,
-    HAPPY_SERVER_URL: process.env.HAPPY_SERVER_URL,
-    HAPPY_SERVER_TOKEN: process.env.HAPPY_SERVER_TOKEN,
   };
 
   beforeEach(() => {
     vi.resetModules();
     process.env.RUNTIME_API_URL = 'http://runtime.test';
     process.env.RUNTIME_API_TOKEN = 'test-token';
-    process.env.HAPPY_SERVER_URL = 'http://runtime.test';
-    process.env.HAPPY_SERVER_TOKEN = 'test-token';
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
     process.env.RUNTIME_API_URL = originalEnv.RUNTIME_API_URL;
     process.env.RUNTIME_API_TOKEN = originalEnv.RUNTIME_API_TOKEN;
-    process.env.HAPPY_SERVER_URL = originalEnv.HAPPY_SERVER_URL;
-    process.env.HAPPY_SERVER_TOKEN = originalEnv.HAPPY_SERVER_TOKEN;
   });
 
   it('clamps chat-scoped session message fetches to the Happy API max page size', async () => {


### PR DESCRIPTION
## Summary

Phase 2.5 Sprint 2.5g — aris-web의 `HAPPY_SERVER_URL`/`HAPPY_SERVER_TOKEN` legacy fallback 제거. 2.5b.2에서 backend가, 2.5c–f에서 runtime core가 happy 명칭에서 벗어났고, aris-web가 legacy 명칭을 유지하던 마지막 표면이라 정리.

## 변경

### `services/aris-web/lib/config.ts`
- `envSchema`에서 `HAPPY_SERVER_URL`, `HAPPY_SERVER_TOKEN` 제거.
- `resolveRuntimeApiUrl`/`resolveRuntimeApiToken`의 `Pick`을 `RUNTIME_API_*`로만 좁힘.
- last-resort default(`'http://localhost:4080'` / `undefined`)는 보존.

### `services/aris-web/server.mjs`
- `process.env.HAPPY_SERVER_URL`/`TOKEN` fallback 제거.
- 기존 `'http://localhost:4080'` default가 양 환경변수가 없을 때를 이미 처리.

### `services/aris-web/.env.example`
- "Legacy fallback names" 주석 블록(`HAPPY_SERVER_URL`/`TOKEN`) 제거.

### `services/aris-web/tests/runtimeApiConfig.test.ts`
- "falls back to legacy happy env names" 테스트 삭제.
- `RUNTIME_API_URL` 단독 동작에 대한 positive / negative / whitespace 케이스로 재구성.

### `services/aris-web/tests/sessionEventsFetchLimit.test.ts`
- `HAPPY_SERVER_*` env scaffolding 제거.

### `deploy/dev/run_web_dev_hot_reload.sh`
- `DEV_HAPPY_SERVER_URL`/`TOKEN` fallback 제거. `DEV_RUNTIME_API_URL` 미설정 시 `http://127.0.0.1:4080` default 유지.

## 작업 범위 외 (2.5h)

- `deploy/.env`의 `HAPPY_SERVER_*` 라인 (gitignore되어 있음 — 런타임 도구가 더 이상 안 읽으므로 무해, 2.5h에서 운영 도구와 함께 정리)
- `deploy/ops/rebuild-happy-server-bundle.sh` 삭제
- `deploy/ops/debug-runbook.md`의 `HAPPY_SERVER_URL` 다이어그램 갱신

## 안전 검증

- ✅ aris-backend: `tsc --noEmit` clean, `vitest --exclude e2e` 261/261 PASS.
- ✅ aris-web: `tsc --noEmit` clean, `vitest run` **462 PASS / 4 FAIL** — main과 정확히 동일한 사전 회귀 4건(sessionEventsRoute, designSystemV3Implementation, mobileOverflowLayout). **본 PR로 인한 새 회귀 0건**.
- ✅ aris-web의 prod env에 `RUNTIME_API_URL`이 설정 안 되어 있어도 default `'http://localhost:4080'`이 작동.

## Test plan

- [x] aris-backend tsc + vitest clean
- [x] aris-web tsc clean, vitest 회귀 0
- [x] config.ts resolver 단독 테스트 갱신 (3 케이스)
- [x] dev hot reload 스크립트 syntax 호환

## Definition of Done (이 PR)

- [x] aris-web이 더 이상 `HAPPY_SERVER_*` env 읽지 않음
- [x] dev hot reload가 `DEV_HAPPY_SERVER_*` fallback 사용 안 함
- [x] tsc + vitest clean (회귀 0)
- [ ] 머지 후 2.5h 진행 (`rebuild-happy-server-bundle.sh` 삭제 + debug-runbook 갱신)
