### PR TITLE
refactor(provider-arch): phase 2 sprint 5 - codex permission bridge

### DIFF
--- a/services/aris-backend/src/runtime/providers/codex/codexPermissionBridge.ts
+++ b/services/aris-backend/src/runtime/providers/codex/codexPermissionBridge.ts
@@ -1,0 +1,245 @@
+/**
+ * Codex permission bridge — pure functions for the app-server approval channel.
+ *
+ * The codex `app-server` process sends JSON-RPC requests to ARIS when it
+ * needs user approval for a command, patch, or legacy MCP review. This
+ * module owns:
+ *   - Extracting structured approval data (key, command, reason, risk, and
+ *     a decision mapper) from any of the four supported approval methods.
+ *   - Mapping ARIS's internal `PermissionDecision` enum back to the
+ *     channel-specific response token codex expects.
+ *   - Narrowing the user-visible approval-policy enum down to the three
+ *     values codex itself accepts.
+ *
+ * No I/O, no state, no JSON-RPC writes — the caller in `runtimeCore.ts`
+ * handles the actual `sendJsonRpcResult` dispatch and permission router
+ * binding. Extracting these pure transformations matches the
+ * `claudePermissionBridge.ts` pattern.
+ *
+ * Phase 2 Sprint 5.
+ */
+
+import type { ApprovalPolicy, PermissionDecision, PermissionRisk } from '../../../types.js';
+
+// ---------------------------------------------------------------------------
+// Pure utilities (mirror those in codexProtocolMapper.ts)
+// ---------------------------------------------------------------------------
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null
+    && value !== undefined
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+function unwrapShellCmd(command: string): string {
+  let current = command.trim();
+  if (current.startsWith('$ ')) {
+    current = current.slice(2).trim();
+  }
+  const wrappers = [
+    /^(?:\/bin\/)?bash\s+-lc\s+([\s\S]+)$/i,
+    /^(?:\/bin\/)?sh\s+-lc\s+([\s\S]+)$/i,
+  ];
+  for (const wrapper of wrappers) {
+    const match = current.match(wrapper);
+    if (!match) {
+      continue;
+    }
+    const inner = match[1]?.trim() ?? '';
+    current =
+      (inner.startsWith('"') && inner.endsWith('"'))
+      || (inner.startsWith("'") && inner.endsWith("'"))
+        ? inner.slice(1, -1).trim()
+        : inner;
+  }
+  return current;
+}
+
+// ---------------------------------------------------------------------------
+// Approval-policy normalisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrow ARIS's `ApprovalPolicy` enum down to the three values codex
+ * itself accepts: `on-request`, `on-failure`, `never`.
+ *
+ * The user-visible `yolo` value short-circuits the approval flow at a
+ * higher layer (auto-approve in the runtime), so it never reaches codex.
+ */
+export function normalizeCodexApprovalPolicy(
+  value: ApprovalPolicy,
+): 'on-request' | 'on-failure' | 'never' {
+  if (value === 'on-failure' || value === 'never' || value === 'on-request') {
+    return value;
+  }
+  return 'on-request';
+}
+
+// ---------------------------------------------------------------------------
+// Decision → JSON-RPC response token
+// ---------------------------------------------------------------------------
+
+/** Map a permission decision to the response token for `item/commandExecution/requestApproval`. */
+export function mapCodexDecisionForCommandApproval(decision: PermissionDecision): string {
+  if (decision === 'allow_session') {
+    return 'acceptForSession';
+  }
+  if (decision === 'deny') {
+    return 'decline';
+  }
+  return 'accept';
+}
+
+/** Map a permission decision to the response token for `item/fileChange/requestApproval`. */
+export function mapCodexDecisionForPatchApproval(decision: PermissionDecision): string {
+  if (decision === 'allow_session') {
+    return 'acceptForSession';
+  }
+  if (decision === 'deny') {
+    return 'decline';
+  }
+  return 'accept';
+}
+
+/** Map a permission decision to the legacy `execCommandApproval` / `applyPatchApproval` response token. */
+export function mapCodexDecisionForLegacyReview(decision: PermissionDecision): string {
+  if (decision === 'allow_session') {
+    return 'approved_for_session';
+  }
+  if (decision === 'deny') {
+    return 'denied';
+  }
+  return 'approved';
+}
+
+// ---------------------------------------------------------------------------
+// Approval-request extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Result shape produced by `extractCodexAppServerApproval`.
+ *
+ * `permissionKey` is the *raw* router key (`${sessionId}:${kind}:${id}`).
+ * The caller is responsible for wrapping it with `buildScopedPermissionKey`
+ * to add chat scoping when applicable.
+ */
+export type CodexAppServerApprovalRequest = {
+  permissionKey: string;
+  command: string;
+  reason: string;
+  risk: PermissionRisk;
+  mapDecision: (decision: PermissionDecision) => string;
+};
+
+/**
+ * Extract a structured approval request from a codex app-server JSON-RPC
+ * method/params pair. Returns `null` if the method is not one of the four
+ * supported approval channels.
+ *
+ * Supported methods:
+ *   - `item/commandExecution/requestApproval` — modern command approval
+ *   - `item/fileChange/requestApproval`       — modern patch approval
+ *   - `execCommandApproval`                   — legacy MCP review (command)
+ *   - `applyPatchApproval`                    — legacy MCP review (patch)
+ */
+export function extractCodexAppServerApproval(input: {
+  method: string;
+  params: Record<string, unknown>;
+  requestIdKey: string;
+  sessionId: string;
+}): CodexAppServerApprovalRequest | null {
+  const { method, params, requestIdKey, sessionId } = input;
+
+  if (method === 'item/commandExecution/requestApproval') {
+    const itemId = asString(params.itemId, '').trim();
+    const approvalId = asString(params.approvalId, '').trim();
+    const callId = approvalId || itemId || requestIdKey;
+    const commandRaw = asString(params.command, `command (${callId})`);
+    const reason = asString(
+      params.reason,
+      '명령 실행을 위해 사용자 승인이 필요합니다.',
+    ).trim();
+    const hasNetworkContext = asRecord(params.networkApprovalContext) !== null;
+    const hasAdditionalPermissions = asRecord(params.additionalPermissions) !== null;
+    const hasNetworkAmendments =
+      Array.isArray(params.proposedNetworkPolicyAmendments)
+      && params.proposedNetworkPolicyAmendments.length > 0;
+    const risk: PermissionRisk =
+      hasNetworkContext || hasAdditionalPermissions || hasNetworkAmendments
+        ? 'high'
+        : 'medium';
+    return {
+      permissionKey: `${sessionId}:cmd:${approvalId || itemId || requestIdKey}`,
+      command: unwrapShellCmd(commandRaw),
+      reason,
+      risk,
+      mapDecision: mapCodexDecisionForCommandApproval,
+    };
+  }
+
+  if (method === 'item/fileChange/requestApproval') {
+    const itemId = asString(params.itemId, '').trim();
+    const grantRoot = asString(params.grantRoot, '').trim();
+    const reason = asString(
+      params.reason,
+      '패치 적용을 위해 사용자 승인이 필요합니다.',
+    ).trim();
+    const command = grantRoot ? `apply_patch (grant_root: ${grantRoot})` : 'apply_patch';
+    return {
+      permissionKey: `${sessionId}:patch:${itemId || requestIdKey}`,
+      command,
+      reason,
+      risk: grantRoot ? 'high' : 'medium',
+      mapDecision: mapCodexDecisionForPatchApproval,
+    };
+  }
+
+  if (method === 'execCommandApproval') {
+    const callId = asString(params.callId, requestIdKey).trim();
+    const approvalId = asString(params.approvalId, '').trim();
+    const commandParts = Array.isArray(params.command)
+      ? params.command.filter((part): part is string => typeof part === 'string')
+      : [];
+    const command =
+      commandParts.length > 0
+        ? commandParts.join(' ')
+        : `exec command (${callId})`;
+    const reason = asString(
+      params.reason,
+      '명령 실행을 위해 사용자 승인이 필요합니다.',
+    ).trim();
+    return {
+      permissionKey: `${sessionId}:legacy-exec:${approvalId || callId}`,
+      command: unwrapShellCmd(command),
+      reason,
+      risk: 'medium',
+      mapDecision: mapCodexDecisionForLegacyReview,
+    };
+  }
+
+  if (method === 'applyPatchApproval') {
+    const callId = asString(params.callId, requestIdKey).trim();
+    const grantRoot = asString(params.grantRoot, '').trim();
+    const reason = asString(
+      params.reason,
+      '패치 적용을 위해 사용자 승인이 필요합니다.',
+    ).trim();
+    const command = grantRoot ? `apply_patch (grant_root: ${grantRoot})` : 'apply_patch';
+    return {
+      permissionKey: `${sessionId}:legacy-patch:${callId}`,
+      command,
+      reason,
+      risk: grantRoot ? 'high' : 'medium',
+      mapDecision: mapCodexDecisionForLegacyReview,
+    };
+  }
+
+  return null;
+}

--- a/services/aris-backend/src/runtime/runtimeCore.ts
+++ b/services/aris-backend/src/runtime/runtimeCore.ts
@@ -45,6 +45,10 @@ import {
   terminateCodexAppServerProcess,
 } from './providers/codex/codexAppServerLifecycle.js';
 import {
+  extractCodexAppServerApproval,
+  normalizeCodexApprovalPolicy,
+} from './providers/codex/codexPermissionBridge.js';
+import {
   buildCodexPermissionKey,
   buildCodexThreadCacheKey,
   classifyCodexAppServerFailure,
@@ -364,13 +368,6 @@ function normalizeApprovalPolicy(value: unknown, fallback: ApprovalPolicy = 'on-
     return normalized;
   }
   return fallback;
-}
-
-function normalizeCodexApprovalPolicy(value: ApprovalPolicy): 'on-request' | 'on-failure' | 'never' {
-  if (value === 'on-failure' || value === 'never' || value === 'on-request') {
-    return value;
-  }
-  return 'on-request';
 }
 
 function normalizeMetadata(raw: unknown): {
@@ -1076,36 +1073,6 @@ function toJsonRpcIdKey(value: unknown): string {
     return 'null';
   }
   return JSON.stringify(value);
-}
-
-function mapCodexDecisionForCommandApproval(decision: PermissionDecision): string {
-  if (decision === 'allow_session') {
-    return 'acceptForSession';
-  }
-  if (decision === 'deny') {
-    return 'decline';
-  }
-  return 'accept';
-}
-
-function mapCodexDecisionForPatchApproval(decision: PermissionDecision): string {
-  if (decision === 'allow_session') {
-    return 'acceptForSession';
-  }
-  if (decision === 'deny') {
-    return 'decline';
-  }
-  return 'accept';
-}
-
-function mapCodexDecisionForLegacyReview(decision: PermissionDecision): string {
-  if (decision === 'allow_session') {
-    return 'approved_for_session';
-  }
-  if (decision === 'deny') {
-    return 'denied';
-  }
-  return 'approved';
 }
 
 function isAbortFailure(error: unknown): boolean {
@@ -2620,89 +2587,19 @@ export class RuntimeCore {
       const params = asRecord(payload.params) ?? {};
       const requestIdKey = toJsonRpcIdKey(requestId);
 
-      if (method === 'item/commandExecution/requestApproval') {
-        const itemId = asString(params.itemId, '').trim();
-        const approvalId = asString(params.approvalId, '').trim();
-        const callId = approvalId || itemId || requestIdKey;
-        const commandRaw = asString(params.command, `command (${callId})`);
-        const reason = asString(params.reason, '명령 실행을 위해 사용자 승인이 필요합니다.').trim();
-        const hasNetworkContext = asRecord(params.networkApprovalContext) !== null;
-        const hasAdditionalPermissions = asRecord(params.additionalPermissions) !== null;
-        const hasNetworkAmendments = Array.isArray(params.proposedNetworkPolicyAmendments)
-          && params.proposedNetworkPolicyAmendments.length > 0;
-        const risk: PermissionRisk = hasNetworkContext || hasAdditionalPermissions || hasNetworkAmendments
-          ? 'high'
-          : 'medium';
-        const key = buildScopedPermissionKey(
-          `${session.id}:cmd:${approvalId || itemId || requestIdKey}`,
-          chatId,
-        );
+      const approval = extractCodexAppServerApproval({
+        method,
+        params,
+        requestIdKey,
+        sessionId: session.id,
+      });
+      if (approval) {
         await registerPermissionResponder(
-          key,
-          unwrapShellCommand(commandRaw),
-          reason,
-          risk,
-          (decision) => sendJsonRpcResult(requestId, { decision: mapCodexDecisionForCommandApproval(decision) }),
-        );
-        return;
-      }
-
-      if (method === 'item/fileChange/requestApproval') {
-        const itemId = asString(params.itemId, '').trim();
-        const grantRoot = asString(params.grantRoot, '').trim();
-        const reason = asString(params.reason, '패치 적용을 위해 사용자 승인이 필요합니다.').trim();
-        const command = grantRoot ? `apply_patch (grant_root: ${grantRoot})` : 'apply_patch';
-        const key = buildScopedPermissionKey(
-          `${session.id}:patch:${itemId || requestIdKey}`,
-          chatId,
-        );
-        await registerPermissionResponder(
-          key,
-          command,
-          reason,
-          grantRoot ? 'high' : 'medium',
-          (decision) => sendJsonRpcResult(requestId, { decision: mapCodexDecisionForPatchApproval(decision) }),
-        );
-        return;
-      }
-
-      if (method === 'execCommandApproval') {
-        const callId = asString(params.callId, requestIdKey).trim();
-        const approvalId = asString(params.approvalId, '').trim();
-        const commandParts = Array.isArray(params.command)
-          ? params.command.filter((part): part is string => typeof part === 'string')
-          : [];
-        const command = commandParts.length > 0 ? commandParts.join(' ') : `exec command (${callId})`;
-        const reason = asString(params.reason, '명령 실행을 위해 사용자 승인이 필요합니다.').trim();
-        const key = buildScopedPermissionKey(
-          `${session.id}:legacy-exec:${approvalId || callId}`,
-          chatId,
-        );
-        await registerPermissionResponder(
-          key,
-          unwrapShellCommand(command),
-          reason,
-          'medium',
-          (decision) => sendJsonRpcResult(requestId, { decision: mapCodexDecisionForLegacyReview(decision) }),
-        );
-        return;
-      }
-
-      if (method === 'applyPatchApproval') {
-        const callId = asString(params.callId, requestIdKey).trim();
-        const grantRoot = asString(params.grantRoot, '').trim();
-        const reason = asString(params.reason, '패치 적용을 위해 사용자 승인이 필요합니다.').trim();
-        const command = grantRoot ? `apply_patch (grant_root: ${grantRoot})` : 'apply_patch';
-        const key = buildScopedPermissionKey(
-          `${session.id}:legacy-patch:${callId}`,
-          chatId,
-        );
-        await registerPermissionResponder(
-          key,
-          command,
-          reason,
-          grantRoot ? 'high' : 'medium',
-          (decision) => sendJsonRpcResult(requestId, { decision: mapCodexDecisionForLegacyReview(decision) }),
+          buildScopedPermissionKey(approval.permissionKey, chatId),
+          approval.command,
+          approval.reason,
+          approval.risk,
+          (decision) => sendJsonRpcResult(requestId, { decision: approval.mapDecision(decision) }),
         );
         return;
       }

--- a/services/aris-backend/tests/codexPermissionBridge.test.ts
+++ b/services/aris-backend/tests/codexPermissionBridge.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractCodexAppServerApproval,
+  mapCodexDecisionForCommandApproval,
+  mapCodexDecisionForLegacyReview,
+  mapCodexDecisionForPatchApproval,
+  normalizeCodexApprovalPolicy,
+} from '../src/runtime/providers/codex/codexPermissionBridge.js';
+
+const SID = 'session-abc';
+const RID = 'rpc-99';
+
+describe('normalizeCodexApprovalPolicy', () => {
+  it('passes through codex-supported values', () => {
+    expect(normalizeCodexApprovalPolicy('on-request')).toBe('on-request');
+    expect(normalizeCodexApprovalPolicy('on-failure')).toBe('on-failure');
+    expect(normalizeCodexApprovalPolicy('never')).toBe('never');
+  });
+
+  it('falls back to on-request for yolo (auto-approve handled upstream)', () => {
+    expect(normalizeCodexApprovalPolicy('yolo')).toBe('on-request');
+  });
+});
+
+describe('mapCodexDecisionFor* — modern channels', () => {
+  it('command approval maps allow→accept, allow_session→acceptForSession, deny→decline', () => {
+    expect(mapCodexDecisionForCommandApproval('allow')).toBe('accept');
+    expect(mapCodexDecisionForCommandApproval('allow_session')).toBe('acceptForSession');
+    expect(mapCodexDecisionForCommandApproval('deny')).toBe('decline');
+  });
+
+  it('patch approval shares the same token set', () => {
+    expect(mapCodexDecisionForPatchApproval('allow')).toBe('accept');
+    expect(mapCodexDecisionForPatchApproval('allow_session')).toBe('acceptForSession');
+    expect(mapCodexDecisionForPatchApproval('deny')).toBe('decline');
+  });
+});
+
+describe('mapCodexDecisionForLegacyReview', () => {
+  it('legacy review uses approved/denied/approved_for_session', () => {
+    expect(mapCodexDecisionForLegacyReview('allow')).toBe('approved');
+    expect(mapCodexDecisionForLegacyReview('allow_session')).toBe('approved_for_session');
+    expect(mapCodexDecisionForLegacyReview('deny')).toBe('denied');
+  });
+});
+
+describe('extractCodexAppServerApproval — item/commandExecution/requestApproval', () => {
+  it('extracts command + risk=medium for plain commands', () => {
+    const approval = extractCodexAppServerApproval({
+      method: 'item/commandExecution/requestApproval',
+      params: { itemId: 'i1', approvalId: 'a1', command: 'ls -la', reason: 'list files' },
+      requestIdKey: RID,
+      sessionId: SID,
+    });
+    expect(approval).not.toBeNull();
+    expect(approval!.permissionKey).toBe(`${SID}:cmd:a1`);
+    expect(approval!.command).toBe('ls -la');
+    expect(approval!.reason).toBe('list files');
+    expect(approval!.risk).toBe('medium');
+    expect(approval!.mapDecision('allow_session')).toBe('acceptForSession');
+  });
+
+  it('escalates risk to high when network context is present', () => {
+    const approval = extractCodexAppServerApproval({
+      method: 'item/commandExecution/requestApproval',
+      params: { command: 'curl example.com', networkApprovalContext: { domain: 'example.com' } },
+      requestIdKey: RID,
+      sessionId: SID,
+    });
+    expect(approval!.risk).toBe('high');
+  });
+
+  it('unwraps bash -lc wrappers', () => {
+    const approval = extractCodexAppServerApproval({
+      method: 'item/commandExecution/requestApproval',
+      params: { itemId: 'i1', command: 'bash -lc "ls -la"' },
+      requestIdKey: RID,
+      sessionId: SID,
+    });
+    expect(approval!.command).toBe('ls -la');
+  });
+
+  it('falls back to requestIdKey when ids missing', () => {
+    const approval = extractCodexAppServerApproval({
+      method: 'item/commandExecution/requestApproval',
+      params: { command: 'pwd' },
+      requestIdKey: RID,
+      sessionId: SID,
+    });
+    expect(approval!.permissionKey).toBe(`${SID}:cmd:${RID}`);
+  });
+});
+
+describe('extractCodexAppServerApproval — item/fileChange/requestApproval', () => {
+  it('uses default reason and risk=medium without grant_root', () => {
+    const approval = extractCodexAppServerApproval({
+      method: 'item/fileChange/requestApproval',
+      params: { itemId: 'item-7' },
+      requestIdKey: RID,
+      sessionId: SID,
+    });
+    expect(approval!.permissionKey).toBe(`${SID}:patch:item-7`);
+    expect(approval!.command).toBe('apply_patch');
+    expect(approval!.risk).toBe('medium');
+    expect(approval!.mapDecision('deny')).toBe('decline');
+  });
+
+  it('escalates to high risk when grantRoot is supplied', () => {
+    const approval = extractCodexAppServerApproval({
+      method: 'item/fileChange/requestApproval',
+      params: { itemId: 'item-7', grantRoot: '/workspace' },
+      requestIdKey: RID,
+      sessionId: SID,
+    });
+    expect(approval!.risk).toBe('high');
+    expect(approval!.command).toBe('apply_patch (grant_root: /workspace)');
+  });
+});
+
+describe('extractCodexAppServerApproval — legacy execCommandApproval', () => {
+  it('joins string-array command and uses legacy decision tokens', () => {
+    const approval = extractCodexAppServerApproval({
+      method: 'execCommandApproval',
+      params: { callId: 'c-1', command: ['rm', '-rf', '/tmp/foo'] },
+      requestIdKey: RID,
+      sessionId: SID,
+    });
+    expect(approval!.permissionKey).toBe(`${SID}:legacy-exec:c-1`);
+    expect(approval!.command).toBe('rm -rf /tmp/foo');
+    expect(approval!.mapDecision('allow_session')).toBe('approved_for_session');
+  });
+});
+
+describe('extractCodexAppServerApproval — legacy applyPatchApproval', () => {
+  it('builds patch command and uses legacy decision tokens', () => {
+    const approval = extractCodexAppServerApproval({
+      method: 'applyPatchApproval',
+      params: { callId: 'c-2', grantRoot: '/repo' },
+      requestIdKey: RID,
+      sessionId: SID,
+    });
+    expect(approval!.permissionKey).toBe(`${SID}:legacy-patch:c-2`);
+    expect(approval!.command).toBe('apply_patch (grant_root: /repo)');
+    expect(approval!.risk).toBe('high');
+    expect(approval!.mapDecision('allow')).toBe('approved');
+  });
+});
+
+describe('extractCodexAppServerApproval — unknown methods', () => {
+  it('returns null for non-approval methods', () => {
+    expect(extractCodexAppServerApproval({
+      method: 'thread/started',
+      params: {},
+      requestIdKey: RID,
+      sessionId: SID,
+    })).toBeNull();
+
+    expect(extractCodexAppServerApproval({
+      method: 'mcpServer/elicitation/request',
+      params: {},
+      requestIdKey: RID,
+      sessionId: SID,
+    })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 Sprint 5 — codex 승인 채널 로직을 `runtimeCore.ts`에서 `providers/codex/codexPermissionBridge.ts`로 분리. `claudePermissionBridge.ts` 패턴 그대로.

## 변경

### 신규 파일

**`codexPermissionBridge.ts`** (~245줄)
- `normalizeCodexApprovalPolicy` — ApprovalPolicy → codex가 받는 3개 값으로 narrowing
- `mapCodexDecisionForCommandApproval` — modern 명령 채널 응답 토큰
- `mapCodexDecisionForPatchApproval` — modern 패치 채널 응답 토큰  
- `mapCodexDecisionForLegacyReview` — legacy MCP 리뷰 응답 토큰
- `extractCodexAppServerApproval` — 4개 승인 JSON-RPC 메서드 모두 처리하는 단일 진입점
  - 반환: `CodexAppServerApprovalRequest { permissionKey, command, reason, risk, mapDecision }`
  - 호출자는 `registerPermissionResponder`로 dispatch

### 수정 파일

**`runtimeCore.ts`** (-135줄, +16줄, net -119줄)
- 4개 `if (method === '...')` 권한 분기 → `extractCodexAppServerApproval` 단일 호출로 축소
- 4개 함수 로컬 정의 삭제

지원 메서드:
- `item/commandExecution/requestApproval` (modern command)
- `item/fileChange/requestApproval` (modern patch)
- `execCommandApproval` (legacy review)
- `applyPatchApproval` (legacy review)

기존 동작 보존:
- network context / grant_root 신호로 risk='high' 격상
- `bash -lc` / `sh -lc` 래퍼 unwrap
- legacy 채널은 `approved/denied/approved_for_session` 토큰
- modern 채널은 `accept/decline/acceptForSession` 토큰

## 안전 검증

- ✅ `tsc --noEmit` clean (aris-backend)
- ✅ `vitest run --exclude e2e`: **315/315 PASS** (회귀 0건)
- ✅ 신규 `codexPermissionBridge.test.ts`: **14/14 PASS**
  - 정책 normalize (yolo → on-request fallback 포함)
  - 양 채널 decision 매핑
  - 4개 메서드별 추출 (risk 격상, shell unwrap, array command join)

## 다음

Sprint 6: `codexRuntime.ts` 신설 + `runCodexCliWithEvents`/`runCodexAppServerWithEvents`/`runCodexExecCliWithEvents` 본체 추출 + `CodexAdapter.parseStdout()` 배선 + runtimeCore.ts에 codex 키워드 0회 달성.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run --exclude e2e` 315/315 PASS
- [x] `codexPermissionBridge.test.ts` 14/14 PASS
- [x] runtimeCore.ts 권한 분기 단일 호출로 축소 확인