### PR TITLE
fix(web): mobile chat 외부 스크롤·컴포저 펄럭임 제거

### DIFF
--- a/services/aris-web/components/layout/ViewportHeightSync.tsx
+++ b/services/aris-web/components/layout/ViewportHeightSync.tsx
@@ -9,7 +9,7 @@ export const VIEWPORT_LAYOUT_CHANGE_EVENT = 'aris:viewport-layout-change';
 export function ViewportHeightSync() {
   useEffect(() => {
     const root = document.documentElement;
-    let maxViewportHeight = window.visualViewport?.height ?? window.innerHeight;
+    let lastNoKeyboardHeight = window.visualViewport?.height ?? window.innerHeight;
     let lastInnerWidth = window.innerWidth;
     let previousMetrics: {
       appViewportHeight: number;
@@ -28,18 +28,25 @@ export function ViewportHeightSync() {
       const layoutViewportHeight = window.innerHeight;
       const orientationChanged = Math.abs(innerWidth - lastInnerWidth) > 120;
       if (orientationChanged) {
-        maxViewportHeight = height;
+        lastNoKeyboardHeight = height;
         lastInnerWidth = innerWidth;
       }
-      if (height > maxViewportHeight) {
-        maxViewportHeight = height;
+
+      // bottomInset = layout viewport에서 visible viewport와 top offset을 뺀 나머지.
+      // iOS Safari 하단 툴바, 하단 URL바, 또는 가상 키보드가 점유하는 영역.
+      const bottomInset = Math.max(0, layoutViewportHeight - height - viewportOffsetTop);
+      const keyboardOpen = bottomInset > 120;
+      const keyboardInset = keyboardOpen ? bottomInset : 0;
+      const visualViewportBottomInset = keyboardOpen ? 0 : bottomInset;
+
+      // 키보드가 닫혀 있는 동안에는 --app-vh가 현재 visible viewport를 그대로 따라가도록 한다.
+      // (이 잠금을 풀지 않으면 maxViewportHeight가 URL바 숨김 상태로 굳어져서 외부 스크롤이 발생한다.)
+      // 키보드가 열린 동안에만 직전 닫힘 상태의 높이로 고정해서 채팅 컨테이너 reflow를 방지한다.
+      if (!keyboardOpen) {
+        lastNoKeyboardHeight = height;
       }
-      const historicalBottomInset = Math.max(0, maxViewportHeight - height - viewportOffsetTop);
-      const layoutBottomInset = Math.max(0, layoutViewportHeight - height - viewportOffsetTop);
-      const visualViewportBottomInset = Math.max(historicalBottomInset, layoutBottomInset);
-      const keyboardInset = visualViewportBottomInset;
-      const keyboardOpen = keyboardInset > 120;
-      const appViewportHeight = keyboardOpen ? height : maxViewportHeight;
+      const appViewportHeight = keyboardOpen ? lastNoKeyboardHeight : height;
+
       const vh = height * 0.01;
       root.style.setProperty('--vh', `${vh}px`);
       root.style.setProperty('--app-vh', `${appViewportHeight}px`);
@@ -69,7 +76,7 @@ export function ViewportHeightSync() {
           metricsChanged,
           ...nextMetrics,
           layoutViewportHeight,
-          maxViewportHeight,
+          lastNoKeyboardHeight,
           keyboardOpen,
         },
       });


### PR DESCRIPTION
## 요약

모바일 채팅 화면에서 외부(body 레벨) 스크롤이 발생하고, 그로 인해 컴포저가 위아래로 펄럭이는 치명적 UX 버그를 수정.

## 근본 원인

`ViewportHeightSync.tsx`가 `maxViewportHeight` (해당 orientation에서 관찰한 visual viewport 최대값)를 영구히 잠가 둔 채 `--app-vh`를 그 값으로 설정.

- 모바일 첫 스크롤 시 URL바가 자동으로 숨겨지며 `visualViewport.height`가 커지고 → `maxViewportHeight`도 같이 커짐 → 영구히 그 값 유지
- 이후 URL바가 다시 나타나면 `--app-vh > 현재 visible viewport`
- `.app-shell-chat-screen { height: var(--app-vh) }`이 visible viewport보다 커지므로 body 레벨에 **외부 스크롤** 발생
- 동시에 `--visual-viewport-bottom-inset`이 `max(historical, layout)`로 계산되며 historical max 오염을 받아, URL바 토글 시 컴포저 `bottom`이 펄럭임

## 변경 사항

`ViewportHeightSync.tsx`만 수정 (1 file, +18 / −11):

1. **`maxViewportHeight` 잠금 제거** — 평상시 `--app-vh`가 현재 `visualViewport.height`를 그대로 추적. 외부 스크롤 원인 제거.
2. **키보드 reflow 보호 유지** — 키보드가 열린 동안에만 `lastNoKeyboardHeight`로 lock해서 채팅 컨테이너 reflow 방지.
3. **`--visual-viewport-bottom-inset` 정확화** — `layoutHeight - height - offsetTop`만 사용. historical max 기반 계산 제거. URL바(top) 토글이 bottom inset을 오염시키지 않음.
4. **변수 의미 분리** — `--keyboard-inset-height`는 `keyboardOpen=true`일 때만 비제로, `--visual-viewport-bottom-inset`은 `keyboardOpen=false`일 때만 비제로. iOS 하단 툴바/URL바 위에 컴포저 유지(메모리 11952 fix 보존).

## 검증

- `tsc --noEmit`: 통과
- `vitest run` (aris-web): 461 pass / 5 pre-existing fail (디자인 시스템 CSS 매칭, sessionEventsRoute — 모두 본 변경과 무관)
- dev hot reload 서버 기동: OK (port 2234)

## Test plan

- [ ] 모바일에서 채팅 화면 진입 시 외부 스크롤 없는지 확인
- [ ] URL바 자동 토글 시 컴포저가 펄럭이지 않는지 확인
- [ ] 입력 탭하여 키보드 열림/닫힘 시 컴포저 정상 동작 확인 (reflow 없이 키보드 위로 이동)
- [ ] iOS Safari 하단 툴바/URL바 위에 컴포저가 유지되는지 확인 (메모리 11952 fix 회귀 없음)
