### PR TITLE
fix(aris-web): hide horizontal scrollbar on project tabs nav

### DIFF
--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -2235,6 +2235,11 @@ html[data-theme='dark'] .proj-list-card--new:focus-visible {
   border-bottom: 1px solid var(--border-subtle);
   background: var(--surface);
   overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.proj-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .proj-tab {
@@ -6102,11 +6107,6 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
     max-width: 100%;
     width: 100%;
     padding: 0 var(--sp-8);
-    scrollbar-width: none;
-  }
-
-  .proj-tabs::-webkit-scrollbar {
-    display: none;
   }
 
   .proj-tab {


### PR DESCRIPTION
## Summary
프로젝트 상세 페이지의 \`Chats / Files / Context / Overview\` 탭 내비게이션에 가로 스크롤바가 보이는 문제 수정.

## Root cause
\`.proj-tabs\`가 \`overflow-x: auto\`로 설정돼 좁은 뷰포트에서 가로 스크롤이 가능했지만, scrollbar 숨김 규칙이 모바일 미디어 쿼리에만 있어 데스크톱에서는 스크롤바가 그대로 노출됐다.

## Fix
- base \`.proj-tabs\`에 \`scrollbar-width: none\` + \`::-webkit-scrollbar { display: none }\` 추가
- 모바일 쿼리의 중복 규칙 제거

## Test plan
- [ ] 데스크톱에서 프로젝트 상세 진입 → 탭 nav에 스크롤바 없는지 확인
- [ ] 모바일 뷰포트에서도 스크롤바 없이 좌우 스와이프 가능한지 확인