### PR TITLE
fix(web): 채팅 메시지 전송 시 SessionChat.agent 동기화 + agent 변경 알림

### DIFF
--- a/services/aris-web/app/api/runtime/sessions/[sessionId]/events/route.ts
+++ b/services/aris-web/app/api/runtime/sessions/[sessionId]/events/route.ts
@@ -176,6 +176,36 @@ export async function POST(
         ...(resolved.fallbackReason ? { fallbackReason: resolved.fallbackReason } : {}),
         ...(resolved.requestedModel ? { requestedModel: resolved.requestedModel } : {}),
       };
+
+      if (chatId && chat && chat.agent !== resolved.agent) {
+        await prisma.sessionChat.update({
+          where: { id: chatId },
+          data: { agent: resolved.agent, model: resolved.model },
+        });
+        const previousAgent = chat.agent;
+        const isKnownPreviousAgent = previousAgent === 'codex'
+          || previousAgent === 'claude'
+          || previousAgent === 'gemini';
+        if (isKnownPreviousAgent) {
+          try {
+            await appendSessionMessage({
+              sessionId,
+              type: 'message',
+              title: '에이전트 변경',
+              text: `이 채팅의 에이전트가 ${previousAgent} → ${resolved.agent}로 변경되었습니다.`,
+              meta: {
+                chatId,
+                role: 'agent',
+                streamEvent: 'agent_switched',
+                fromAgent: previousAgent,
+                toAgent: resolved.agent,
+              },
+            });
+          } catch {
+            // 알림 이벤트 적재 실패는 사용자 메시지 전송을 막지 않는다.
+          }
+        }
+      }
     }
 
     const event = role === 'user' && type === 'message'

--- a/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/ChatInterface.tsx
@@ -12,6 +12,7 @@ import {
   getLatestAgentEventTimestampSince,
   getLatestCompletionSignalTimestampSince,
   getLatestRunStatusSince,
+  isAgentSwitchEvent,
   isCompletionSignalStillTerminal,
   isRunLifecycleEvent,
   resolveChatRunPhase as resolveRunPhaseState,
@@ -637,7 +638,7 @@ export function ChatInterface({
   );
 
   const nonLifecycleEvents = useMemo(
-    () => events.filter((event) => !isRunLifecycleEvent(event)),
+    () => events.filter((event) => !isRunLifecycleEvent(event) && !isAgentSwitchEvent(event)),
     [events],
   );
   const visibleEvents = useMemo(

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/ChatTimeline.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/ChatTimeline.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import type { CSSProperties, RefObject } from 'react';
 import { CheckCircle2, ChevronDown, ChevronLeft, ChevronUp, Copy, Eye, Loader2, MessageSquarePlus } from 'lucide-react';
 import { readChatImageAttachments } from '@/lib/chatImageAttachments';
-import { isRunLifecycleEvent } from '@/lib/happy/chatRuntime';
+import { isAgentSwitchEvent, isRunLifecycleEvent } from '@/lib/happy/chatRuntime';
 import { ProviderLogo } from '@/components/ui/ProviderLogo';
 import type { AgentFlavor, PermissionDecision, SessionChat, UiEvent } from '@/lib/happy/types';
 import { PermissionRequestMessage } from '../../PermissionRequestMessage';
@@ -15,6 +15,7 @@ import type { AgentMeta, TimelineRenderItem, Tone } from '../types';
 import { renderEventPayload } from './renderers/ActionEventCard';
 import { LinkPreviewCarousel } from './renderers/LinkPreviewCarousel';
 import { RunStatusEventCard } from './renderers/RunStatusEventCard';
+import { AgentSwitchEventCard } from './renderers/AgentSwitchEventCard';
 
 function getToneClass(tone: Tone): string {
   const map: Record<Tone, string> = {
@@ -256,7 +257,8 @@ export function ChatTimeline({
           const event = item.event;
           const userEvent = isUserEvent(event);
           const runLifecycleEvent = isRunLifecycleEvent(event);
-          const actionEvent = !userEvent && isActionKind(event.kind);
+          const agentSwitchEvent = isAgentSwitchEvent(event);
+          const actionEvent = !userEvent && !agentSwitchEvent && isActionKind(event.kind);
 
           if (userEvent) {
             const userAttachments = readChatImageAttachments(event.meta);
@@ -327,6 +329,17 @@ export function ChatTimeline({
                 {dayDivider}
                 <article id={`event-${event.id}`} className={`${styles.messageRow} ${styles.runStatusRow}`}>
                   <RunStatusEventCard event={event} />
+                </article>
+              </React.Fragment>
+            );
+          }
+
+          if (agentSwitchEvent) {
+            return (
+              <React.Fragment key={event.id}>
+                {dayDivider}
+                <article id={`event-${event.id}`} className={`${styles.messageRow} ${styles.runStatusRow}`}>
+                  <AgentSwitchEventCard event={event} />
                 </article>
               </React.Fragment>
             );

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/renderers/AgentSwitchEventCard.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/center-pane/renderers/AgentSwitchEventCard.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import React from 'react';
+import { ArrowRightLeft } from 'lucide-react';
+import { readAgentSwitchInfo } from '@/lib/happy/chatRuntime';
+import type { UiEvent } from '@/lib/happy/types';
+import { formatClock } from '../../helpers';
+import styles from '../../../ChatInterface.module.css';
+
+const AGENT_LABELS: Record<string, string> = {
+  codex: 'Codex',
+  claude: 'Claude',
+  gemini: 'Gemini',
+};
+
+function labelForAgent(agent: string): string {
+  return AGENT_LABELS[agent.toLowerCase()] ?? agent;
+}
+
+export function AgentSwitchEventCard({ event }: { event: UiEvent }) {
+  const info = readAgentSwitchInfo(event);
+  if (!info) {
+    return null;
+  }
+  const fromLabel = labelForAgent(info.fromAgent);
+  const toLabel = labelForAgent(info.toAgent);
+  const switchTime = formatClock(event.timestamp);
+  const ariaLabel = `에이전트 ${fromLabel}에서 ${toLabel}로 변경됨 ${switchTime}`;
+
+  return (
+    <div
+      className={`${styles.runStatusCard} ${styles.toneSky}`}
+      title={`${fromLabel} → ${toLabel} · ${switchTime}`}
+      aria-label={ariaLabel}
+      data-stream-event="agent_switched"
+    >
+      <ArrowRightLeft size={13} className={styles.runStatusIcon} />
+      <span className={styles.runStatusLabel}>{`에이전트 변경: ${fromLabel} → ${toLabel}`}</span>
+      <span className={styles.runStatusSeparator}>·</span>
+      <time className={styles.runStatusTime} dateTime={event.timestamp}>
+        {switchTime}
+      </time>
+    </div>
+  );
+}

--- a/services/aris-web/app/sessions/[sessionId]/chat-screen/helpers.tsx
+++ b/services/aris-web/app/sessions/[sessionId]/chat-screen/helpers.tsx
@@ -9,6 +9,7 @@ import {
   TerminalSquare,
 } from 'lucide-react';
 import {
+  isAgentSwitchEvent,
   isRunLifecycleEvent,
   isTerminalRunStatus,
   readUiEventRunStatus,
@@ -434,7 +435,7 @@ export function resolveRecentSummary(event: UiEvent): string {
 export function getLatestVisibleEvent(events: UiEvent[]): UiEvent | null {
   for (let index = events.length - 1; index >= 0; index -= 1) {
     const event = events[index];
-    if (!isRunLifecycleEvent(event)) {
+    if (!isRunLifecycleEvent(event) && !isAgentSwitchEvent(event)) {
       return event;
     }
   }

--- a/services/aris-web/lib/happy/chatRuntime.ts
+++ b/services/aris-web/lib/happy/chatRuntime.ts
@@ -112,6 +112,27 @@ export function isRunLifecycleEvent(event: UiEvent): boolean {
   return readUiEventStreamEvent(event) === 'run_status';
 }
 
+export type AgentSwitchInfo = {
+  fromAgent: string;
+  toAgent: string;
+};
+
+export function isAgentSwitchEvent(event: UiEvent): boolean {
+  return readUiEventStreamEvent(event) === 'agent_switched';
+}
+
+export function readAgentSwitchInfo(event: UiEvent): AgentSwitchInfo | null {
+  if (!isAgentSwitchEvent(event)) {
+    return null;
+  }
+  const fromAgent = typeof event.meta?.fromAgent === 'string' ? event.meta.fromAgent.trim() : '';
+  const toAgent = typeof event.meta?.toAgent === 'string' ? event.meta.toAgent.trim() : '';
+  if (!fromAgent || !toAgent) {
+    return null;
+  }
+  return { fromAgent, toAgent };
+}
+
 export function isTerminalRunStatus(status: string | null | undefined): boolean {
   return TERMINAL_RUN_STATUSES.has((status ?? '').trim().toLowerCase() as RunLifecycleStatus);
 }

--- a/services/aris-web/tests/sessionEventsRoute.test.ts
+++ b/services/aris-web/tests/sessionEventsRoute.test.ts
@@ -4,10 +4,12 @@ import { NextRequest } from 'next/server';
 const mocks = vi.hoisted(() => ({
   requireApiUser: vi.fn(),
   appendSessionMessage: vi.fn(),
+  submitUserPrompt: vi.fn(),
   getUserModelSettings: vi.fn(),
   resolveRuntimeMessageModel: vi.fn(),
   normalizeSupportedAgent: vi.fn(),
   prismaFindFirst: vi.fn(),
+  prismaUpdate: vi.fn(),
 }));
 
 vi.mock('@/lib/auth/guard', () => ({
@@ -16,6 +18,7 @@ vi.mock('@/lib/auth/guard', () => ({
 
 vi.mock('@/lib/happy/client', () => ({
   appendSessionMessage: mocks.appendSessionMessage,
+  submitUserPrompt: mocks.submitUserPrompt,
   getSessionEvents: vi.fn(),
   HappyHttpError: class HappyHttpError extends Error {
     status: number;
@@ -40,6 +43,7 @@ vi.mock('@/lib/db/prisma', () => ({
   prisma: {
     sessionChat: {
       findFirst: mocks.prismaFindFirst,
+      update: mocks.prismaUpdate,
     },
   },
 }));
@@ -51,6 +55,7 @@ describe('session events route', () => {
     vi.clearAllMocks();
     mocks.requireApiUser.mockResolvedValue({ user: { id: 'user-1', role: 'operator' } });
     mocks.prismaFindFirst.mockResolvedValue({ agent: 'codex', model: 'gpt-5.4', geminiMode: null });
+    mocks.prismaUpdate.mockResolvedValue({ id: 'chat-1', agent: 'codex' });
     mocks.normalizeSupportedAgent.mockImplementation((agent: unknown, fallback: unknown) => agent ?? fallback);
     mocks.getUserModelSettings.mockResolvedValue({
       providers: {
@@ -72,13 +77,21 @@ describe('session events route', () => {
       fallbackReason: null,
       customModel: null,
     });
-    mocks.appendSessionMessage.mockResolvedValue({
-      id: 'evt-1',
+    mocks.submitUserPrompt.mockResolvedValue({
+      id: 'evt-user-1',
       timestamp: '2026-04-11T09:00:00.000Z',
       kind: 'text_reply',
       title: 'User Instruction',
       body: '이미지 확인',
       meta: { role: 'user' },
+    });
+    mocks.appendSessionMessage.mockResolvedValue({
+      id: 'evt-notice-1',
+      timestamp: '2026-04-11T09:00:00.000Z',
+      kind: 'text_reply',
+      title: '에이전트 변경',
+      body: '이 채팅의 에이전트가 codex → claude로 변경되었습니다.',
+      meta: { role: 'agent', streamEvent: 'agent_switched' },
     });
   });
 
@@ -113,7 +126,7 @@ describe('session events route', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mocks.appendSessionMessage).toHaveBeenCalledWith(expect.objectContaining({
+    expect(mocks.submitUserPrompt).toHaveBeenCalledWith(expect.objectContaining({
       meta: expect.objectContaining({
         attachments: [
           expect.objectContaining({
@@ -166,5 +179,135 @@ describe('session events route', () => {
       requestedModel: 'gpt-5.5',
       customModels: ['gpt-5.4', 'gpt-5.5'],
     }));
+  });
+
+  describe('chat agent synchronization', () => {
+    it('updates SessionChat.agent and emits agent-switch notice when user message changes the active agent', async () => {
+      mocks.prismaFindFirst.mockResolvedValueOnce({
+        agent: 'codex',
+        model: 'gpt-5.4',
+        geminiMode: null,
+      });
+      mocks.resolveRuntimeMessageModel.mockReturnValueOnce({
+        agent: 'claude',
+        model: 'claude-opus-4-7',
+        source: 'requested',
+        requestedModel: 'claude-opus-4-7',
+        fallbackReason: null,
+        customModel: null,
+      });
+
+      const response = await POST(
+        new NextRequest('http://localhost/api/runtime/sessions/session-1/events', {
+          method: 'POST',
+          body: JSON.stringify({
+            type: 'message',
+            title: 'User Instruction',
+            text: 'switch to claude',
+            meta: {
+              role: 'user',
+              chatId: 'chat-1',
+              agent: 'claude',
+              model: 'claude-opus-4-7',
+            },
+          }),
+        }),
+        { params: Promise.resolve({ sessionId: 'session-1' }) },
+      );
+
+      expect(response.status).toBe(200);
+
+      expect(mocks.prismaUpdate).toHaveBeenCalledWith({
+        where: { id: 'chat-1' },
+        data: expect.objectContaining({ agent: 'claude', model: 'claude-opus-4-7' }),
+      });
+
+      expect(mocks.appendSessionMessage).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: 'session-1',
+        type: 'message',
+        title: '에이전트 변경',
+        meta: expect.objectContaining({
+          chatId: 'chat-1',
+          role: 'agent',
+          streamEvent: 'agent_switched',
+          fromAgent: 'codex',
+          toAgent: 'claude',
+        }),
+      }));
+
+      // user prompt is still submitted exactly once
+      expect(mocks.submitUserPrompt).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not update SessionChat or emit a notice when the user message keeps the same agent', async () => {
+      mocks.prismaFindFirst.mockResolvedValueOnce({
+        agent: 'codex',
+        model: 'gpt-5.4',
+        geminiMode: null,
+      });
+
+      const response = await POST(
+        new NextRequest('http://localhost/api/runtime/sessions/session-1/events', {
+          method: 'POST',
+          body: JSON.stringify({
+            type: 'message',
+            title: 'User Instruction',
+            text: 'same agent',
+            meta: {
+              role: 'user',
+              chatId: 'chat-1',
+              agent: 'codex',
+              model: 'gpt-5.4',
+            },
+          }),
+        }),
+        { params: Promise.resolve({ sessionId: 'session-1' }) },
+      );
+
+      expect(response.status).toBe(200);
+      expect(mocks.prismaUpdate).not.toHaveBeenCalled();
+      expect(mocks.appendSessionMessage).not.toHaveBeenCalled();
+    });
+
+    it('updates SessionChat silently (no notice) when previous agent is unknown — treats as fresh chat', async () => {
+      mocks.prismaFindFirst.mockResolvedValueOnce({
+        agent: 'unknown',
+        model: null,
+        geminiMode: null,
+      });
+      mocks.resolveRuntimeMessageModel.mockReturnValueOnce({
+        agent: 'claude',
+        model: 'claude-opus-4-7',
+        source: 'requested',
+        requestedModel: 'claude-opus-4-7',
+        fallbackReason: null,
+        customModel: null,
+      });
+
+      const response = await POST(
+        new NextRequest('http://localhost/api/runtime/sessions/session-1/events', {
+          method: 'POST',
+          body: JSON.stringify({
+            type: 'message',
+            title: 'User Instruction',
+            text: 'first message',
+            meta: {
+              role: 'user',
+              chatId: 'chat-1',
+              agent: 'claude',
+              model: 'claude-opus-4-7',
+            },
+          }),
+        }),
+        { params: Promise.resolve({ sessionId: 'session-1' }) },
+      );
+
+      expect(response.status).toBe(200);
+      expect(mocks.prismaUpdate).toHaveBeenCalledWith({
+        where: { id: 'chat-1' },
+        data: expect.objectContaining({ agent: 'claude', model: 'claude-opus-4-7' }),
+      });
+      expect(mocks.appendSessionMessage).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## 문제

ModelSelector에서 다른 provider(예: codex→claude)로 전환해 메시지를 보내면 실제 응답은 Claude에서 오는데, 사이드바/헤더의 chat 라벨은 codex로 표시되는 라벨 불일치 발생.

원인: `SessionChat.agent` 컬럼은 chat 생성 시점에만 설정되고, 이후 user message가 다른 `meta.agent`로 들어와도 갱신되지 않았음. `events` POST 핸들러는 `meta.agent`를 라우팅에는 사용하지만 chat row는 read-only로만 참조.

DB 직접 조회로 확인: 오늘 만들어진 chat 5개 모두 `agent='codex'`, `model='gpt-5.4'`인데 그 안의 첫 user message부터 `meta.agent='claude'`, 응답도 모두 `agent='claude'`, `source='cli-agent'`였음.

## 변경

- POST `/api/runtime/sessions/[sessionId]/events` 에서 user message 처리 중 `resolved.agent !== chat.agent`이면:
  - `prisma.sessionChat.update`로 `agent`/`model` 즉시 갱신
  - 이전 agent가 known(codex/claude/gemini)이었던 경우 timeline에 `streamEvent: 'agent_switched'` notice 이벤트 한 줄 적재 (`이 채팅의 에이전트가 codex → claude로 변경되었습니다.`)
  - 알림 적재 실패는 user message 전송을 막지 않음 (try/catch)
- `isAgentSwitchEvent` / `readAgentSwitchInfo` 헬퍼 추가 (chatRuntime)
- `AgentSwitchEventCard` 렌더러 추가 — `RunStatusEventCard`와 동일한 인라인 카드 패턴
- `ChatTimeline` 분기 추가, `ChatInterface.nonLifecycleEvents` / `helpers.getLatestVisibleEvent` 필터에서 agent_switched도 lifecycle처럼 제외 (스크롤/하이라이트 계산이 인라인 카드를 일반 메시지로 취급하지 않도록)

## 테스트

- `sessionEventsRoute.test.ts`
  - 기존: `submitUserPrompt` 모킹 누락으로 깨져있던 케이스 복구
  - 신규: agent 전환 시 `prisma.update` + `appendSessionMessage` 호출 검증 (1건)
  - 신규: 같은 agent 유지 시 update/notice 미발생 (1건)
  - 신규: 이전 agent가 'unknown'이면 update만, notice는 미발생 (1건)
- 워크트리 aris-web 전체 vitest: 218 suites, 472 pass, 7 fail (기존 main에서도 깨져있던 layout/snapshot 테스트만 잔류 — 같은 파일 6개)
- typecheck: 0 errors

## Test plan

- [ ] 배포 후 codex chat에서 model selector로 claude 선택 → 메시지 전송
- [ ] 사이드바/헤더가 즉시 claude로 라벨 갱신되는지 확인
- [ ] timeline에 "에이전트 변경: codex → Claude" 카드가 user message 직전에 한 줄 들어가는지 확인
- [ ] 같은 agent로 메시지 보낼 때는 카드가 추가되지 않는지 확인