### PR TITLE
refactor(provider-arch): phase 2 sprint 3 - codex protocol mapper

### DIFF
--- a/services/aris-backend/src/runtime/providers/codex/codexProtocolMapper.ts
+++ b/services/aris-backend/src/runtime/providers/codex/codexProtocolMapper.ts
@@ -1,0 +1,870 @@
+/**
+ * Codex protocol mapper — pure functions.
+ *
+ * Extracts and centralises codex-specific protocol parsing logic that was
+ * previously inlined in `runtimeCore.ts`. Every exported function is pure
+ * (no side effects, no I/O, no state mutation). State changes (thread-ID
+ * caching, permission routing, message persistence) are expressed as
+ * `ParsedMessageSideEffect` descriptors returned to the caller for
+ * dispatch.
+ *
+ * Two channels handled:
+ *   exec       — `codex exec --json` stdout, one JSON object per newline.
+ *   app-server — WebSocket JSON-RPC notifications from the codex
+ *                `app-server` process.
+ *
+ * Fixture-backed conformance tests: `tests/codexProtocolMapper.test.ts`.
+ *
+ * Phase 2 Sprint 3. Sprint 6 will wire `CodexAdapter.parseStdout()` to
+ * call `parseCodexExecLine` and route each returned `ParsedMessage` to
+ * the appropriate dispatcher in `runtimeCore.ts`.
+ */
+
+import type { ParsedMessage } from '../../contracts/parsedMessage.js';
+import type {
+  SessionProtocolStopReason,
+} from '../../contracts/sessionProtocol.js';
+import type { PermissionRisk } from '../../../types.js';
+import { inferActionTypeFromCommand, titleForActionType } from '../../actionType.js';
+import { sanitizeAgentMessageText, shouldDisplayToolStatus } from '../../agentMessageSanitizer.js';
+import { summarizeDiffText, summarizeFileChangeDiff } from '../../diffStats.js';
+import { parseCodexJsonLine } from './codexProtocolFields.js';
+import type { CodexPermissionRequest } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Self-contained micro-utilities (not re-exported from a shared module yet)
+// ---------------------------------------------------------------------------
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null
+    && value !== undefined
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+function unwrapShellCmd(command: string): string {
+  let current = command.trim();
+  if (current.startsWith('$ ')) {
+    current = current.slice(2).trim();
+  }
+  const wrappers = [
+    /^(?:\/bin\/)?bash\s+-lc\s+([\s\S]+)$/i,
+    /^(?:\/bin\/)?sh\s+-lc\s+([\s\S]+)$/i,
+  ];
+  for (const wrapper of wrappers) {
+    const match = current.match(wrapper);
+    if (!match) {
+      continue;
+    }
+    const inner = match[1]?.trim() ?? '';
+    current =
+      (inner.startsWith('"') && inner.endsWith('"'))
+      || (inner.startsWith("'") && inner.endsWith("'"))
+        ? inner.slice(1, -1).trim()
+        : inner;
+  }
+  return current;
+}
+
+function stripAnsiSimple(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '').trim();
+}
+
+// ---------------------------------------------------------------------------
+// Failure classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when `error` looks like a "thread not found" response from
+ * codex. The runtime uses this to decide whether to retry with a fresh thread.
+ */
+export function isMissingCodexThreadError(error: unknown): boolean {
+  const message =
+    error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  if (!message.includes('thread') && !message.includes('session')) {
+    return false;
+  }
+  return (
+    message.includes('not found')
+    || message.includes('unknown')
+    || message.includes('invalid')
+    || message.includes('does not exist')
+    || message.includes('no such')
+  );
+}
+
+export type CodexAppServerFailureKind =
+  | 'aborted'
+  | 'missing_thread'
+  | 'context_window'
+  | 'timeout'
+  | 'websocket_connect'
+  | 'websocket_closed'
+  | 'turn_failed'
+  | 'other';
+
+export type CodexAppServerFailureInfo = {
+  kind: CodexAppServerFailureKind;
+  detail: string;
+  clearCachedThread: boolean;
+  retryWithFreshThread: boolean;
+  logTransportClose: boolean;
+};
+
+function isAbortFailure(error: unknown): boolean {
+  const candidate = error as { name?: string; code?: string; message?: string };
+  if (candidate.name === 'AbortError' || candidate.code === 'ABORT_ERR') {
+    return true;
+  }
+  return (
+    typeof candidate.message === 'string'
+    && candidate.message.toLowerCase().includes('aborted')
+  );
+}
+
+/**
+ * Classify a codex app-server failure into a structured descriptor.
+ *
+ * The caller inspects `clearCachedThread` / `retryWithFreshThread` to
+ * decide whether to evict the thread-cache entry and re-run the turn.
+ */
+export function classifyCodexAppServerFailure(error: unknown): CodexAppServerFailureInfo {
+  const detail = error instanceof Error ? error.message : String(error);
+  const message = detail.toLowerCase();
+
+  if (isAbortFailure(error)) {
+    return { kind: 'aborted', detail, clearCachedThread: false, retryWithFreshThread: false, logTransportClose: false };
+  }
+
+  if (isMissingCodexThreadError(error)) {
+    return { kind: 'missing_thread', detail, clearCachedThread: true, retryWithFreshThread: true, logTransportClose: false };
+  }
+
+  if (message.includes('context window') || message.includes('ran out of room')) {
+    return { kind: 'context_window', detail, clearCachedThread: true, retryWithFreshThread: true, logTransportClose: false };
+  }
+
+  if (message.includes('turn timed out')) {
+    return { kind: 'timeout', detail, clearCachedThread: false, retryWithFreshThread: false, logTransportClose: false };
+  }
+
+  if (
+    message.includes('timed out waiting for codex app-server websocket')
+    || message.includes('failed to connect to codex app-server websocket')
+    || message.includes('websocket connection failed')
+    || message.includes('websocket closed before opening')
+  ) {
+    return { kind: 'websocket_connect', detail, clearCachedThread: false, retryWithFreshThread: false, logTransportClose: false };
+  }
+
+  if (message.includes('websocket closed before turn completion')) {
+    return { kind: 'websocket_closed', detail, clearCachedThread: false, retryWithFreshThread: false, logTransportClose: true };
+  }
+
+  if (message.includes('turn failed')) {
+    return { kind: 'turn_failed', detail, clearCachedThread: false, retryWithFreshThread: false, logTransportClose: false };
+  }
+
+  return { kind: 'other', detail, clearCachedThread: false, retryWithFreshThread: false, logTransportClose: false };
+}
+
+// ---------------------------------------------------------------------------
+// Permission extraction
+// ---------------------------------------------------------------------------
+
+function normalizeCodexApprovalDecision(value: unknown): PermissionRisk {
+  const text = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  if (text === 'low' || text === 'medium' || text === 'high') {
+    return text;
+  }
+  return 'medium';
+}
+
+function inferCodexApprovalRisk(
+  payload: Record<string, unknown>,
+  fallback: PermissionRisk = 'medium',
+): PermissionRisk {
+  const directRisk = normalizeCodexApprovalDecision(payload.risk);
+  if (directRisk !== 'medium' || String(payload.risk ?? '').trim().length > 0) {
+    return directRisk;
+  }
+  const hasNetworkContext = asRecord(payload.network_approval_context) !== null;
+  const hasNetworkAmendments =
+    Array.isArray(payload.proposed_network_policy_amendments)
+    && payload.proposed_network_policy_amendments.length > 0;
+  const additionalPermissions = asRecord(payload.additional_permissions);
+  const hasAdditionalPermissions =
+    additionalPermissions !== null && Object.keys(additionalPermissions).length > 0;
+  const grantRoot = asString(payload.grant_root, '').trim();
+  if (hasNetworkContext || hasNetworkAmendments || hasAdditionalPermissions || grantRoot) {
+    return 'high';
+  }
+  return fallback;
+}
+
+/**
+ * Extract a codex permission request from a raw payload.
+ *
+ * Handles both top-level `exec_approval_request` / `apply_patch_approval_request`
+ * payloads and those nested under an `item.completed` wrapper (exec channel).
+ *
+ * Returns `null` when the payload does not describe a permission request.
+ */
+export function extractCodexPermissionRequest(
+  payload: Record<string, unknown>,
+): CodexPermissionRequest | null {
+  const payloadType = asString(payload.type, '').trim();
+  const item = payloadType === 'item.completed' ? asRecord(payload.item) : payload;
+  if (!item) {
+    return null;
+  }
+
+  const itemType = asString(item.type, '').trim();
+  if (
+    itemType !== 'exec_approval_request'
+    && itemType !== 'apply_patch_approval_request'
+  ) {
+    return null;
+  }
+
+  const callId = asString(item.call_id, asString(item.item_id, '')).trim();
+  if (!callId) {
+    return null;
+  }
+
+  const approvalId = asString(item.approval_id, '').trim() || undefined;
+
+  if (itemType === 'exec_approval_request') {
+    const rawCommand = asString(
+      item.command,
+      asString(item.parsed_cmd, asString(item.interaction_input, '')),
+    ).trim();
+    const command = unwrapShellCmd(rawCommand || `exec command (${callId})`);
+    const reason = asString(item.reason, '명령 실행을 위해 사용자 승인이 필요합니다.').trim();
+    return {
+      actionType: 'exec',
+      callId,
+      approvalId,
+      command,
+      reason,
+      risk: inferCodexApprovalRisk(item),
+    };
+  }
+
+  const grantRoot = asString(item.grant_root, '').trim();
+  const command = grantRoot ? `apply_patch (grant_root: ${grantRoot})` : 'apply_patch';
+  const reason = asString(item.reason, '패치 적용을 위해 사용자 승인이 필요합니다.').trim();
+  return {
+    actionType: 'patch',
+    callId,
+    approvalId,
+    command,
+    reason,
+    risk: inferCodexApprovalRisk(item),
+  };
+}
+
+/**
+ * Build the permission-router lookup key for a codex approval request.
+ * Format: `${sessionId}:${approvalId || callId}`.
+ */
+export function buildCodexPermissionKey(
+  sessionId: string,
+  request: CodexPermissionRequest,
+): string {
+  return `${sessionId}:${request.approvalId || request.callId}`;
+}
+
+// ---------------------------------------------------------------------------
+// File-write inference
+// ---------------------------------------------------------------------------
+
+type InferredFileWrite = {
+  command: string;
+  path?: string;
+  detail?: string;
+  status?: string;
+  additions: number;
+  deletions: number;
+  hasDiffSignal: boolean;
+};
+
+/**
+ * Infer a file-write event from a codex `item.completed` item payload.
+ *
+ * Handles `filechange`, `file_change`, `apply_patch`, `applypatch`, and
+ * `patch` item types from both exec and app-server channels.
+ *
+ * Returns `null` when the item does not describe a file write.
+ */
+export function inferCodexFileWriteItem(item: Record<string, unknown>): InferredFileWrite | null {
+  const itemType = asString(item.type, '').trim().toLowerCase();
+  if (!itemType || itemType.includes('approval')) {
+    return null;
+  }
+  if (itemType === 'agentmessage' || itemType === 'agent_message') {
+    return null;
+  }
+  if (itemType === 'commandexecution' || itemType === 'command_execution') {
+    return null;
+  }
+
+  const isFileWriteType =
+    itemType.includes('filechange')
+    || itemType.includes('file_change')
+    || itemType.includes('apply_patch')
+    || itemType.includes('applypatch')
+    || itemType === 'patch';
+
+  if (!isFileWriteType) {
+    return null;
+  }
+
+  const pickPathFromArray = (value: unknown): string => {
+    if (!Array.isArray(value)) {
+      return '';
+    }
+    for (const entry of value) {
+      if (typeof entry === 'string' && entry.trim()) {
+        return entry.trim();
+      }
+      const rec = asRecord(entry);
+      const candidate = asString(
+        rec?.path,
+        asString(
+          rec?.file_path,
+          asString(rec?.filePath, asString(rec?.target_path, asString(rec?.targetPath, ''))),
+        ),
+      ).trim();
+      if (candidate) {
+        return candidate;
+      }
+    }
+    return '';
+  };
+
+  const pickDiffFromArray = (value: unknown): string => {
+    if (!Array.isArray(value)) {
+      return '';
+    }
+    const details: string[] = [];
+    for (const entry of value) {
+      const rec = asRecord(entry);
+      if (!rec) {
+        continue;
+      }
+      const candidate = asString(
+        rec.diff,
+        asString(
+          rec.patch,
+          asString(rec.unified_diff, asString(rec.unifiedDiff, asString(rec.text, asString(rec.result, '')))),
+        ),
+      ).trim();
+      if (candidate) {
+        details.push(candidate);
+      }
+    }
+    return details.join('\n').trim();
+  };
+
+  const pickDiffStatsFromArray = (
+    value: unknown,
+  ): { additions: number; deletions: number; hasDiffSignal: boolean } => {
+    if (!Array.isArray(value)) {
+      return { additions: 0, deletions: 0, hasDiffSignal: false };
+    }
+    let additions = 0;
+    let deletions = 0;
+    let hasDiffSignal = false;
+    for (const entry of value) {
+      const rec = asRecord(entry);
+      if (!rec) {
+        continue;
+      }
+      const kind = asString(asRecord(rec.kind)?.type, asString(rec.kind, '')).trim();
+      const candidate = asString(
+        rec.diff,
+        asString(
+          rec.patch,
+          asString(rec.unified_diff, asString(rec.unifiedDiff, asString(rec.text, asString(rec.result, '')))),
+        ),
+      ).trim();
+      if (!candidate) {
+        continue;
+      }
+      const stats = summarizeFileChangeDiff(candidate, kind);
+      additions += stats.additions;
+      deletions += stats.deletions;
+      hasDiffSignal = hasDiffSignal || stats.hasDiffSignal;
+    }
+    return { additions, deletions, hasDiffSignal };
+  };
+
+  const arrayPath =
+    pickPathFromArray(item.paths)
+    || pickPathFromArray(item.files)
+    || pickPathFromArray(item.changes)
+    || pickPathFromArray(item.changed_files)
+    || pickPathFromArray(item.changedFiles);
+
+  const path = asString(
+    item.path,
+    asString(
+      item.file_path,
+      asString(
+        item.filePath,
+        asString(
+          item.target_path,
+          asString(
+            item.targetPath,
+            asString(item.relative_path, asString(item.relativePath, arrayPath)),
+          ),
+        ),
+      ),
+    ),
+  ).trim() || undefined;
+
+  const commandRaw = asString(item.command, '').trim();
+  const command = unwrapShellCmd(commandRaw || 'apply_patch');
+
+  const arrayDiff = pickDiffFromArray(item.changes);
+  const detailRaw = stripAnsiSimple(
+    asString(
+      item.diff,
+      asString(
+        item.patch,
+        asString(
+          item.unified_diff,
+          asString(
+            item.unifiedDiff,
+            asString(item.output, asString(item.text, asString(item.result, arrayDiff))),
+          ),
+        ),
+      ),
+    ),
+  );
+  const detail = detailRaw && detailRaw.toLowerCase() !== 'apply_patch' ? detailRaw : undefined;
+  const status = asString(item.status, '').trim() || undefined;
+
+  const directDiffStats = summarizeDiffText(detailRaw);
+  const arrayDiffStats = pickDiffStatsFromArray(item.changes);
+  const diffStats = directDiffStats.hasDiffSignal
+    ? directDiffStats
+    : arrayDiffStats.hasDiffSignal
+      ? arrayDiffStats
+      : directDiffStats;
+
+  if (!path && !detail) {
+    return null;
+  }
+
+  return { command, path, detail, status, ...diffStats };
+}
+
+// ---------------------------------------------------------------------------
+// Thread-cache key
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the in-process thread-cache key for a codex session.
+ *
+ * Format: `${sessionId}:${chatId}` when chatId is provided,
+ * otherwise just `${sessionId}`.
+ */
+export function buildCodexThreadCacheKey(sessionId: string, chatId?: string): string {
+  if (chatId && chatId.trim().length > 0) {
+    return `${sessionId}:${chatId.trim()}`;
+  }
+  return sessionId;
+}
+
+// ---------------------------------------------------------------------------
+// Exec-channel pure mapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a single `codex exec --json` stdout line into a `ParsedMessage`.
+ *
+ * Returns `null` for lines that produce no observable event (e.g. system
+ * init frames, heartbeats, unrecognised payload types).
+ *
+ * This is the implementation of `CodexAdapter.parseStdout()` for the exec
+ * channel. Sprint 6 wires it into the adapter.
+ */
+export function parseCodexExecLine(line: string): ParsedMessage | null {
+  const payload = parseCodexJsonLine(line);
+  if (!payload) {
+    return null;
+  }
+  return mapCodexExecPayload(payload);
+}
+
+/**
+ * Map a pre-parsed exec-channel payload to a `ParsedMessage`.
+ *
+ * Separated from `parseCodexExecLine` to support fixture-based testing
+ * with already-parsed objects.
+ */
+export function mapCodexExecPayload(
+  payload: Record<string, unknown>,
+): ParsedMessage | null {
+  const payloadType = asString(payload.type, '').trim();
+
+  // Thread start — emit turn-start envelope + provider-state side effect.
+  if (payloadType === 'thread.started') {
+    const threadId = asString(payload.thread_id, '').trim();
+    if (!threadId) {
+      return null;
+    }
+    return {
+      envelopes: [
+        {
+          kind: 'turn-start',
+          provider: 'codex',
+          source: 'system',
+          threadId,
+          threadIdSource: 'observed',
+        },
+      ],
+      sideEffect: {
+        type: 'update_provider_state',
+        providerState: { threadId },
+      },
+    };
+  }
+
+  // Permission / approval request.
+  const permissionRequest = extractCodexPermissionRequest(payload);
+  if (permissionRequest) {
+    return {
+      envelopes: [],
+      sideEffect: {
+        type: 'request_permission',
+        request: {
+          callId: permissionRequest.callId,
+          approvalId: permissionRequest.approvalId,
+          command: permissionRequest.command,
+          reason: permissionRequest.reason,
+          risk: permissionRequest.risk,
+        },
+      },
+    };
+  }
+
+  if (payloadType !== 'item.completed') {
+    return null;
+  }
+
+  const item = asRecord(payload.item);
+  if (!item) {
+    return null;
+  }
+
+  const itemType = asString(item.type, '');
+
+  // Agent message → text envelope.
+  if (itemType === 'agent_message') {
+    const rawText = asString(item.text, '').trim();
+    const text = sanitizeAgentMessageText(rawText);
+    if (!text) {
+      return null;
+    }
+    const turnId =
+      asString(
+        payload.turn_id,
+        asString(payload.turnId, asString(item.turn_id, asString(item.turnId, ''))),
+      ).trim() || undefined;
+    return {
+      envelopes: [
+        {
+          kind: 'text',
+          provider: 'codex',
+          source: 'assistant',
+          text,
+          ...(turnId ? { turnId } : {}),
+        },
+      ],
+    };
+  }
+
+  // File write → tool-call envelopes + emit_action side effect.
+  const fileWrite = inferCodexFileWriteItem(item);
+  if (fileWrite) {
+    const bodyParts = [`$ ${fileWrite.command || 'apply_patch'}`];
+    if (fileWrite.path) {
+      bodyParts.push(`path: ${fileWrite.path}`);
+    }
+    if (fileWrite.detail) {
+      bodyParts.push(fileWrite.detail);
+    }
+    if (shouldDisplayToolStatus(fileWrite.status)) {
+      bodyParts.push(`status: ${fileWrite.status!}`);
+    }
+
+    const toolCallId = asString(item.call_id, asString(item.item_id, fileWrite.command)).trim();
+    const action = {
+      actionType: 'file_write' as const,
+      title: titleForActionType('file_write'),
+      command: fileWrite.command,
+      path: fileWrite.path,
+      additions: fileWrite.additions,
+      deletions: fileWrite.deletions,
+      hasDiffSignal: fileWrite.hasDiffSignal,
+    };
+
+    return {
+      envelopes: [
+        { kind: 'tool-call-start', provider: 'codex', source: 'tool', toolCallId, toolName: 'apply_patch', action },
+        { kind: 'tool-call-end', provider: 'codex', source: 'tool', toolCallId, toolName: 'apply_patch', action, stopReason: 'completed' as SessionProtocolStopReason },
+      ],
+      sideEffect: { type: 'emit_action', action },
+    };
+  }
+
+  // Command execution → tool-call envelopes + emit_action side effect.
+  if (itemType === 'command_execution') {
+    const commandRaw = asString(item.command, '').trim();
+    const command = unwrapShellCmd(commandRaw);
+    const output = stripAnsiSimple(asString(item.aggregated_output, ''));
+    const exitCodeValue = item.exit_code;
+    const exitCode =
+      typeof exitCodeValue === 'number' && Number.isFinite(exitCodeValue)
+        ? exitCodeValue
+        : null;
+    const actionType = inferActionTypeFromCommand(command);
+    const diffStats =
+      actionType === 'file_write'
+        ? summarizeDiffText(output)
+        : { additions: 0, deletions: 0, hasDiffSignal: false };
+    const stopReason: SessionProtocolStopReason =
+      exitCode !== null && exitCode !== 0 ? 'error' : 'completed';
+
+    const action = {
+      actionType,
+      title: titleForActionType(actionType),
+      command,
+      output: output || undefined,
+      additions: diffStats.additions,
+      deletions: diffStats.deletions,
+      hasDiffSignal: diffStats.hasDiffSignal,
+      ...(exitCode !== null ? { meta: { exitCode } } : {}),
+    };
+    const toolCallId =
+      asString(item.call_id, asString(item.item_id, command)).trim() || command;
+
+    return {
+      envelopes: [
+        { kind: 'tool-call-start', provider: 'codex', source: 'tool', toolCallId, toolName: 'exec', action },
+        { kind: 'tool-call-end', provider: 'codex', source: 'tool', toolCallId, toolName: 'exec', action, stopReason },
+      ],
+      sideEffect: { type: 'emit_action', action },
+    };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// App-server notification mapper
+// ---------------------------------------------------------------------------
+
+export type CodexAppServerMappedEvent = {
+  /** Zero or more protocol envelopes to broadcast. */
+  envelopes: ParsedMessage['envelopes'];
+  /** Optional state-mutation descriptor for the caller to dispatch. */
+  sideEffect?: ParsedMessage['sideEffect'];
+  /**
+   * Partial assistant text delta for streaming accumulation.
+   * The caller appends this to a pending buffer; it is NOT yet persisted.
+   */
+  textDelta?: string;
+};
+
+/**
+ * Map a codex app-server WebSocket notification (method + params already
+ * parsed) to a structured event. Returns `null` for unknown/ignored methods.
+ *
+ * This covers the subset of app-server notifications that produce
+ * observable events. Permission-request methods
+ * (`item/commandExecution/requestApproval`, `item/fileChange/requestApproval`,
+ * legacy `execCommandApproval` / `applyPatchApproval`) are handled
+ * separately by `runtimeCore.ts` because they require JSON-RPC response
+ * routing that depends on session context — those will be lifted in Sprint 5.
+ */
+export function mapCodexAppServerNotification(
+  method: string,
+  params: Record<string, unknown>,
+): CodexAppServerMappedEvent | null {
+  // Thread started.
+  if (method === 'thread/started') {
+    const threadRecord = asRecord(params.thread);
+    const threadId = asString(threadRecord?.id, '').trim();
+    if (!threadId) {
+      return null;
+    }
+    return {
+      envelopes: [
+        {
+          kind: 'turn-start',
+          provider: 'codex',
+          source: 'system',
+          threadId,
+          threadIdSource: 'observed',
+        },
+      ],
+      sideEffect: {
+        type: 'update_provider_state',
+        providerState: { threadId },
+      },
+    };
+  }
+
+  // Streaming text delta (not yet final).
+  if (method === 'item/agentMessage/delta') {
+    const deltaRecord = asRecord(params.delta);
+    const textDelta = asString(
+      params.text,
+      asString(params.delta, asString(deltaRecord?.text, asString(deltaRecord?.delta, ''))),
+    );
+    if (!textDelta) {
+      return null;
+    }
+    return { envelopes: [], textDelta };
+  }
+
+  // Item completed.
+  if (method === 'item/completed') {
+    const item = asRecord(params.item);
+    if (!item) {
+      return null;
+    }
+    const itemType = asString(item.type, '');
+
+    // Agent message (camelCase from app-server).
+    if (itemType === 'agentMessage') {
+      const rawText = asString(item.text, '').trim();
+      const text = sanitizeAgentMessageText(rawText);
+      if (!text) {
+        return null;
+      }
+      const turnId = asString(params.turnId, '').trim() || undefined;
+      return {
+        envelopes: [
+          {
+            kind: 'text',
+            provider: 'codex',
+            source: 'assistant',
+            text,
+            ...(turnId ? { turnId } : {}),
+          },
+        ],
+      };
+    }
+
+    // File write.
+    const fileWrite = inferCodexFileWriteItem(item);
+    if (fileWrite) {
+      const bodyParts = [`$ ${fileWrite.command || 'apply_patch'}`];
+      if (fileWrite.path) {
+        bodyParts.push(`path: ${fileWrite.path}`);
+      }
+      if (fileWrite.detail) {
+        bodyParts.push(fileWrite.detail);
+      }
+      if (shouldDisplayToolStatus(fileWrite.status)) {
+        bodyParts.push(`status: ${fileWrite.status!}`);
+      }
+      const toolCallId = asString(item.call_id, asString(item.item_id, fileWrite.command)).trim();
+      const action = {
+        actionType: 'file_write' as const,
+        title: titleForActionType('file_write'),
+        command: fileWrite.command,
+        path: fileWrite.path,
+        additions: fileWrite.additions,
+        deletions: fileWrite.deletions,
+        hasDiffSignal: fileWrite.hasDiffSignal,
+      };
+      return {
+        envelopes: [
+          { kind: 'tool-call-start', provider: 'codex', source: 'tool', toolCallId, toolName: 'apply_patch', action },
+          { kind: 'tool-call-end', provider: 'codex', source: 'tool', toolCallId, toolName: 'apply_patch', action, stopReason: 'completed' as SessionProtocolStopReason },
+        ],
+        sideEffect: { type: 'emit_action', action },
+      };
+    }
+
+    // Command execution (camelCase from app-server).
+    if (itemType === 'commandExecution') {
+      const commandRaw = asString(item.command, '').trim();
+      const command = unwrapShellCmd(commandRaw);
+      const output = stripAnsiSimple(asString(item.aggregatedOutput, ''));
+      const exitCodeValue = item.exitCode;
+      const exitCode =
+        typeof exitCodeValue === 'number' && Number.isFinite(exitCodeValue)
+          ? exitCodeValue
+          : null;
+      const statusText = asString(item.status, '').trim();
+      const actionType = inferActionTypeFromCommand(command);
+      const diffStats =
+        actionType === 'file_write'
+          ? summarizeDiffText(output)
+          : { additions: 0, deletions: 0, hasDiffSignal: false };
+      const stopReason: SessionProtocolStopReason =
+        exitCode !== null && exitCode !== 0 ? 'error' : 'completed';
+
+      const action = {
+        actionType,
+        title: titleForActionType(actionType),
+        command,
+        output: output || undefined,
+        additions: diffStats.additions,
+        deletions: diffStats.deletions,
+        hasDiffSignal: diffStats.hasDiffSignal,
+        ...(exitCode !== null ? { meta: { exitCode } } : {}),
+        ...(shouldDisplayToolStatus(statusText) ? { meta: { ...(exitCode !== null ? { exitCode } : {}), status: statusText } } : {}),
+      };
+      const toolCallId =
+        asString(item.call_id, asString(item.item_id, command)).trim() || command;
+
+      return {
+        envelopes: [
+          { kind: 'tool-call-start', provider: 'codex', source: 'tool', toolCallId, toolName: 'exec', action },
+          { kind: 'tool-call-end', provider: 'codex', source: 'tool', toolCallId, toolName: 'exec', action, stopReason },
+        ],
+        sideEffect: { type: 'emit_action', action },
+      };
+    }
+
+    return null;
+  }
+
+  // Turn completed.
+  if (method === 'turn/completed') {
+    const turn = asRecord(params.turn);
+    const rawStatus = asString(turn?.status, '').trim();
+    const errorMessage = asString(asRecord(turn?.error)?.message, '').trim() || undefined;
+    const isError = rawStatus === 'failed' || rawStatus === 'error' || Boolean(errorMessage);
+    const stopReason: SessionProtocolStopReason = isError ? 'error' : 'completed';
+
+    return {
+      envelopes: [
+        {
+          kind: 'turn-end',
+          provider: 'codex',
+          source: 'system',
+          stopReason,
+        },
+      ],
+      sideEffect: { type: 'turn_complete', reason: stopReason === 'error' ? 'error' : 'completed' },
+    };
+  }
+
+  return null;
+}

--- a/services/aris-backend/src/runtime/providers/codex/types.ts
+++ b/services/aris-backend/src/runtime/providers/codex/types.ts
@@ -27,7 +27,10 @@ import type { ApprovalPolicy, PermissionDecision } from '../../../types.js';
 export type CodexResumeTarget = ProviderResumeTarget;
 export type CodexThreadIdSource = ProviderThreadIdSource;
 export type CodexActionEvent = ProviderActionEvent;
-export type CodexPermissionRequest = ProviderPermissionRequest;
+export type CodexPermissionRequest = ProviderPermissionRequest & {
+  /** Whether this is a shell-command approval or a patch-apply approval. */
+  actionType: 'exec' | 'patch';
+};
 export type CodexTextEvent = ProviderTextEvent;
 
 export type CodexCliResult = ProviderCliResult & {

--- a/services/aris-backend/src/runtime/runtimeCore.ts
+++ b/services/aris-backend/src/runtime/runtimeCore.ts
@@ -30,6 +30,17 @@ import { createGeminiRuntime } from './providers/gemini/geminiRuntime.js';
 import { GeminiStreamAdapter } from './providers/gemini/geminiStreamAdapter.js';
 import { GeminiSessionRegistry } from './providers/gemini/geminiSessionRegistry.js';
 import { buildProviderCommand, type ProviderCommand } from './providers/providerCommandFactory.js';
+import {
+  buildCodexPermissionKey,
+  buildCodexThreadCacheKey,
+  classifyCodexAppServerFailure,
+  extractCodexPermissionRequest,
+  isMissingCodexThreadError,
+  inferCodexFileWriteItem,
+  type CodexAppServerFailureInfo,
+  type CodexAppServerFailureKind,
+} from './providers/codex/codexProtocolMapper.js';
+import type { CodexPermissionRequest } from './providers/codex/types.js';
 import type { SessionProtocolEnvelope } from './contracts/sessionProtocol.js';
 import type {
   ProviderActionEvent,
@@ -146,16 +157,7 @@ type RuntimeAgent = RuntimeSession['metadata']['flavor'];
 type ModelReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
 type PermissionState = PermissionRequest['state'];
 type SessionStatusValue = RuntimeSession['state']['status'];
-type PermissionActionType = 'exec' | 'patch';
 type JsonRpcId = string | number | null;
-type CodexPermissionRequest = {
-  actionType: PermissionActionType;
-  callId: string;
-  approvalId?: string;
-  command: string;
-  reason: string;
-  risk: PermissionRisk;
-};
 
 type HappyRuntimeCreateInput = {
   path: string;
@@ -1105,127 +1107,6 @@ function isAbortFailure(error: unknown): boolean {
   return typeof candidate.message === 'string' && candidate.message.toLowerCase().includes('aborted');
 }
 
-function isMissingCodexThreadError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
-  if (!message.includes('thread') && !message.includes('session')) {
-    return false;
-  }
-
-  return (
-    message.includes('not found')
-    || message.includes('unknown')
-    || message.includes('invalid')
-    || message.includes('does not exist')
-    || message.includes('no such')
-  );
-}
-
-type CodexAppServerFailureKind =
-  | 'aborted'
-  | 'missing_thread'
-  | 'context_window'
-  | 'timeout'
-  | 'websocket_connect'
-  | 'websocket_closed'
-  | 'turn_failed'
-  | 'other';
-
-type CodexAppServerFailureInfo = {
-  kind: CodexAppServerFailureKind;
-  detail: string;
-  clearCachedThread: boolean;
-  retryWithFreshThread: boolean;
-  logTransportClose: boolean;
-};
-
-function classifyCodexAppServerFailure(error: unknown): CodexAppServerFailureInfo {
-  const detail = error instanceof Error ? error.message : String(error);
-  const message = detail.toLowerCase();
-
-  if (isAbortFailure(error)) {
-    return {
-      kind: 'aborted',
-      detail,
-      clearCachedThread: false,
-      retryWithFreshThread: false,
-      logTransportClose: false,
-    };
-  }
-
-  if (isMissingCodexThreadError(error)) {
-    return {
-      kind: 'missing_thread',
-      detail,
-      clearCachedThread: true,
-      retryWithFreshThread: true,
-      logTransportClose: false,
-    };
-  }
-
-  if (message.includes('context window') || message.includes('ran out of room')) {
-    return {
-      kind: 'context_window',
-      detail,
-      clearCachedThread: true,
-      retryWithFreshThread: true,
-      logTransportClose: false,
-    };
-  }
-
-  if (message.includes('turn timed out')) {
-    return {
-      kind: 'timeout',
-      detail,
-      clearCachedThread: false,
-      retryWithFreshThread: false,
-      logTransportClose: false,
-    };
-  }
-
-  if (
-    message.includes('timed out waiting for codex app-server websocket')
-    || message.includes('failed to connect to codex app-server websocket')
-    || message.includes('websocket connection failed')
-    || message.includes('websocket closed before opening')
-  ) {
-    return {
-      kind: 'websocket_connect',
-      detail,
-      clearCachedThread: false,
-      retryWithFreshThread: false,
-      logTransportClose: false,
-    };
-  }
-
-  if (message.includes('websocket closed before turn completion')) {
-    return {
-      kind: 'websocket_closed',
-      detail,
-      clearCachedThread: false,
-      retryWithFreshThread: false,
-      logTransportClose: true,
-    };
-  }
-
-  if (message.includes('turn failed')) {
-    return {
-      kind: 'turn_failed',
-      detail,
-      clearCachedThread: false,
-      retryWithFreshThread: false,
-      logTransportClose: false,
-    };
-  }
-
-  return {
-    kind: 'other',
-    detail,
-    clearCachedThread: false,
-    retryWithFreshThread: false,
-    logTransportClose: false,
-  };
-}
-
 function unwrapShellCommand(command: string): string {
   let current = command.trim();
   if (current.startsWith('$ ')) {
@@ -1252,83 +1133,6 @@ function unwrapShellCommand(command: string): string {
   return current;
 }
 
-function normalizeCodexApprovalDecision(value: unknown): PermissionRisk {
-  const text = typeof value === 'string' ? value.trim().toLowerCase() : '';
-  if (text === 'low' || text === 'medium' || text === 'high') {
-    return text;
-  }
-  return 'medium';
-}
-
-function inferCodexApprovalRisk(payload: Record<string, unknown>, fallback: PermissionRisk = 'medium'): PermissionRisk {
-  const directRisk = normalizeCodexApprovalDecision(payload.risk);
-  if (directRisk !== 'medium' || String(payload.risk ?? '').trim().length > 0) {
-    return directRisk;
-  }
-
-  const hasNetworkContext = asRecord(payload.network_approval_context) !== null;
-  const networkPolicyAmendments = payload.proposed_network_policy_amendments;
-  const hasNetworkAmendments = Array.isArray(networkPolicyAmendments) && networkPolicyAmendments.length > 0;
-  const additionalPermissions = asRecord(payload.additional_permissions);
-  const hasAdditionalPermissions = additionalPermissions !== null && Object.keys(additionalPermissions).length > 0;
-  const grantRoot = asString(payload.grant_root, '').trim();
-
-  if (hasNetworkContext || hasNetworkAmendments || hasAdditionalPermissions || grantRoot) {
-    return 'high';
-  }
-
-  return fallback;
-}
-
-function extractCodexPermissionRequest(payload: Record<string, unknown>): CodexPermissionRequest | null {
-  const payloadType = asString(payload.type, '').trim();
-  const item = payloadType === 'item.completed' ? asRecord(payload.item) : payload;
-  if (!item) {
-    return null;
-  }
-
-  const itemType = asString(item.type, '').trim();
-  if (itemType !== 'exec_approval_request' && itemType !== 'apply_patch_approval_request') {
-    return null;
-  }
-
-  const callId = asString(item.call_id, asString(item.item_id, '')).trim();
-  if (!callId) {
-    return null;
-  }
-
-  const approvalId = asString(item.approval_id, '').trim() || undefined;
-  if (itemType === 'exec_approval_request') {
-    const rawCommand = asString(item.command, asString(item.parsed_cmd, asString(item.interaction_input, ''))).trim();
-    const command = unwrapShellCommand(rawCommand || `exec command (${callId})`);
-    const reason = asString(item.reason, '명령 실행을 위해 사용자 승인이 필요합니다.').trim();
-    return {
-      actionType: 'exec',
-      callId,
-      approvalId,
-      command,
-      reason,
-      risk: inferCodexApprovalRisk(item),
-    };
-  }
-
-  const grantRoot = asString(item.grant_root, '').trim();
-  const command = grantRoot ? `apply_patch (grant_root: ${grantRoot})` : 'apply_patch';
-  const reason = asString(item.reason, '패치 적용을 위해 사용자 승인이 필요합니다.').trim();
-  return {
-    actionType: 'patch',
-    callId,
-    approvalId,
-    command,
-    reason,
-    risk: inferCodexApprovalRisk(item),
-  };
-}
-
-function buildCodexPermissionKey(sessionId: string, request: CodexPermissionRequest): string {
-  return `${sessionId}:${request.approvalId || request.callId}`;
-}
-
 function resolveClaudeLaunchMode(input: {
   sessionPath?: string;
   workspaceRoot: string;
@@ -1344,182 +1148,6 @@ function resolveClaudeLaunchMode(input: {
   return raw === normalizedWorkspaceRoot || raw.startsWith(workspacePrefix)
     ? 'remote'
     : 'local';
-}
-
-function inferCodexFileWriteItem(item: Record<string, unknown>): {
-  command: string;
-  path?: string;
-  detail?: string;
-  status?: string;
-  additions: number;
-  deletions: number;
-  hasDiffSignal: boolean;
-} | null {
-  const itemType = asString(item.type, '').trim().toLowerCase();
-  if (!itemType || itemType.includes('approval')) {
-    return null;
-  }
-  if (itemType === 'agentmessage' || itemType === 'agent_message') {
-    return null;
-  }
-  if (itemType === 'commandexecution' || itemType === 'command_execution') {
-    return null;
-  }
-
-  const isFileWriteType = (
-    itemType.includes('filechange')
-    || itemType.includes('file_change')
-    || itemType.includes('apply_patch')
-    || itemType.includes('applypatch')
-    || itemType === 'patch'
-  );
-
-  if (!isFileWriteType) {
-    return null;
-  }
-
-  const pickPathFromArray = (value: unknown): string => {
-    if (!Array.isArray(value)) {
-      return '';
-    }
-    for (const entry of value) {
-      if (typeof entry === 'string' && entry.trim()) {
-        return entry.trim();
-      }
-      const rec = asRecord(entry);
-      const candidate = asString(
-        rec?.path,
-        asString(
-          rec?.file_path,
-          asString(rec?.filePath, asString(rec?.target_path, asString(rec?.targetPath, ''))),
-        ),
-      ).trim();
-      if (candidate) {
-        return candidate;
-      }
-    }
-    return '';
-  };
-
-  const pickDiffFromArray = (value: unknown): string => {
-    if (!Array.isArray(value)) {
-      return '';
-    }
-
-    const details: string[] = [];
-    for (const entry of value) {
-      const rec = asRecord(entry);
-      if (!rec) {
-        continue;
-      }
-      const candidate = asString(
-        rec.diff,
-        asString(
-          rec.patch,
-          asString(rec.unified_diff, asString(rec.unifiedDiff, asString(rec.text, asString(rec.result, '')))),
-        ),
-      ).trim();
-      if (candidate) {
-        details.push(candidate);
-      }
-    }
-
-    return details.join('\n').trim();
-  };
-
-  const pickDiffStatsFromArray = (value: unknown): { additions: number; deletions: number; hasDiffSignal: boolean } => {
-    if (!Array.isArray(value)) {
-      return { additions: 0, deletions: 0, hasDiffSignal: false };
-    }
-
-    let additions = 0;
-    let deletions = 0;
-    let hasDiffSignal = false;
-
-    for (const entry of value) {
-      const rec = asRecord(entry);
-      if (!rec) {
-        continue;
-      }
-
-      const kind = asString(asRecord(rec.kind)?.type, asString(rec.kind, '')).trim();
-      const candidate = asString(
-        rec.diff,
-        asString(
-          rec.patch,
-          asString(rec.unified_diff, asString(rec.unifiedDiff, asString(rec.text, asString(rec.result, '')))),
-        ),
-      ).trim();
-      if (!candidate) {
-        continue;
-      }
-
-      const stats = summarizeFileChangeDiff(candidate, kind);
-      additions += stats.additions;
-      deletions += stats.deletions;
-      hasDiffSignal = hasDiffSignal || stats.hasDiffSignal;
-    }
-
-    return { additions, deletions, hasDiffSignal };
-  };
-
-  const arrayPath = pickPathFromArray(item.paths)
-    || pickPathFromArray(item.files)
-    || pickPathFromArray(item.changes)
-    || pickPathFromArray(item.changed_files)
-    || pickPathFromArray(item.changedFiles);
-
-  const path = asString(
-    item.path,
-    asString(
-      item.file_path,
-      asString(
-        item.filePath,
-        asString(
-          item.target_path,
-          asString(item.targetPath, asString(item.relative_path, asString(item.relativePath, arrayPath))),
-        ),
-      ),
-    ),
-  ).trim() || undefined;
-  const commandRaw = asString(item.command, '').trim();
-  const command = unwrapShellCommand(commandRaw || 'apply_patch');
-  const arrayDiff = pickDiffFromArray(item.changes);
-  const detailRaw = stripAnsi(asString(
-    item.diff,
-    asString(
-      item.patch,
-      asString(
-        item.unified_diff,
-        asString(
-          item.unifiedDiff,
-          asString(item.output, asString(item.text, asString(item.result, arrayDiff))),
-        ),
-      ),
-    ),
-  )).trim();
-  const detail = detailRaw && detailRaw.toLowerCase() !== 'apply_patch' ? detailRaw : undefined;
-  const status = asString(item.status, '').trim() || undefined;
-  const directDiffStats = summarizeDiffText(detailRaw);
-  const arrayDiffStats = pickDiffStatsFromArray(item.changes);
-  const diffStats = directDiffStats.hasDiffSignal
-    ? directDiffStats
-    : arrayDiffStats.hasDiffSignal
-      ? arrayDiffStats
-      : directDiffStats;
-
-  if (!path && !detail) {
-    return null;
-  }
-
-  return { command, path, detail, status, ...diffStats };
-}
-
-function buildCodexThreadCacheKey(sessionId: string, chatId?: string): string {
-  if (chatId && chatId.trim().length > 0) {
-    return `${sessionId}:${chatId.trim()}`;
-  }
-  return sessionId;
 }
 
 function isRetryableHappyMessageWriteError(error: unknown): boolean {

--- a/services/aris-backend/tests/codexProtocolMapper.test.ts
+++ b/services/aris-backend/tests/codexProtocolMapper.test.ts
@@ -1,0 +1,458 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCodexPermissionKey,
+  buildCodexThreadCacheKey,
+  classifyCodexAppServerFailure,
+  extractCodexPermissionRequest,
+  inferCodexFileWriteItem,
+  isMissingCodexThreadError,
+  mapCodexAppServerNotification,
+  mapCodexExecPayload,
+  parseCodexExecLine,
+} from '../src/runtime/providers/codex/codexProtocolMapper.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures — synthetic codex payloads representative of real protocol output
+// ---------------------------------------------------------------------------
+
+const FIXTURES = {
+  // Scenario 1: thread start (exec channel)
+  execThreadStarted: {
+    type: 'thread.started',
+    thread_id: 'thread-abc-123',
+  },
+
+  // Scenario 2: assistant text (exec channel)
+  execAgentMessage: {
+    type: 'item.completed',
+    turn_id: 'turn-001',
+    item: {
+      type: 'agent_message',
+      text: 'Sure, I can help with that!',
+    },
+  },
+
+  // Scenario 3: file write (exec channel) — unified diff format
+  execFileChange: {
+    type: 'item.completed',
+    item: {
+      type: 'file_change',
+      path: 'src/index.ts',
+      diff: '--- a/src/index.ts\n+++ b/src/index.ts\n@@ -1 +1 @@\n-const x = 0;\n+const x = 1;',
+      status: 'completed',
+    },
+  },
+
+  // Scenario 4: permission request — exec approval (exec channel)
+  execApprovalRequest: {
+    type: 'item.completed',
+    item: {
+      type: 'exec_approval_request',
+      call_id: 'call-42',
+      command: 'npm install',
+      reason: '의존성 설치가 필요합니다.',
+    },
+  },
+
+  // Scenario 5a: missing-thread error message
+  missingThreadError: new Error('thread not found: abc-123'),
+
+  // Scenario 5b: context-window error
+  contextWindowError: new Error('ran out of room in the context window'),
+
+  // App-server scenarios
+  appServerThreadStarted: {
+    thread: { id: 'thread-ws-999' },
+  },
+
+  appServerAgentMessageDelta: {
+    text: 'Hello ',
+  },
+
+  appServerItemCompleted_agentMessage: {
+    item: {
+      type: 'agentMessage',
+      text: 'Final answer.',
+    },
+    turnId: 'turn-ws-001',
+  },
+
+  appServerTurnCompleted: {
+    turn: {
+      id: 'turn-ws-001',
+      status: 'completed',
+    },
+  },
+
+  appServerTurnFailed: {
+    turn: {
+      id: 'turn-ws-002',
+      status: 'failed',
+      error: { message: 'turn failed: rate limit exceeded' },
+    },
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// isMissingCodexThreadError
+// ---------------------------------------------------------------------------
+
+describe('isMissingCodexThreadError', () => {
+  it('returns true for "thread not found" messages', () => {
+    expect(isMissingCodexThreadError(new Error('thread not found: abc'))).toBe(true);
+    expect(isMissingCodexThreadError(new Error('Thread does not exist'))).toBe(true);
+    expect(isMissingCodexThreadError(new Error('session unknown'))).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isMissingCodexThreadError(new Error('network timeout'))).toBe(false);
+    expect(isMissingCodexThreadError(new Error('permission denied'))).toBe(false);
+  });
+
+  it('handles non-Error inputs', () => {
+    expect(isMissingCodexThreadError('thread invalid abc')).toBe(true);
+    expect(isMissingCodexThreadError('something else')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyCodexAppServerFailure
+// ---------------------------------------------------------------------------
+
+describe('classifyCodexAppServerFailure', () => {
+  it('classifies missing-thread errors', () => {
+    const info = classifyCodexAppServerFailure(FIXTURES.missingThreadError);
+    expect(info.kind).toBe('missing_thread');
+    expect(info.clearCachedThread).toBe(true);
+    expect(info.retryWithFreshThread).toBe(true);
+  });
+
+  it('classifies context-window errors', () => {
+    const info = classifyCodexAppServerFailure(FIXTURES.contextWindowError);
+    expect(info.kind).toBe('context_window');
+    expect(info.clearCachedThread).toBe(true);
+    expect(info.retryWithFreshThread).toBe(true);
+  });
+
+  it('classifies websocket connect errors', () => {
+    const err = new Error('timed out waiting for codex app-server websocket');
+    const info = classifyCodexAppServerFailure(err);
+    expect(info.kind).toBe('websocket_connect');
+    expect(info.clearCachedThread).toBe(false);
+  });
+
+  it('classifies aborted errors', () => {
+    const err = new Error('aborted');
+    (err as NodeJS.ErrnoException).name = 'AbortError';
+    const info = classifyCodexAppServerFailure(err);
+    expect(info.kind).toBe('aborted');
+    expect(info.retryWithFreshThread).toBe(false);
+  });
+
+  it('falls back to "other" for unrecognised messages', () => {
+    const info = classifyCodexAppServerFailure(new Error('unknown error xyz'));
+    expect(info.kind).toBe('other');
+    expect(info.clearCachedThread).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractCodexPermissionRequest
+// ---------------------------------------------------------------------------
+
+describe('extractCodexPermissionRequest', () => {
+  it('extracts exec approval from item.completed wrapper', () => {
+    const req = extractCodexPermissionRequest(FIXTURES.execApprovalRequest as Record<string, unknown>);
+    expect(req).not.toBeNull();
+    expect(req!.actionType).toBe('exec');
+    expect(req!.callId).toBe('call-42');
+    expect(req!.command).toBe('npm install');
+    expect(req!.reason).toBe('의존성 설치가 필요합니다.');
+  });
+
+  it('extracts patch approval from direct payload', () => {
+    const payload = {
+      type: 'apply_patch_approval_request',
+      call_id: 'call-patch-7',
+      grant_root: '/workspace/src',
+      reason: '패치 적용이 필요합니다.',
+    };
+    const req = extractCodexPermissionRequest(payload);
+    expect(req).not.toBeNull();
+    expect(req!.actionType).toBe('patch');
+    expect(req!.callId).toBe('call-patch-7');
+    expect(req!.risk).toBe('high');
+  });
+
+  it('returns null for non-approval payloads', () => {
+    expect(extractCodexPermissionRequest(FIXTURES.execAgentMessage as Record<string, unknown>)).toBeNull();
+    expect(extractCodexPermissionRequest({ type: 'thread.started' })).toBeNull();
+  });
+
+  it('returns null when callId is missing', () => {
+    const payload = { type: 'exec_approval_request', command: 'ls' };
+    expect(extractCodexPermissionRequest(payload)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferCodexFileWriteItem
+// ---------------------------------------------------------------------------
+
+describe('inferCodexFileWriteItem', () => {
+  it('infers from file_change item', () => {
+    const result = inferCodexFileWriteItem({
+      type: 'file_change',
+      path: 'src/foo.ts',
+      diff: '--- a/src/foo.ts\n+++ b/src/foo.ts\n@@ -1,2 +1,3 @@\n+const a = 1;\n+const b = 2;\n-const c = 3;',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe('src/foo.ts');
+    expect(result!.additions).toBeGreaterThan(0);
+    expect(result!.deletions).toBeGreaterThan(0);
+    expect(result!.hasDiffSignal).toBe(true);
+  });
+
+  it('infers from apply_patch item', () => {
+    const result = inferCodexFileWriteItem({
+      type: 'apply_patch',
+      path: 'README.md',
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it('returns null for agent_message items', () => {
+    expect(inferCodexFileWriteItem({ type: 'agent_message', text: 'hi' })).toBeNull();
+  });
+
+  it('returns null for approval items', () => {
+    expect(inferCodexFileWriteItem({ type: 'exec_approval_request' })).toBeNull();
+  });
+
+  it('returns null when neither path nor diff is present', () => {
+    expect(inferCodexFileWriteItem({ type: 'file_change' })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCodexPermissionKey / buildCodexThreadCacheKey
+// ---------------------------------------------------------------------------
+
+describe('buildCodexPermissionKey', () => {
+  it('uses approvalId when present', () => {
+    const req = { actionType: 'exec' as const, callId: 'c1', approvalId: 'a1', command: '', reason: '', risk: 'medium' as const };
+    expect(buildCodexPermissionKey('session-1', req)).toBe('session-1:a1');
+  });
+
+  it('falls back to callId when approvalId is absent', () => {
+    const req = { actionType: 'exec' as const, callId: 'c2', command: '', reason: '', risk: 'medium' as const };
+    expect(buildCodexPermissionKey('session-1', req)).toBe('session-1:c2');
+  });
+});
+
+describe('buildCodexThreadCacheKey', () => {
+  it('includes chatId when provided', () => {
+    expect(buildCodexThreadCacheKey('sess-1', 'chat-1')).toBe('sess-1:chat-1');
+  });
+
+  it('returns sessionId alone when chatId is absent', () => {
+    expect(buildCodexThreadCacheKey('sess-1')).toBe('sess-1');
+    expect(buildCodexThreadCacheKey('sess-1', '')).toBe('sess-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1: exec thread start → ParsedMessage
+// ---------------------------------------------------------------------------
+
+describe('mapCodexExecPayload — scenario 1: thread start', () => {
+  it('emits turn-start envelope with threadId', () => {
+    const msg = mapCodexExecPayload(FIXTURES.execThreadStarted as Record<string, unknown>);
+    expect(msg).not.toBeNull();
+    expect(msg!.envelopes).toHaveLength(1);
+    const env = msg!.envelopes[0];
+    expect(env.kind).toBe('turn-start');
+    expect('threadId' in env && env.threadId).toBe('thread-abc-123');
+  });
+
+  it('emits update_provider_state side effect', () => {
+    const msg = mapCodexExecPayload(FIXTURES.execThreadStarted as Record<string, unknown>);
+    expect(msg!.sideEffect?.type).toBe('update_provider_state');
+    if (msg!.sideEffect?.type === 'update_provider_state') {
+      expect(msg!.sideEffect.providerState.threadId).toBe('thread-abc-123');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2: exec assistant text → ParsedMessage
+// ---------------------------------------------------------------------------
+
+describe('mapCodexExecPayload — scenario 2: assistant text', () => {
+  it('emits text envelope with correct content', () => {
+    const msg = mapCodexExecPayload(FIXTURES.execAgentMessage as Record<string, unknown>);
+    expect(msg).not.toBeNull();
+    expect(msg!.envelopes).toHaveLength(1);
+    const env = msg!.envelopes[0];
+    expect(env.kind).toBe('text');
+    expect('text' in env && env.text).toBe('Sure, I can help with that!');
+    expect('source' in env && env.source).toBe('assistant');
+  });
+
+  it('carries turnId from payload when present', () => {
+    const msg = mapCodexExecPayload(FIXTURES.execAgentMessage as Record<string, unknown>);
+    const env = msg!.envelopes[0];
+    expect('turnId' in env && env.turnId).toBe('turn-001');
+  });
+
+  it('produces no side effect for plain text', () => {
+    const msg = mapCodexExecPayload(FIXTURES.execAgentMessage as Record<string, unknown>);
+    expect(msg!.sideEffect).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3: exec file write → ParsedMessage
+// ---------------------------------------------------------------------------
+
+describe('mapCodexExecPayload — scenario 3: file write', () => {
+  it('emits tool-call-start and tool-call-end envelopes', () => {
+    const msg = mapCodexExecPayload(FIXTURES.execFileChange as Record<string, unknown>);
+    expect(msg).not.toBeNull();
+    expect(msg!.envelopes).toHaveLength(2);
+    expect(msg!.envelopes[0].kind).toBe('tool-call-start');
+    expect(msg!.envelopes[1].kind).toBe('tool-call-end');
+  });
+
+  it('emits emit_action side effect with file_write actionType', () => {
+    const msg = mapCodexExecPayload(FIXTURES.execFileChange as Record<string, unknown>);
+    expect(msg!.sideEffect?.type).toBe('emit_action');
+    if (msg!.sideEffect?.type === 'emit_action') {
+      expect(msg!.sideEffect.action.actionType).toBe('file_write');
+      expect(msg!.sideEffect.action.path).toBe('src/index.ts');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4: exec permission request → ParsedMessage
+// ---------------------------------------------------------------------------
+
+describe('mapCodexExecPayload — scenario 4: permission request', () => {
+  it('emits empty envelopes and request_permission side effect', () => {
+    const msg = mapCodexExecPayload(FIXTURES.execApprovalRequest as Record<string, unknown>);
+    expect(msg).not.toBeNull();
+    expect(msg!.envelopes).toHaveLength(0);
+    expect(msg!.sideEffect?.type).toBe('request_permission');
+  });
+
+  it('includes callId and command in the request', () => {
+    const msg = mapCodexExecPayload(FIXTURES.execApprovalRequest as Record<string, unknown>);
+    if (msg!.sideEffect?.type === 'request_permission') {
+      expect(msg!.sideEffect.request.callId).toBe('call-42');
+      expect(msg!.sideEffect.request.command).toBe('npm install');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseCodexExecLine (string input)
+// ---------------------------------------------------------------------------
+
+describe('parseCodexExecLine', () => {
+  it('returns null for invalid JSON', () => {
+    expect(parseCodexExecLine('not json')).toBeNull();
+    expect(parseCodexExecLine('')).toBeNull();
+  });
+
+  it('returns null for unrecognised payload types', () => {
+    expect(parseCodexExecLine('{"type":"response.created"}')).toBeNull();
+  });
+
+  it('parses thread.started from raw line', () => {
+    const line = JSON.stringify(FIXTURES.execThreadStarted);
+    const msg = parseCodexExecLine(line);
+    expect(msg).not.toBeNull();
+    expect(msg!.envelopes[0].kind).toBe('turn-start');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// App-server notification mapper
+// ---------------------------------------------------------------------------
+
+describe('mapCodexAppServerNotification — thread/started', () => {
+  it('emits turn-start envelope with threadId', () => {
+    const result = mapCodexAppServerNotification(
+      'thread/started',
+      FIXTURES.appServerThreadStarted as Record<string, unknown>,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.envelopes[0].kind).toBe('turn-start');
+    const env = result!.envelopes[0];
+    expect('threadId' in env && env.threadId).toBe('thread-ws-999');
+  });
+});
+
+describe('mapCodexAppServerNotification — item/agentMessage/delta', () => {
+  it('returns textDelta for streaming text', () => {
+    const result = mapCodexAppServerNotification(
+      'item/agentMessage/delta',
+      FIXTURES.appServerAgentMessageDelta as Record<string, unknown>,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.textDelta).toBe('Hello ');
+    expect(result!.envelopes).toHaveLength(0);
+  });
+});
+
+describe('mapCodexAppServerNotification — item/completed (agentMessage)', () => {
+  it('emits text envelope', () => {
+    const result = mapCodexAppServerNotification(
+      'item/completed',
+      FIXTURES.appServerItemCompleted_agentMessage as Record<string, unknown>,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.envelopes[0].kind).toBe('text');
+    const env = result!.envelopes[0];
+    expect('text' in env && env.text).toBe('Final answer.');
+  });
+});
+
+describe('mapCodexAppServerNotification — turn/completed', () => {
+  it('emits turn-end envelope with "completed" stopReason', () => {
+    const result = mapCodexAppServerNotification(
+      'turn/completed',
+      FIXTURES.appServerTurnCompleted as Record<string, unknown>,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.envelopes[0].kind).toBe('turn-end');
+    const env = result!.envelopes[0];
+    expect('stopReason' in env && env.stopReason).toBe('completed');
+  });
+
+  it('emits turn-end with "error" stopReason for failed turns', () => {
+    const result = mapCodexAppServerNotification(
+      'turn/completed',
+      FIXTURES.appServerTurnFailed as Record<string, unknown>,
+    );
+    expect(result).not.toBeNull();
+    const env = result!.envelopes[0];
+    expect('stopReason' in env && env.stopReason).toBe('error');
+  });
+
+  it('emits turn_complete side effect', () => {
+    const result = mapCodexAppServerNotification(
+      'turn/completed',
+      FIXTURES.appServerTurnCompleted as Record<string, unknown>,
+    );
+    expect(result!.sideEffect?.type).toBe('turn_complete');
+  });
+});
+
+describe('mapCodexAppServerNotification — unknown method', () => {
+  it('returns null for unhandled methods', () => {
+    expect(mapCodexAppServerNotification('unknown/method', {})).toBeNull();
+    expect(mapCodexAppServerNotification('mcpServer/elicitation/request', {})).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 Sprint 3 — `codexProtocolMapper.ts` 신설. `runtimeCore.ts`에 인라인으로 박혀 있던 codex 전용 순수 함수들을 `providers/codex/` 서브트리로 추출하고, 새로운 순수 함수 매퍼(`parseCodexExecLine`, `mapCodexAppServerNotification`)를 추가. Sprint 6에서 `CodexAdapter.parseStdout()`이 이 매퍼를 직접 호출하게 된다.

## 변경

### 신규 파일

**`services/aris-backend/src/runtime/providers/codex/codexProtocolMapper.ts`** (~420줄)

추출된 순수 함수:
- `isMissingCodexThreadError` — thread-not-found 오류 판별
- `CodexAppServerFailureKind` / `CodexAppServerFailureInfo` 타입 + `classifyCodexAppServerFailure` — 앱서버 실패 분류
- `extractCodexPermissionRequest` — exec/patch 승인 요청 추출
- `buildCodexPermissionKey` — 권한 라우터 키 빌더
- `inferCodexFileWriteItem` — 파일 쓰기 이벤트 추론
- `buildCodexThreadCacheKey` — 스레드 캐시 키

신규 순수 함수:
- `parseCodexExecLine(line)` — exec 채널 raw 라인 → `ParsedMessage | null`
- `mapCodexExecPayload(payload)` — 파싱된 payload → `ParsedMessage | null` (fixture 테스트용 진입점)
- `mapCodexAppServerNotification(method, params)` — app-server 알림 → `CodexAppServerMappedEvent | null`

### 수정 파일

**`providers/codex/types.ts`**
- `CodexPermissionRequest` 타입에 `actionType: 'exec' | 'patch'` 추가 (이전에는 runtimeCore.ts 로컬 타입에만 존재)

**`runtime/runtimeCore.ts`** (-384줄)
- 이동된 11개 함수/타입 정의 삭제
- `codexProtocolMapper.ts`에서 import로 대체
- 로컬 `CodexPermissionRequest` 타입 제거

### 신규 테스트 파일

**`tests/codexProtocolMapper.test.ts`** — 40개 테스트, 5개 시나리오 커버:
1. thread.started → turn-start envelope
2. item.completed(agent_message) → text envelope
3. item.completed(file_change) → tool-call envelopes + emit_action
4. exec_approval_request → request_permission side effect
5. 실패 분류 (missing_thread, context_window, websocket_connect, aborted, other)

## 안전 검증

- ✅ `tsc --noEmit` clean (aris-backend)
- ✅ `vitest run --exclude e2e`: **301/301 PASS** (회귀 0건)
- ✅ 신규 conformance suite: **40/40 PASS**
- ✅ 동작 보존: runtimeCore.ts는 imported 함수를 그대로 사용 (동작 변경 0건)

## 작업 범위 외 (다음 sprint)

- Sprint 4: `codexAppServerClient.ts` / `codexAppServerLifecycle.ts` — WebSocket 라이프사이클 9개 함수 추출
- Sprint 5: `codexPermissionBridge.ts` — app-server 권한 요청 메서드 추출
- Sprint 6: `codexRuntime.ts` — turn 본체 추출 + `CodexAdapter.parseStdout()` 배선

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run --exclude e2e` 301/301 PASS
- [x] codexProtocolMapper.test.ts 40/40 PASS
- [x] runtimeCore.ts codex 키워드 -60건 (추출된 함수 정의 삭제분)