### PR TITLE
refactor(runtime-core): rename HappyEventLogger to RuntimeEventLogger

### DIFF
--- a/services/aris-backend/src/runtime/runtimeCore.ts
+++ b/services/aris-backend/src/runtime/runtimeCore.ts
@@ -9,7 +9,7 @@ import { promisify } from 'node:util';
 import { inferActionTypeFromCommand, titleForActionType } from './actionType.js';
 import { sanitizeAgentMessageText, shouldDisplayToolStatus } from './agentMessageSanitizer.js';
 import { summarizeDiffText, summarizeFileChangeDiff } from './diffStats.js';
-import { HappyEventLogger } from './happyEventLogger.js';
+import { RuntimeEventLogger } from './runtimeEventLogger.js';
 import { resolveRuntimeModelSelection } from './modelPolicy.js';
 import { recoverClaudeThreadIdFromMessages, runClaudeProviderTurn } from './providers/claude/claudeOrchestrator.js';
 import {
@@ -1899,7 +1899,7 @@ export class RuntimeCore {
   private readonly serverToken: string;
   private readonly workspaceRoot: string;
   private readonly hostProjectsRoot: string;
-  private readonly happyEventLogger: HappyEventLogger;
+  private readonly runtimeEventLogger: RuntimeEventLogger;
   private readonly activeRunRegistry: ActiveRunRegistry;
 
   // listSessions() 응답을 1초간 캐시하여 getSession() 호출 시 happy-server 왕복을 줄임
@@ -1918,7 +1918,7 @@ export class RuntimeCore {
     this.workspaceRoot = (opts.workspaceRoot || '/workspace').replace(/\/+$/, '');
     this.hostProjectsRoot = (opts.hostProjectsRoot || '').replace(/\/+$/, '');
     this.coordinationStore = opts.coordinationStore ?? null;
-    this.happyEventLogger = new HappyEventLogger(HAPPY_EVENT_LOG_DIR, HAPPY_EVENT_LOG_MAX_BYTES);
+    this.runtimeEventLogger = new RuntimeEventLogger(HAPPY_EVENT_LOG_DIR, HAPPY_EVENT_LOG_MAX_BYTES);
     this.permissionRouter = new PermissionRouter({
       coordinationStore: this.coordinationStore,
       getSession: (sessionId) => this.getSession(sessionId),
@@ -2150,7 +2150,7 @@ export class RuntimeCore {
 
   private async handleStaleRunCleanup(input: StaleRunCleanupInput): Promise<void> {
     const channel = input.agent === 'codex' && CODEX_RUNTIME_MODE !== 'exec' ? 'app_server' : 'exec_cli';
-    this.happyEventLogger.logParsed({
+    this.runtimeEventLogger.logParsed({
       sessionId: input.sessionId,
       agent: input.agent,
       ...(input.chatId ? { chatId: input.chatId } : {}),
@@ -2863,7 +2863,7 @@ export class RuntimeCore {
         ? ((event, meta) => input.onText!(event, meta))
         : undefined,
       onRawLine: (line) => {
-        this.happyEventLogger.logRaw({
+        this.runtimeEventLogger.logRaw({
           sessionId: input.session.id,
           agent: 'gemini',
           ...(input.chatId ? { chatId: input.chatId } : {}),
@@ -2992,7 +2992,7 @@ export class RuntimeCore {
         this.codexThreads.delete(threadCacheKey);
       }
       if (failure.retryWithFreshThread && hadThreadId) {
-        this.happyEventLogger.logParsed({
+        this.runtimeEventLogger.logParsed({
           sessionId: session.id,
           agent: 'codex',
           ...(chatId ? { chatId } : {}),
@@ -3010,7 +3010,7 @@ export class RuntimeCore {
         return this.runCodexAppServerWithEvents(session, prompt, signal, undefined, chatId, model, modelReasoningEffort);
       }
 
-      this.happyEventLogger.logParsed({
+      this.runtimeEventLogger.logParsed({
         sessionId: session.id,
         agent: 'codex',
         ...(chatId ? { chatId } : {}),
@@ -3067,7 +3067,7 @@ export class RuntimeCore {
       args,
       signal,
     });
-    this.happyEventLogger.logParsed({
+    this.runtimeEventLogger.logParsed({
       sessionId: session.id,
       agent: 'codex',
       ...(chatId ? { chatId } : {}),
@@ -3144,7 +3144,7 @@ export class RuntimeCore {
       meta: Record<string, unknown>,
       options: { type?: string; title?: string } = {},
     ) => {
-      this.happyEventLogger.logParsed({
+      this.runtimeEventLogger.logParsed({
         sessionId: session.id,
         agent: 'codex',
         ...(chatId ? { chatId } : {}),
@@ -3560,7 +3560,7 @@ export class RuntimeCore {
 
         const status = asString(turn?.status, '').trim() || 'completed';
         const errorMessage = asString(asRecord(turn?.error)?.message, '').trim() || undefined;
-        this.happyEventLogger.logParsed({
+        this.runtimeEventLogger.logParsed({
           sessionId: session.id,
           agent: 'codex',
           ...(chatId ? { chatId } : {}),
@@ -3583,7 +3583,7 @@ export class RuntimeCore {
       transportActivityTick += 1;
       lastTransportActivityAt = Date.now();
       const rawLine = rawText.trim();
-      this.happyEventLogger.logRaw({
+      this.runtimeEventLogger.logRaw({
         sessionId: session.id,
         agent: 'codex',
         ...(chatId ? { chatId } : {}),
@@ -3593,7 +3593,7 @@ export class RuntimeCore {
       });
       const payload = parseJsonLine(rawLine);
       if (!payload) {
-        this.happyEventLogger.logParsed({
+        this.runtimeEventLogger.logParsed({
           sessionId: session.id,
           agent: 'codex',
           ...(chatId ? { chatId } : {}),
@@ -3604,7 +3604,7 @@ export class RuntimeCore {
         });
         return;
       }
-      this.happyEventLogger.logParsed({
+      this.runtimeEventLogger.logParsed({
         sessionId: session.id,
         agent: 'codex',
         ...(chatId ? { chatId } : {}),
@@ -3769,7 +3769,7 @@ export class RuntimeCore {
         approvalPolicy: codexApprovalPolicy,
       });
       activeTurnId = asString(asRecord(turnStarted.turn)?.id, '').trim();
-      this.happyEventLogger.logParsed({
+      this.runtimeEventLogger.logParsed({
         sessionId: session.id,
         agent: 'codex',
         ...(chatId ? { chatId } : {}),
@@ -3857,7 +3857,7 @@ export class RuntimeCore {
           runErrorMessage = 'turn did not complete before process close';
           runFailureKind = 'websocket_closed';
         }
-        this.happyEventLogger.logParsed({
+        this.runtimeEventLogger.logParsed({
           sessionId: session.id,
           agent: 'codex',
           ...(chatId ? { chatId } : {}),
@@ -3878,7 +3878,7 @@ export class RuntimeCore {
           console.error(`codex app-server transport closed early; pid=${appServerPid} listenUrl=${listenUrl}`);
         }
       }
-      this.happyEventLogger.logParsed({
+      this.runtimeEventLogger.logParsed({
         sessionId: session.id,
         agent: 'codex',
         ...(chatId ? { chatId } : {}),
@@ -3938,7 +3938,7 @@ export class RuntimeCore {
       stdio: ['pipe', 'pipe', 'pipe'],
       signal,
     });
-    this.happyEventLogger.logParsed({
+    this.runtimeEventLogger.logParsed({
       sessionId: session.id,
       agent: 'codex',
       ...(chatId ? { chatId } : {}),
@@ -3969,7 +3969,7 @@ export class RuntimeCore {
       meta: Record<string, unknown>,
       options: { type?: string; title?: string } = {},
     ) => {
-      this.happyEventLogger.logParsed({
+      this.runtimeEventLogger.logParsed({
         sessionId: session.id,
         agent: 'codex',
         ...(chatId ? { chatId } : {}),
@@ -4032,7 +4032,7 @@ export class RuntimeCore {
 
     stdoutLines.on('line', (line) => {
       const rawLine = line.trim();
-      this.happyEventLogger.logRaw({
+      this.runtimeEventLogger.logRaw({
         sessionId: session.id,
         agent: 'codex',
         ...(chatId ? { chatId } : {}),
@@ -4042,7 +4042,7 @@ export class RuntimeCore {
       });
       const payload = parseJsonLine(rawLine);
       if (!payload) {
-        this.happyEventLogger.logParsed({
+        this.runtimeEventLogger.logParsed({
           sessionId: session.id,
           agent: 'codex',
           ...(chatId ? { chatId } : {}),
@@ -4053,7 +4053,7 @@ export class RuntimeCore {
         });
         return;
       }
-      this.happyEventLogger.logParsed({
+      this.runtimeEventLogger.logParsed({
         sessionId: session.id,
         agent: 'codex',
         ...(chatId ? { chatId } : {}),
@@ -4210,7 +4210,7 @@ export class RuntimeCore {
 
     const finalText = sanitizeAgentMessageText(lastAgentMessage.trim());
     if (signal?.aborted) {
-      this.happyEventLogger.logParsed({
+      this.runtimeEventLogger.logParsed({
         sessionId: session.id,
         agent: 'codex',
         ...(chatId ? { chatId } : {}),
@@ -4233,7 +4233,7 @@ export class RuntimeCore {
 
     if (result.code !== 0 && !finalText) {
       const detail = stripAnsi(stderr).slice(0, 800) || `exit code ${result.code}`;
-      this.happyEventLogger.logParsed({
+      this.runtimeEventLogger.logParsed({
         sessionId: session.id,
         agent: 'codex',
         ...(chatId ? { chatId } : {}),
@@ -4250,7 +4250,7 @@ export class RuntimeCore {
       throw new Error(`codex CLI failed: ${detail}`);
     }
 
-    this.happyEventLogger.logParsed({
+    this.runtimeEventLogger.logParsed({
       sessionId: session.id,
       agent: 'codex',
       ...(chatId ? { chatId } : {}),
@@ -4361,7 +4361,7 @@ export class RuntimeCore {
       ? normalizeModelReasoningEffort(context.modelReasoningEffort)
       : undefined;
     if (modelSelection.source !== 'requested') {
-      this.happyEventLogger.logParsed({
+      this.runtimeEventLogger.logParsed({
         sessionId: session.id,
         agent: flavor,
         ...(scopedChatId ? { chatId: scopedChatId } : {}),
@@ -4706,7 +4706,7 @@ export class RuntimeCore {
             session: geminiSession,
             chatId: scopedChatId,
           });
-          this.happyEventLogger.logParsed({
+          this.runtimeEventLogger.logParsed({
             sessionId: session.id,
             agent: 'gemini',
             ...(scopedChatId ? { chatId: scopedChatId } : {}),
@@ -4720,7 +4720,7 @@ export class RuntimeCore {
               requestedThreadId,
             },
           });
-          this.happyEventLogger.logParsed({
+          this.runtimeEventLogger.logParsed({
             sessionId: session.id,
             agent: 'gemini',
             ...(scopedChatId ? { chatId: scopedChatId } : {}),
@@ -4759,7 +4759,7 @@ export class RuntimeCore {
                   threadId: meta.threadId,
                 },
               });
-              this.happyEventLogger.logParsed({
+              this.runtimeEventLogger.logParsed({
                 sessionId: session.id,
                 agent: 'gemini',
                 ...(scopedChatId ? { chatId: scopedChatId } : {}),
@@ -4813,7 +4813,7 @@ export class RuntimeCore {
                 streamedGeminiCompletedTextPersisted = true;
               }
               const isCommentaryText = event.phase === 'commentary';
-              this.happyEventLogger.logParsed({
+              this.runtimeEventLogger.logParsed({
                 sessionId: session.id,
                 agent: 'gemini',
                 ...(scopedChatId ? { chatId: scopedChatId } : {}),
@@ -4843,7 +4843,7 @@ export class RuntimeCore {
               await geminiMessageQueue?.flush();
             },
           });
-          this.happyEventLogger.logParsed({
+          this.runtimeEventLogger.logParsed({
             sessionId: session.id,
             agent: 'gemini',
             ...(scopedChatId ? { chatId: scopedChatId } : {}),

--- a/services/aris-backend/src/runtime/runtimeEventLogger.ts
+++ b/services/aris-backend/src/runtime/runtimeEventLogger.ts
@@ -40,7 +40,7 @@ export type HappyParsedLogRecord = {
   payload: unknown;
 };
 
-export class HappyEventLogger {
+export class RuntimeEventLogger {
   private readonly logsDir: string;
 
   private readonly maxBytes: number;

--- a/services/aris-backend/tests/runtimeEventLogger.test.ts
+++ b/services/aris-backend/tests/runtimeEventLogger.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:f
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { HappyEventLogger } from '../src/runtime/happyEventLogger.js';
+import { RuntimeEventLogger } from '../src/runtime/runtimeEventLogger.js';
 
 const tempDirs: string[] = [];
 
@@ -32,7 +32,7 @@ function collectNdjsonFiles(dir: string): string[] {
   return collectNdjsonFilesRecursively(dir, files);
 }
 
-describe('HappyEventLogger', () => {
+describe('RuntimeEventLogger', () => {
   afterEach(() => {
     while (tempDirs.length > 0) {
       const dir = tempDirs.pop();
@@ -44,7 +44,7 @@ describe('HappyEventLogger', () => {
 
   it('writes raw and parsed records into separate ndjson files', () => {
     const logsDir = createTempLogsDir();
-    const logger = new HappyEventLogger(logsDir, 10_000);
+    const logger = new RuntimeEventLogger(logsDir, 10_000);
 
     logger.logRaw({
       sessionId: 's1',
@@ -85,7 +85,7 @@ describe('HappyEventLogger', () => {
 
   it('prunes oldest ndjson logs when total size exceeds configured limit', () => {
     const logsDir = createTempLogsDir();
-    const logger = new HappyEventLogger(logsDir, 350);
+    const logger = new RuntimeEventLogger(logsDir, 350);
 
     for (let index = 0; index < 12; index += 1) {
       logger.logRaw({


### PR DESCRIPTION
## Summary

Phase 2.5의 cosmetic 후속 — `HappyEventLogger`를 `RuntimeEventLogger`로 리네임. 2.5f에서 `happyClient.ts`/`HappyRuntimeStore` 리네임 후 aris-backend에 남은 마지막 "happy" 명칭 코드 표면.

## 변경

### 파일 리네임
- `services/aris-backend/src/runtime/happyEventLogger.ts` → `runtimeEventLogger.ts`
- `services/aris-backend/tests/happyEventLogger.test.ts` → `runtimeEventLogger.test.ts`

### 식별자 리네임
- 클래스 `HappyEventLogger` → `RuntimeEventLogger`
- 필드 `this.happyEventLogger` → `this.runtimeEventLogger` (runtimeCore.ts의 32 사용처)

### import 경로
- `'../src/runtime/happyEventLogger.js'` / `'./happyEventLogger.js'` 경로 갱신

## 작업 범위 외

- **`HAPPY_EVENT_LOG_DIR` / `HAPPY_EVENT_LOG_MAX_BYTES` 모듈 상수**: `process.env.HAPPY_EVENT_LOG_MAX_BYTES`를 읽음. 운영자가 prod 호스트에 설정해 두었을 수 있어 backward-compat 깨면 위험. 환경변수 명을 legacy로 문서화한 후 정리하는 별도 작업으로 이연.
- **`HAPPY_MESSAGE_*`, `HAPPY_RUNTIME_*` 상수들**: 잔존 self-fetch HTTP 메서드 + happy-server wire format 묘사. self-fetch 제거 트랙에서 함께 정리.
- **ndjson 로그 파일명 `chat-{agent}-{chatId}-{threadId}-parsed.ndjson`**: 클래스명과 독립적이라 영향 없음. 외부 도구(`debug-chat-log.sh`) 호환 유지.

## 안전 검증

- ✅ aris-backend `tsc --noEmit` clean.
- ✅ `vitest run --exclude e2e` **261/261 PASS** (회귀 0).
- ✅ git rename detection 작동 (blame history 보존).
- ✅ 3 files changed, +35 -35 (순수 mechanical rename).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run --exclude e2e` 261/261 PASS
- [x] grep으로 `HappyEventLogger` 잔존 0
- [x] grep으로 `happyEventLogger` 잔존 0 (filename + field 모두)
