### PR TITLE
fix(web): 모바일 채팅 이중 스크롤 회귀 제거 (.stream.streamMobileScroll page-scroll 정합)

### DIFF
--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.module.css
@@ -2798,12 +2798,16 @@
 }
 
 .stream.streamMobileScroll {
-  flex: 1;
-  height: 0;
+  /* Page-scroll model on mobile (PR #312 복구와 정합).
+     이 클래스는 isMobileLayout=true일 때만 적용되며 모바일은 page-scroll 모델이므로
+     inner stream scroll을 비활성화한다. body가 스크롤을 담당하지 않으면
+     outer body scroll + inner stream scroll로 이중 스크롤 회귀가 발생함. */
+  flex: 0 0 auto;
+  height: auto;
   min-height: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
-  overscroll-behavior-y: contain;
+  overflow: visible;
+  overflow-x: visible;
+  overscroll-behavior-y: auto;
 }
 
 .historyLoadMoreRow {


### PR DESCRIPTION
## Summary

PR #312 머지 후 모바일 채팅에서 발생한 **이중 스크롤** 회귀 수정. body page-scroll(PR #312)과 inner `.stream.streamMobileScroll` scroll이 동시에 동작.

## Root cause

PR #312가 모바일 page-scroll 복구 시 `@media (max-width: 767px)` 안에서 `.csTimeline { overflow: visible }`(specificity `0,1,0`)을 추가했지만, 같은 element는 `.stream.streamMobileScroll` 클래스도 함께 갖고 있고 base 정의가 `overflow-y: auto`(specificity `0,2,0`)라 specificity로 이김:

```tsx
// ChatTimeline.tsx:116
className={`${styles.stream} ${styles.csTimeline} ${isMobileLayout ? styles.streamMobileScroll : ''} ...`}
```

결과: outer body scroll(PR #312) + inner stream scroll = 이중 스크롤.

## Fix

`.stream.streamMobileScroll` base를 page-scroll 친화로 변경:

```diff
 .stream.streamMobileScroll {
-  flex: 1;
-  height: 0;
-  min-height: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
-  overscroll-behavior-y: contain;
+  flex: 0 0 auto;
+  height: auto;
+  min-height: 0;
+  overflow: visible;
+  overflow-x: visible;
+  overscroll-behavior-y: auto;
 }
```

`streamMobileScroll` 클래스는 `isMobileLayout=true` 조건으로만 추가되므로 데스크탑 영향 없음. PR #312의 `.chatShell.chatShellMobileScroll` 변경과 동일 패턴.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run chatTailRestore* / chatScroll* / mobileScrollAutoHide / mobileOverflowLayout`: 61 PASS / 1 FAIL — 실패 1건은 main 기준 동일 pre-existing, 본 PR 무관
- [ ] 사용자 모바일 디바이스 verification (iOS Safari):
  - 모바일 채팅에서 body page-scroll만 동작, inner stream scroll 사라짐
  - 컨텐츠 위로 밀리는 회귀 / 키보드 가림 회귀 모두 미발생

🤖 Generated with [Claude Code](https://claude.com/claude-code)
