### PR TITLE
perf(deploy): parallel backend+web deploy when no schema changes

### DIFF
--- a/deploy/deploy_zero_downtime.sh
+++ b/deploy/deploy_zero_downtime.sh
@@ -3,7 +3,70 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-"${ROOT_DIR}/deploy/deploy_backend_zero_downtime.sh"
-"${ROOT_DIR}/deploy/deploy_web.sh"
+# Run backend and web deploys in parallel when no Prisma schema migrations are
+# present in the last commit. Set PARALLEL_DEPLOY=0 to force sequential, or
+# ARIS_SCHEMA_CHANGED=1/0 to override automatic detection.
+PARALLEL_DEPLOY="${PARALLEL_DEPLOY:-1}"
+
+has_schema_change() {
+  if [[ "${ARIS_SCHEMA_CHANGED:-}" == "1" ]]; then
+    return 0
+  fi
+  if [[ "${ARIS_SCHEMA_CHANGED:-}" == "0" ]]; then
+    return 1
+  fi
+  if git -C "$ROOT_DIR" rev-parse HEAD >/dev/null 2>&1; then
+    local changed
+    changed="$(git -C "$ROOT_DIR" diff --name-only HEAD~1..HEAD 2>/dev/null || true)"
+    if echo "$changed" | grep -qE '^services/aris-backend/prisma/migrations/'; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+run_parallel() {
+  local backend_log web_log
+  backend_log="$(mktemp /tmp/aris-deploy-backend-XXXXXX.log)"
+  web_log="$(mktemp /tmp/aris-deploy-web-XXXXXX.log)"
+
+  "${ROOT_DIR}/deploy/deploy_backend_zero_downtime.sh" >"$backend_log" 2>&1 &
+  local backend_pid=$!
+
+  "${ROOT_DIR}/deploy/deploy_web.sh" >"$web_log" 2>&1 &
+  local web_pid=$!
+
+  local backend_exit=0 web_exit=0
+  wait "$backend_pid" || backend_exit=$?
+  wait "$web_pid"     || web_exit=$?
+
+  echo "[deploy:zero-downtime] --- backend log ---"
+  cat "$backend_log"
+  echo "[deploy:zero-downtime] --- web log ---"
+  cat "$web_log"
+  rm -f "$backend_log" "$web_log"
+
+  if [[ "$backend_exit" -ne 0 ]]; then
+    echo "[deploy:zero-downtime] backend deploy FAILED (exit ${backend_exit})" >&2
+    return 1
+  fi
+  if [[ "$web_exit" -ne 0 ]]; then
+    echo "[deploy:zero-downtime] web deploy FAILED (exit ${web_exit})" >&2
+    return 1
+  fi
+}
+
+if [[ "$PARALLEL_DEPLOY" == "1" ]] && ! has_schema_change; then
+  echo "[deploy:zero-downtime] no schema changes detected — running backend+web in parallel"
+  run_parallel
+else
+  if has_schema_change; then
+    echo "[deploy:zero-downtime] schema changes detected — running backend first, then web"
+  else
+    echo "[deploy:zero-downtime] PARALLEL_DEPLOY=0 — running sequentially"
+  fi
+  "${ROOT_DIR}/deploy/deploy_backend_zero_downtime.sh"
+  "${ROOT_DIR}/deploy/deploy_web.sh"
+fi
 
 echo "[deploy:zero-downtime] complete"


### PR DESCRIPTION
## 변경 요약

`deploy/deploy_zero_downtime.sh`에 backend + web 병렬 배포 지원 추가.

### 기존 동작

```
backend (PM2 reload, ~2분) → web (Docker 빌드+blue/green swap, ~4분) = 총 ~6분
```

### 변경 후

스키마 변경이 없으면 두 단계를 동시에 실행:

```
backend ──┐
           ├── 병렬 ──→ max(~2분, ~4분) = ~4분  (-2분, -33%)
web ───────┘
```

스키마 변경이 있는 커밋에서는 기존 직렬 순서 유지 (backend 먼저, 그 후 web의 prisma migrate 실행).

### 제어 환경변수

| 변수 | 값 | 동작 |
|---|---|---|
| `PARALLEL_DEPLOY` | `0` | 항상 직렬 강제 |
| `ARIS_SCHEMA_CHANGED` | `1` | 직렬 강제 (migration 있음으로 간주) |
| `ARIS_SCHEMA_CHANGED` | `0` | 병렬 강제 (git 감지 스킵) |

기본(`PARALLEL_DEPLOY=1`, `ARIS_SCHEMA_CHANGED` 미설정): `services/aris-backend/prisma/migrations/` 변경 여부를 `HEAD~1..HEAD` diff로 자동 감지.

### 출력 형식

병렬 실행 시 각 프로세스 로그를 임시 파일에 캡처 후 순서대로(backend → web) 출력. 어느 한쪽이라도 실패하면 비정상 종료.

### 검증

- `bash -n deploy/deploy_zero_downtime.sh` → OK
- 케이스별 단위 테스트:
  - 스키마 변경 없음 → NOT DETECTED (병렬) ✓
  - `ARIS_SCHEMA_CHANGED=1` → DETECTED (직렬) ✓
  - `ARIS_SCHEMA_CHANGED=0` → NOT DETECTED (병렬) ✓
  - `PARALLEL_DEPLOY=0` → 직렬 ✓

### 관련 PR

- PR #290: web fingerprint scope + healthcheck (production 적용 완료)
- PR #301: GHA paths-filter + build cache TTL 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)
