### PR TITLE
docs(agents): worktree 경로 컨벤션 명시 (.worktrees/ 프리픽스 강제)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@
 - 동일한 워킹 디렉터리를 여러 에이전트가 공유해서 동시에 수정하는 것을 금지한다.
 - 모든 작업은 시작 전 아래 표준 절차로 전용 작업 디렉터리를 생성하고, 해당 경로에서만 커밋/푸쉬를 수행한다.
 - 1) 메인 체크아웃에서 `services/aris-backend/node_modules` 와 `services/aris-web/node_modules` 가 준비되어 있는지 먼저 확인한다. 없거나 필요한 dev 바이너리(`vitest`, `tsc`)가 없으면 메인 체크아웃에서 각 서비스의 의존성을 먼저 설치한다.
-- 2) 새 작업 디렉터리는 `scripts/create_worktree_with_shared_node_modules.sh <worktree_path> <branch> [base_ref]` 로 생성한다. 이 스크립트를 표준 경로로 사용하며, 내부에서 `git worktree add` 이후 공유 `node_modules` 심볼릭 링크까지 연결한다.
+- 2) 새 작업 디렉터리는 `scripts/create_worktree_with_shared_node_modules.sh <worktree_path> <branch> [base_ref]` 로 생성한다. 이 스크립트를 표준 경로로 사용하며, 내부에서 `git worktree add` 이후 공유 `node_modules` 심볼릭 링크까지 연결한다. **`worktree_path`는 반드시 `.worktrees/<name>` 형식의 상대 경로를 사용한다** (예: `.worktrees/fix-my-feature`). `../`로 시작하는 경로는 ARIS 폴더 밖에 워크트리를 생성하므로 절대 금지한다.
 - 3) 이미 `git worktree add` 로 만든 작업 디렉터리라면 즉시 `scripts/link_shared_node_modules.sh <worktree_path>` 를 실행해 공유 `node_modules` 를 연결한다.
 - 4) 링크 이후 필요한 바이너리가 보이지 않으면 메인 체크아웃에서 의존성을 다시 설치한 뒤 `scripts/link_shared_node_modules.sh <worktree_path>` 를 다시 실행한다.
 - 5) 수정, 테스트, 커밋, 푸쉬, 머지는 모두 해당 전용 `git worktree` 내부에서만 수행한다.


### PR DESCRIPTION
## 변경 요약

- AGENTS.md: worktree 생성 시 `worktree_path`를 `.worktrees/<name>` 형식으로 사용해야 함을 명시
- `../`로 시작하는 경로는 ARIS 폴더 밖에 워크트리를 생성하므로 금지로 명시

## 원인

MEMORY.md에 `git worktree add ../<worktree-dir>` 패턴이 기록되어 있었고,
AGENTS.md에 경로 형식 예시가 없어서 에이전트마다 다른 경로를 사용했음.
그 결과 `ARIS-wt/`, `ARIS-refactor-*` 등의 폴더가 `/home/ubuntu/project/` 아래에 산발적으로 생성됨.

## 관련 수정

- `/home/ubuntu/.claude/projects/.../memory/MEMORY.md` (로컬 메모리, git 외): 명령어 템플릿을 스크립트 기반으로 교체