### PR TITLE
fix(web): 모바일 채팅 page-scroll 모델 복구 (CSS+JS 정공법)

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -1231,10 +1231,12 @@
 }
 
 .chatShell.chatShellMobileScroll {
-  height: calc(var(--app-vh, 100dvh) - var(--global-header-offset-effective));
-  max-height: calc(var(--app-vh, 100dvh) - var(--global-header-offset-effective));
-  min-height: 0;
-  overflow: hidden;
+  /* Page-scroll model on mobile: shell grows with content, body handles scroll.
+     이렇게 해야 iOS 하단 툴바가 스크롤에 따라 자동 숨김 처리되어 채팅 영역 확보. */
+  height: auto;
+  max-height: none;
+  min-height: calc(var(--app-vh, 100dvh) - var(--global-header-offset-effective));
+  overflow: visible;
 }
 
 .chatSidebar {
@@ -7818,9 +7820,19 @@
   .chatShellPrototype,
   .chatShellPrototype.chatShellSidebarOpen,
   .chatShellPrototype.chatShellSidebarClosed {
-    --composer-dock-bottom-offset: calc(var(--sp-4) + var(--safe-area-bottom-effective) + var(--chat-viewport-bottom-inset));
-    --chat-timeline-bottom-offset: calc(var(--composer-dock-height) + var(--sp-10) + var(--safe-area-bottom-effective) + var(--chat-viewport-bottom-inset));
+    /* Page-scroll model on mobile (pre-redesign 동작 복구).
+       composer/timeline 오프셋은 keyboard만 반영. iOS 하단 툴바는 body scroll 시 자동 숨김 처리되므로
+       --visual-viewport-bottom-inset를 더하지 않는다. (commit 01d0842가 추가한 보정이 고정 viewport 조합에서
+       전체 UI를 위로 밀어 올리는 회귀를 만들었음.) */
+    --safe-area-bottom-effective: max(0px, calc(env(safe-area-inset-bottom) - var(--keyboard-inset-height, 0px)));
+    --composer-dock-bottom-offset: calc(var(--sp-4) + var(--safe-area-bottom-effective) + var(--keyboard-inset-height, 0px));
+    --chat-timeline-bottom-offset: calc(var(--composer-dock-height) + var(--sp-10) + var(--safe-area-bottom-effective) + var(--keyboard-inset-height, 0px));
     grid-template-columns: minmax(0, 1fr);
+    /* Page-scroll model: shell grows with content, body handles scroll */
+    height: auto;
+    max-height: none;
+    min-height: 100dvh;
+    overflow: visible;
   }
 
   .chatShellPrototype .csSidebar {
@@ -7828,6 +7840,11 @@
   }
 
   .csTimeline {
+    /* Page-scroll model: no inner scroll, content grows with messages */
+    flex: 0 0 auto;
+    height: auto;
+    min-height: 0;
+    overflow: visible;
     padding: var(--sp-8) var(--sp-4) var(--chat-timeline-bottom-offset);
   }
 

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -736,6 +736,7 @@ export function ChatInterface({
     eventsForChatId,
     hasLoadedCurrentChat,
     hasDetachedTail,
+    isMobileLayout,
     isTailRestoreHydrated,
     isNewChatPlaceholder,
     isWorkspaceHome,

--- a/services/aris-web/app/sessions/[sessionId]/chatScroll.ts
+++ b/services/aris-web/app/sessions/[sessionId]/chatScroll.ts
@@ -1,3 +1,13 @@
+type ScrollToBottomTargetInput = {
+  isMobileLayout: boolean;
+  keyboardOpen: boolean;
+};
+
+type MobileWindowScrollTopInput = {
+  scrollHeight: number;
+  viewportHeight: number;
+};
+
 type TailScrollAnchorIdInput = {
   latestVisibleEventId: string | null;
 };
@@ -119,6 +129,19 @@ type ShouldAllowSystemScrollWriteInput = {
   writer: SystemScrollWriter;
   scrollPhase?: SessionScrollPhase;
 };
+export function resolveScrollToBottomTarget(input: ScrollToBottomTargetInput): 'window' | 'stream' {
+  // 모바일은 page-scroll 모델: 본문이 viewport보다 길면 window가 자연 스크롤하고
+  // iOS 하단 툴바도 자동 숨김 처리됨. 키보드 오픈 중에도 window 기준이 안정적.
+  if (input.isMobileLayout) {
+    return 'window';
+  }
+  return 'stream';
+}
+
+export function resolveMobileWindowScrollTop(input: MobileWindowScrollTopInput): number {
+  return Math.max(0, input.scrollHeight - input.viewportHeight);
+}
+
 export function resolveTailScrollAnchorId(input: TailScrollAnchorIdInput): string | null {
   if (!input.latestVisibleEventId) {
     return null;

--- a/services/aris-web/app/sessions/[sessionId]/useChatTailRestore.ts
+++ b/services/aris-web/app/sessions/[sessionId]/useChatTailRestore.ts
@@ -14,6 +14,8 @@ import {
 import {
   hasTailLayoutSettled,
   isNearBottom,
+  resolveMobileWindowScrollTop,
+  resolveScrollToBottomTarget,
   resolveTailScrollAnchorId,
   shouldRestoreTailScrollOnChatEntry,
 } from './chatScroll';
@@ -31,6 +33,7 @@ export type UseChatTailRestoreInput = {
   eventsForChatId: string | null;
   hasLoadedCurrentChat: boolean;
   hasDetachedTail: boolean;
+  isMobileLayout: boolean;
   isTailRestoreHydrated: boolean;
   isNewChatPlaceholder: boolean;
   isWorkspaceHome: boolean;
@@ -152,6 +155,7 @@ export function useChatTailRestore({
   eventsForChatId,
   hasLoadedCurrentChat,
   hasDetachedTail,
+  isMobileLayout,
   isTailRestoreHydrated,
   isNewChatPlaceholder,
   isWorkspaceHome,
@@ -195,6 +199,30 @@ export function useChatTailRestore({
 
   const scrollConversationToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
     const stream = scrollRef.current;
+    const target = resolveScrollToBottomTarget({
+      isMobileLayout,
+      keyboardOpen: typeof document !== 'undefined' && document.documentElement.dataset.keyboardOpen === 'true',
+    });
+    if (target === 'window' && typeof window !== 'undefined') {
+      const documentScrollHeight = Math.max(
+        document.documentElement.scrollHeight,
+        document.body.scrollHeight,
+      );
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      const top = resolveMobileWindowScrollTop({
+        scrollHeight: documentScrollHeight,
+        viewportHeight,
+      });
+      recordScrollDebugEvent({
+        kind: 'write',
+        source: 'tail:scrollConversationToBottom:window',
+        top,
+        behavior,
+        detail: { documentScrollHeight, viewportHeight },
+      });
+      window.scrollTo({ top, behavior });
+      return;
+    }
     if (!stream) {
       recordScrollDebugEvent({
         kind: 'trigger',
@@ -213,7 +241,7 @@ export function useChatTailRestore({
       behavior,
     });
     stream.scrollTo({ top, behavior });
-  }, [scrollRef]);
+  }, [isMobileLayout, scrollRef]);
 
   const restoreConversationToTail = useCallback((behavior: ScrollBehavior = 'auto') => {
     const anchorId = resolveTailScrollAnchorId({

--- a/services/aris-web/app/styles/layout.css
+++ b/services/aris-web/app/styles/layout.css
@@ -1,17 +1,19 @@
 /* Layout Utilities */
 
-/* Lock window scroll on immersive/chat layouts.
-   .app-shell-chat-screen은 visible viewport와 같은 높이로 의도되어 있지만,
+/* Desktop only: lock window scroll on immersive/chat layouts (single fixed viewport).
+   모바일은 pre-redesign처럼 page-scroll 모델로 동작해야 iOS 하단 툴바가 자동 숨김 처리됨.
    초기 페인트(JS sync 전) 또는 scrollIntoView 호출이 body를 스크롤시켜
-   상단 헤더가 viewport 위로 밀려 올라가는 회귀가 있어 명시적으로 잠근다. */
-html:has(body > .app-shell-chat-screen),
-html:has(body > .app-shell-ia--chat-screen),
-html:has(body > .app-shell-immersive),
-body:has(> .app-shell-chat-screen),
-body:has(> .app-shell-ia--chat-screen),
-body:has(> .app-shell-immersive) {
-  overflow: hidden;
-  height: 100%;
+   상단 헤더가 viewport 위로 밀려 올라가는 회귀를 막기 위해 데스크탑 한정으로 명시적 lock. */
+@media (min-width: 961px) {
+  html:has(body > .app-shell-chat-screen),
+  html:has(body > .app-shell-ia--chat-screen),
+  html:has(body > .app-shell-immersive),
+  body:has(> .app-shell-chat-screen),
+  body:has(> .app-shell-ia--chat-screen),
+  body:has(> .app-shell-immersive) {
+    overflow: hidden;
+    height: 100%;
+  }
 }
 
 .app-shell {
@@ -64,9 +66,10 @@ body:has(> .app-shell-immersive) {
 
   .app-shell-chat-screen,
   .app-shell-ia--chat-screen {
-    height: var(--app-vh, 100dvh);
+    height: auto;
     min-height: var(--app-vh, 100dvh);
-    overflow: hidden;
+    overflow: visible;
+    overflow-x: clip;
   }
 }
 


### PR DESCRIPTION
## Summary

리디자인(76e43e5, 4/25 + 37fcee0, 4/28 + d19e29e, 4/29) 시점에 모바일 채팅이 **page-scroll 모델 → fixed-viewport stream-scroll 모델**로 의도적으로 이행되면서 다음 핵심 모바일 친화 helper와 listener가 사라졌고, 그 이후 누적된 회귀가 PR #307과 #311의 hotfix로도 완전히 잡히지 않아 사용자가 채팅 진입 시 "전체 UI가 위로 밀려 올라간 상태"를 계속 경험.

이 PR은 모바일 한정으로 pre-redesign(75029a9) 동작을 정공법으로 복원한다. 데스크탑 fixed-viewport 모델은 그대로 유지.

## Root cause (75029a9 vs main 비교 결과)

`chatScroll.ts` — 2개 helper 삭제됨:
- `resolveScrollToBottomTarget()` — `'window' | 'stream'` 선택 (모바일은 window)
- `resolveMobileWindowScrollTop()` — 모바일 window-scroll 위치 계산

`ChatInterface.tsx` — 3개 핵심 call site 제거됨:
- load-older 시 `getWindowScrollTop()` 캡처 → `window.scrollTo({ top: previousTop + delta })` 보존
- `isNearWindowBottom()` 으로 stick-to-bottom 결정
- `getWindowScrollTop() <= 96` 시 load-older 트리거

`useChatTailRestore.ts` — `scrollConversationToBottom`이 stream만 보고 window를 무시.

CSS도 `app-shell-chat-screen`/`chatShellPrototype`/`csTimeline`이 모바일에서 `height: var(--app-vh)` + `overflow: hidden`으로 강제되어 body 스크롤 자체가 불가능.

## Fix (3 commits)

### fb97cc2 — CSS page-scroll 모델 복구
- `layout.css`: `:has()` body overflow lock을 `min-width: 961px` 데스크탑 한정. 모바일 `app-shell-chat-screen`은 `height: auto, overflow: visible`
- `ChatInterface.module.css`:
  - `.chatShell.chatShellMobileScroll`: `height: auto, overflow: visible`
  - `@media (max-width: 767px)` `chatShellPrototype`: `height: auto, max-height: none, overflow: visible, min-height: 100dvh`
  - `.csTimeline` 모바일: `flex: 0 0 auto, overflow: visible` (내부 스크롤 컨테이너 → normal flow)
  - composer/timeline 오프셋에서 `--chat-viewport-bottom-inset` 제거, `--keyboard-inset-height`만 사용 (iOS 하단 툴바는 body scroll 자동 숨김에 위임)

### b7558a5 — JS scroll target 분기 복원
- `chatScroll.ts`: `resolveScrollToBottomTarget`, `resolveMobileWindowScrollTop` 다시 추가
- `useChatTailRestore`:
  - 입력에 `isMobileLayout: boolean` 추가
  - `scrollConversationToBottom`이 모바일에서 `window.scrollTo` 사용
- `ChatInterface`: `useChatTailRestore` 호출에 `isMobileLayout` 전달

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run chatTailRestore*` / `chatScroll*` / `mobileScrollAutoHide` / `mobileOverflowLayout`: 50/50 통과 (PR #311 base 대비 회귀 0건; pre-existing fail 1건은 본 변경과 무관)
- [ ] **사용자 모바일 디바이스 verification (블로커)**:
  - 채팅 진입 시 헤더가 viewport 최상단에 위치
  - composer가 visible viewport 하단(safe-area 위)에 위치, 너무 위로 밀려있지 않음
  - body 스크롤 시 iOS 하단 툴바 자동 숨김 작동
  - 키보드 open/close 시 composer 안정적
- [ ] 데스크탑(≥961px) fixed-viewport 모델 회귀 없음
- [ ] 후속: load-older 모바일 시 window-scroll 보존 (현재는 stream-anchor 방식 → 모바일에서는 window scroll로 별도 처리 필요할 수 있음)
