### PR TITLE
fix(aris-web): stretch project detail layout edge-to-edge

### DIFF
--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -929,6 +929,10 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
   perspective-origin: 50% 35%;
 }
 
+.m-main-scroll--project-detail {
+  padding: 0;
+}
+
 .m-main-scroll--project-chat-detail {
   overflow: hidden;
   padding: 0;


### PR DESCRIPTION
## Summary
프로젝트 상세 페이지 탭 nav가 화면 가로 전체를 채우도록 수정.

## Root cause
`.m-main-scroll` 기본 `padding: var(--sp-16)`이 데스크톱에서 `.m-main-scroll--project-detail`에도 적용돼 탭 바가 좌우로 축소됐다. 모바일 미디어 쿼리에는 이미 `padding: 0` override가 있었지만 데스크톱에는 없었다.

## Fix
데스크톱에도 `.m-main-scroll--project-detail { padding: 0 }` 추가. `proj-head` / `proj-tabs` / `proj-pane`은 각자 내부 padding을 갖고 있어 콘텐츠 정렬 변화 없음.

## Test plan
- [ ] 데스크톱에서 프로젝트 진입 → 탭 nav가 화면 가로 전체를 채우는지 확인
- [ ] proj-head, proj-pane 내부 여백이 유지되는지 확인