### PR TITLE
feat(web): 채팅 화면 상단 헤더에 ARIS 로고·프로젝트명 표시

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -751,7 +751,19 @@ function Sidebar({
   );
 }
 
-function Topbar({ activeTab, sessions }: { activeTab: TabType; sessions: SessionSummary[] }) {
+function Topbar({
+  activeTab,
+  sessions,
+  chatScreenMode = false,
+  chatProjectName = null,
+  onLogoHome,
+}: {
+  activeTab: TabType;
+  sessions: SessionSummary[];
+  chatScreenMode?: boolean;
+  chatProjectName?: string | null;
+  onLogoHome?: () => void;
+}) {
   const [themeMode, setThemeMode] = useState<ThemeMode>('system');
   const activeProjects = sessions.filter((session) => session.status === 'running' || session.status === 'error').length;
   const copy: Record<TabType, { title: string; crumb: string }> = {
@@ -796,9 +808,30 @@ function Topbar({ activeTab, sessions }: { activeTab: TabType; sessions: Session
 
   return (
     <header className="m-top">
-      <div className="m-top__left">
-        <span className="m-top__title">{copy[activeTab].title}</span>
-        <span className="m-top__crumb">{copy[activeTab].crumb}</span>
+      <div className={`m-top__left${chatScreenMode ? ' m-top__left--chat' : ''}`}>
+        {chatScreenMode ? (
+          <>
+            <button
+              type="button"
+              className="m-top__brand"
+              onClick={onLogoHome}
+              aria-label="ARIS 홈으로 이동"
+            >
+              <span className="m-top__brand-logo" aria-hidden="true">A</span>
+              <span className="m-top__brand-name">ARIS</span>
+            </button>
+            {chatProjectName && (
+              <span className="m-top__project-name" title={chatProjectName}>
+                {chatProjectName}
+              </span>
+            )}
+          </>
+        ) : (
+          <>
+            <span className="m-top__title">{copy[activeTab].title}</span>
+            <span className="m-top__crumb">{copy[activeTab].crumb}</span>
+          </>
+        )}
       </div>
       <div className="m-top__right">
         {activeTab === 'project' && (
@@ -3582,6 +3615,14 @@ export default function HomePageWrapper({
   })();
 
   const shouldShowBottomNav = !(activeTab === 'project' && selectedProjectView === 'chat');
+  const isChatScreen = !shouldShowBottomNav;
+  const chatScreenProject = isChatScreen && selectedProjectId
+    ? sessions.find((session) => session.id === selectedProjectId) ?? null
+    : null;
+  const chatScreenProjectName = chatScreenProject ? displayProjectName(chatScreenProject) : null;
+  const handleTopbarLogoHome = () => {
+    handleTabChange('home');
+  };
 
   return (
     <div className={`app-shell app-shell-ia${shouldShowBottomNav ? '' : ' app-shell-ia--chat-screen'}`}>
@@ -3597,7 +3638,13 @@ export default function HomePageWrapper({
           user={user}
         />
         <main className="m-main">
-          <Topbar activeTab={activeTab} sessions={sessions} />
+          <Topbar
+            activeTab={activeTab}
+            sessions={sessions}
+            chatScreenMode={isChatScreen}
+            chatProjectName={chatScreenProjectName}
+            onLogoHome={handleTopbarLogoHome}
+          />
           {runtimeError && <div className="ia-runtime-notice"><BackendNotice message={runtimeError} /></div>}
           {content}
         </main>

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -849,6 +849,59 @@ html[data-theme='dark'] .m-sb__chat-child--active {
   white-space: nowrap;
 }
 
+.m-top__left--chat {
+  gap: var(--sp-3);
+}
+
+.m-top__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: 0;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--text-primary);
+  flex-shrink: 0;
+}
+
+.m-top__brand:hover .m-top__brand-name {
+  color: var(--text-primary);
+}
+
+.m-top__brand-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: var(--accent, #7c5cff);
+  color: #fff;
+  font-weight: 700;
+  font-size: var(--text-xs);
+  letter-spacing: 0;
+}
+
+.m-top__brand-name {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: 0;
+}
+
+.m-top__project-name {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--text-secondary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-left: var(--sp-3);
+  border-left: 1px solid var(--border-subtle);
+}
+
 .m-top__right {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- 채팅 화면(`activeTab === 'project' && selectedProjectView === 'chat'`)의 Topbar 좌측을 'Projects / N active · project chats in sidebar' 텍스트 대신 **ARIS 로고(홈 이동 버튼) + 현재 프로젝트명**으로 교체
- 다른 탭(home/ask/project list/files)에서는 기존 title/crumb 유지

## 변경 파일
- `services/aris-web/app/HomePageClient.tsx` — `Topbar` props 확장(`chatScreenMode`, `chatProjectName`, `onLogoHome`), 채팅 화면일 때 좌측 분기 렌더, 메인 렌더에서 props 전달
- `services/aris-web/app/styles/ui.css` — `.m-top__brand`, `.m-top__brand-logo`, `.m-top__brand-name`, `.m-top__project-name` 스타일 추가

## 검증
- `tsc --noEmit` ✅
- `vitest run tests/projectListSurface.test.ts tests/homeProjects.test.ts` ✅ (26/26 통과)
- dev hot reload: https://lawdigest.cloud/proxy/2233/

## Test plan
- [ ] 홈/Ask/Files 탭 → 기존 title/crumb 그대로 표시되는지
- [ ] 프로젝트 목록(`tab=project`, view=chats) → 'Projects · N active · project chats in sidebar' 그대로 노출
- [ ] 프로젝트 채팅 진입 → 좌측에 ARIS 로고 버튼과 프로젝트명만 표시
- [ ] ARIS 로고 클릭 → 홈 탭으로 이동 (`/?tab=home`)
- [ ] 모바일 폭에서도 좌측이 깨지지 않는지