### PR TITLE
fix(web): 모바일 키보드 가림 - 포커스 시점 viewport 강제 sync

### DIFF
--- a/services/aris-web/components/layout/ViewportHeightSync.tsx
+++ b/services/aris-web/components/layout/ViewportHeightSync.tsx
@@ -6,6 +6,25 @@ import { recordScrollDebugEvent } from '@/app/sessions/[sessionId]/scrollDebug';
 
 export const VIEWPORT_LAYOUT_CHANGE_EVENT = 'aris:viewport-layout-change';
 
+const KEYBOARD_INSET_THRESHOLD_DEFAULT_PX = 120;
+// 입력 요소가 포커스 상태일 때는 키보드일 가능성이 높으므로 임계값을 낮춰
+// 작은 가상 키보드/부분 키보드/키보드 애니메이션 중간 상태에서도 inset이 적용되도록 한다.
+const KEYBOARD_INSET_THRESHOLD_FOCUSED_PX = 60;
+
+const isTextInputElement = (element: Element | null): boolean => {
+  if (!element) return false;
+  const tag = element.tagName;
+  if (tag === 'TEXTAREA') return true;
+  if (tag === 'INPUT') {
+    const type = (element as HTMLInputElement).type?.toLowerCase();
+    // checkbox/radio/file/button 등은 포커스되어도 키보드를 띄우지 않는다.
+    return type !== 'checkbox' && type !== 'radio' && type !== 'button'
+      && type !== 'submit' && type !== 'reset' && type !== 'file'
+      && type !== 'color' && type !== 'range' && type !== 'image';
+  }
+  return (element as HTMLElement).isContentEditable === true;
+};
+
 export function ViewportHeightSync() {
   useEffect(() => {
     const root = document.documentElement;
@@ -18,6 +37,16 @@ export function ViewportHeightSync() {
       visualViewportBottomInset: number;
       viewportOffsetTop: number;
     } | null = null;
+    const focusResyncTimeouts: number[] = [];
+
+    const clearFocusResyncTimeouts = () => {
+      while (focusResyncTimeouts.length > 0) {
+        const id = focusResyncTimeouts.pop();
+        if (typeof id === 'number') {
+          window.clearTimeout(id);
+        }
+      }
+    };
 
     const updateViewportHeight = (reason: string) => {
       // visualViewport.height는 iOS Safari 주소창 슬라이드 시 정확한 높이를 반환
@@ -35,7 +64,13 @@ export function ViewportHeightSync() {
       // bottomInset = layout viewport에서 visible viewport와 top offset을 뺀 나머지.
       // iOS Safari 하단 툴바, 하단 URL바, 또는 가상 키보드가 점유하는 영역.
       const bottomInset = Math.max(0, layoutViewportHeight - height - viewportOffsetTop);
-      const keyboardOpen = bottomInset > 120;
+      // 입력 요소가 포커스되어 있다면 가상 키보드일 가능성이 높으므로
+      // URL바와 키보드를 구분하는 임계값을 낮춰 키보드 inset이 끊기는 회귀를 막는다.
+      const focusedTextInput = isTextInputElement(document.activeElement);
+      const threshold = focusedTextInput
+        ? KEYBOARD_INSET_THRESHOLD_FOCUSED_PX
+        : KEYBOARD_INSET_THRESHOLD_DEFAULT_PX;
+      const keyboardOpen = bottomInset > threshold;
       const keyboardInset = keyboardOpen ? bottomInset : 0;
       const visualViewportBottomInset = keyboardOpen ? 0 : bottomInset;
 
@@ -78,6 +113,8 @@ export function ViewportHeightSync() {
           layoutViewportHeight,
           lastNoKeyboardHeight,
           keyboardOpen,
+          threshold,
+          focusedTextInput,
         },
       });
       if (metricsChanged) {
@@ -101,6 +138,37 @@ export function ViewportHeightSync() {
     const handleVisualViewportScroll = () => {
       updateViewportHeight('visualViewport:scroll');
     };
+    // iOS Safari: 입력 요소에 포커스되는 순간 키보드 애니메이션이 시작되지만
+    // visualViewport.resize는 애니메이션 도중 한두 프레임 늦게 또는 중간 값으로
+    // 한 차례만 발화할 수 있다. focus 시점에 강제 sync + 100/300/600ms 후 재sync해서
+    // 키보드 최종 높이가 안정된 시점에 inset CSS 변수가 확실히 반영되도록 한다.
+    const handleDocumentFocusIn = (event: FocusEvent) => {
+      if (!isTextInputElement(event.target as Element | null)) {
+        return;
+      }
+      clearFocusResyncTimeouts();
+      updateViewportHeight('document:focusin');
+      [100, 300, 600].forEach((delay) => {
+        const id = window.setTimeout(() => {
+          updateViewportHeight(`document:focusin:resync:${delay}ms`);
+        }, delay);
+        focusResyncTimeouts.push(id);
+      });
+    };
+    const handleDocumentFocusOut = (event: FocusEvent) => {
+      if (!isTextInputElement(event.target as Element | null)) {
+        return;
+      }
+      clearFocusResyncTimeouts();
+      // 키보드가 닫히는 애니메이션도 한 번에 끝나지 않을 수 있어 같은 패턴으로 재sync.
+      updateViewportHeight('document:focusout');
+      [100, 300, 600].forEach((delay) => {
+        const id = window.setTimeout(() => {
+          updateViewportHeight(`document:focusout:resync:${delay}ms`);
+        }, delay);
+        focusResyncTimeouts.push(id);
+      });
+    };
 
     updateViewportHeight('mount');
 
@@ -111,12 +179,17 @@ export function ViewportHeightSync() {
     // window.resize는 이 경우 발생하지 않아 --vh가 stale해지는 문제 해결
     window.visualViewport?.addEventListener('resize', handleVisualViewportResize, { passive: true } as EventListenerOptions);
     window.visualViewport?.addEventListener('scroll', handleVisualViewportScroll, { passive: true } as EventListenerOptions);
+    document.addEventListener('focusin', handleDocumentFocusIn, { passive: true } as EventListenerOptions);
+    document.addEventListener('focusout', handleDocumentFocusOut, { passive: true } as EventListenerOptions);
 
     return () => {
+      clearFocusResyncTimeouts();
       window.removeEventListener('resize', handleWindowResize);
       window.removeEventListener('orientationchange', handleOrientationChange);
       window.visualViewport?.removeEventListener('resize', handleVisualViewportResize);
       window.visualViewport?.removeEventListener('scroll', handleVisualViewportScroll);
+      document.removeEventListener('focusin', handleDocumentFocusIn);
+      document.removeEventListener('focusout', handleDocumentFocusOut);
       delete root.dataset.keyboardOpen;
       root.style.removeProperty('--keyboard-inset-height');
       root.style.removeProperty('--visual-viewport-bottom-inset');


### PR DESCRIPTION
## Summary

모바일 가상 키보드가 올라올 때 입력 컴포저/콘텐츠 일부가 키보드 뒤에 가려지는 회귀 수정.

## Root cause

`ViewportHeightSync`는 `visualViewport.resize/scroll`만 구독해서 keyboard inset을 갱신했는데, iOS Safari/Chrome에서 다음 두 가지 문제 발생:

1. resize 이벤트가 키보드 애니메이션 도중 한두 프레임 늦거나 중간 값으로만 발화 → 최종 keyboard inset이 반영되지 않음.
2. `bottomInset > 120` 임계값이 보수적이라 부분 inset/작은 가상 키보드 상태에서 `keyboardOpen=false`로 떨어지며 `--keyboard-inset-height=0` → composer가 키보드 높이만큼 못 올라감.

## Fix

`services/aris-web/components/layout/ViewportHeightSync.tsx`:

- `document` 레벨 `focusin`/`focusout`에서 텍스트 입력 요소(textarea / text-like input / contentEditable)일 때만 즉시 + 100/300/600ms 후 `updateViewportHeight` 재sync. 키보드 애니메이션 종료 시점에 inset CSS 변수가 확실히 안정화되도록 함.
- 텍스트 입력이 포커스된 동안에는 `keyboardOpen` 임계값을 `60px`로 낮춤. 포커스가 없을 때(URL바 변동을 키보드로 오인하면 안 되는 일반 상태)는 기존 `120px` 유지.
- `scrollDebug` 트레이스에 `threshold`/`focusedTextInput` 필드 추가하여 실디바이스 검증 시 임계 판정 흐름 확인 가능.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run tests/scrollDebug.test.ts tests/chatComposerDockLayout.test.ts`: 7 PASS / 1 FAIL — 실패 1건은 main 기준 동일 (pre-existing, 본 PR과 무관)
- [ ] 사용자 모바일 디바이스 verification:
  - 컴포저 textarea 탭 → 키보드 올라올 때 컴포저가 키보드 위 visible viewport 하단에 안정적으로 위치
  - 키보드 닫힐 때 composer/콘텐츠 정상 복원
  - URL바 슬라이드(키보드 아닌 상태)는 `keyboardOpen` 트리거 안 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)
