### PR TITLE
fix(web): 모바일 채팅 진입 시 UI 위로 밀리는 잔여 회귀 제거

### DIFF
--- a/services/aris-web/app/styles/layout.css
+++ b/services/aris-web/app/styles/layout.css
@@ -1,4 +1,17 @@
 /* Layout Utilities */
+
+/* Lock window scroll on immersive/chat layouts.
+   .app-shell-chat-screen은 visible viewport와 같은 높이로 의도되어 있지만,
+   초기 페인트(JS sync 전) 또는 scrollIntoView 호출이 body를 스크롤시켜
+   상단 헤더가 viewport 위로 밀려 올라가는 회귀가 있어 명시적으로 잠근다. */
+html:has(body > .app-shell-chat-screen),
+html:has(body > .app-shell-immersive),
+body:has(> .app-shell-chat-screen),
+body:has(> .app-shell-immersive) {
+  overflow: hidden;
+  height: 100%;
+}
+
 .app-shell {
   display: flex;
   flex-direction: column;

--- a/services/aris-web/app/styles/tokens.css
+++ b/services/aris-web/app/styles/tokens.css
@@ -250,6 +250,15 @@
   --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
 }
 
+/* iOS Safari 15.4+: dvh가 layout viewport(URL바·툴바 포함)보다 작은 dynamic 값이라
+   초기 페인트에서 .app-shell-chat-screen이 visible viewport를 넘어 body 스크롤을 만드는 것을 방지. */
+@supports (height: 100dvh) {
+  :root {
+    --app-vh: 100dvh;
+    --visual-viewport-height: 100dvh;
+  }
+}
+
 html[data-theme='dark'] {
   color-scheme: dark;
   --b-50: #112358;


### PR DESCRIPTION
## Summary

PR #307 이후에도 모바일 채팅 진입 시 컴포저 포함 전체 UI가 viewport 위로 밀려 올라가는 회귀가 남아 있었다. 이번 PR은 그 잔여 회귀를 CSS 레벨에서 제거한다.

## Root cause

1. `tokens.css`의 fallback `--app-vh: 100vh`가 iOS Safari layout viewport(주소창·하단 툴바 포함된 큰 값)와 동일해, 초기 페인트(JS sync 전) 시점에 `.app-shell-chat-screen` 높이가 visible viewport보다 큼.
2. `html`/`body`에 `overflow-y` 잠금이 없어 window 스크롤이 가능 상태.
3. 진입 직후 `useChatTailRestore.restoreConversationToTail()` → `anchor.scrollIntoView({ block: 'end' })`가 overflow:auto/visible ancestors를 따라 올라가며 body를 스크롤 → 헤더가 viewport 위로 밀려 올라감.
4. `ViewportHeightSync`가 useEffect에서 정확한 값으로 `--app-vh`를 보정해 shell 높이는 줄어들지만 `window.scrollY > 0`은 잔존하여 UI가 위로 밀린 채로 남음.

## Fix

`services/aris-web/app/styles/tokens.css`
- `@supports (height: 100dvh)` 분기에서 `--app-vh: 100dvh`, `--visual-viewport-height: 100dvh`로 덮어써 초기 페인트 단계부터 dynamic viewport와 일치하게 만듦. 미지원 브라우저는 기존 `100vh` fallback 유지.

`services/aris-web/app/styles/layout.css`
- `:has()` selector로 `.app-shell-chat-screen` 또는 `.app-shell-immersive`가 직속 자식인 경우에만 `html, body { overflow: hidden; height: 100% }` 적용.
- login·workspace home·settings 등 다른 레이아웃의 body 스크롤은 영향 없음.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` for `mobileOverflowLayout` / `mobileScrollAutoHide` / `scrollDebug` / `chatTailRestoreSettle` / `chatTailRestoreActions` — 27/28 (실패 1건은 main에서도 동일하게 발생하는 pre-existing 회귀, 본 변경과 무관)
- [ ] 사용자 모바일 디바이스에서 채팅 진입 시 UI 정렬 확인 (배포 후)
- [ ] 키보드 open/close 동안 컴포저 위치 안정성 회귀 없음 (PR #307 검증 항목)
- [ ] login / workspace home / settings 페이지에서 body 스크롤 정상 동작
