### PR TITLE
WebSocket 실시간 이벤트 채널 도입

### DIFF
--- a/services/aris-backend/package-lock.json
+++ b/services/aris-backend/package-lock.json
@@ -7,13 +7,16 @@
     "": {
       "name": "aris-backend",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@prisma/adapter-pg": "^7.5.0",
         "@prisma/client": "^7.5.0",
         "@types/pg": "^8.18.0",
+        "@types/ws": "^8.18.1",
         "fastify": "^5.6.1",
         "pg": "^8.20.0",
         "prisma": "^7.5.0",
+        "ws": "^8.20.0",
         "zod": "^4.1.8"
       },
       "devDependencies": {
@@ -1320,6 +1323,15 @@
       "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -3469,6 +3481,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/services/aris-backend/package.json
+++ b/services/aris-backend/package.json
@@ -15,9 +15,11 @@
     "@prisma/adapter-pg": "^7.5.0",
     "@prisma/client": "^7.5.0",
     "@types/pg": "^8.18.0",
+    "@types/ws": "^8.18.1",
     "fastify": "^5.6.1",
     "pg": "^8.20.0",
     "prisma": "^7.5.0",
+    "ws": "^8.20.0",
     "zod": "^4.1.8"
   },
   "devDependencies": {

--- a/services/aris-backend/src/runtime/orchestration/realtimeEventBus.ts
+++ b/services/aris-backend/src/runtime/orchestration/realtimeEventBus.ts
@@ -44,6 +44,8 @@ export interface ListRealtimeEventsOptions {
   chatId?: string;
 }
 
+export type RealtimeEventBusListener = (record: SessionRealtimeEventRecord) => void;
+
 /**
  * Host-side callbacks the bus needs.
  */
@@ -60,6 +62,10 @@ const DEFAULT_LIST_LIMIT = 100;
 export class RealtimeEventBus {
   private readonly events = new Map<string, SessionRealtimeEventRecord[]>();
   private readonly cursors = new Map<string, number>();
+  private readonly subscribers = new Map<string, Set<{
+    options: Pick<ListRealtimeEventsOptions, 'chatId'>;
+    listener: RealtimeEventBusListener;
+  }>>();
 
   constructor(private readonly deps: RealtimeEventBusDeps) {}
 
@@ -76,7 +82,25 @@ export class RealtimeEventBus {
       bucket.splice(0, bucket.length - SESSION_BUCKET_CAP);
     }
     this.events.set(sessionId, bucket);
+    this.notify(sessionId, { cursor: nextCursor, event });
     return event;
+  }
+
+  subscribe(
+    sessionId: string,
+    options: Pick<ListRealtimeEventsOptions, 'chatId'>,
+    listener: RealtimeEventBusListener,
+  ): () => void {
+    const subscribers = this.subscribers.get(sessionId) ?? new Set();
+    const subscription = { options, listener };
+    subscribers.add(subscription);
+    this.subscribers.set(sessionId, subscribers);
+    return () => {
+      subscribers.delete(subscription);
+      if (subscribers.size === 0) {
+        this.subscribers.delete(sessionId);
+      }
+    };
   }
 
   /**
@@ -121,4 +145,27 @@ export class RealtimeEventBus {
       cursor: this.cursors.get(sessionId) ?? 0,
     };
   }
+
+  private notify(sessionId: string, record: SessionRealtimeEventRecord): void {
+    const subscribers = this.subscribers.get(sessionId);
+    if (!subscribers || subscribers.size === 0) {
+      return;
+    }
+    for (const subscriber of subscribers) {
+      if (!matchesChatFilter(record.event, subscriber.options.chatId)) {
+        continue;
+      }
+      subscriber.listener(record);
+    }
+  }
+}
+
+function matchesChatFilter(event: RuntimeMessage, chatId?: string): boolean {
+  if (!chatId) {
+    return true;
+  }
+  const eventChatId = typeof event.meta?.chatId === 'string'
+    ? event.meta.chatId.trim()
+    : '';
+  return eventChatId === chatId;
 }

--- a/services/aris-backend/src/runtime/realtimeWebSocketGateway.ts
+++ b/services/aris-backend/src/runtime/realtimeWebSocketGateway.ts
@@ -1,0 +1,122 @@
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import type { FastifyInstance } from 'fastify';
+import { WebSocket, WebSocketServer } from 'ws';
+import type {
+  RuntimeRealtimeChannelEvent,
+  RuntimeRealtimeChannelFilter,
+  RuntimeStore,
+} from '../store.js';
+
+type UpgradeContext = RuntimeRealtimeChannelFilter;
+
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+function parseUpgradeContext(url: string | undefined): UpgradeContext | null {
+  const parsed = new URL(url ?? '/', 'http://localhost');
+  const match = parsed.pathname.match(/^\/v1\/sessions\/([^/]+)\/realtime-events\/ws$/);
+  if (!match) {
+    return null;
+  }
+  const sessionId = decodeURIComponent(match[1] ?? '').trim();
+  if (!sessionId) {
+    return null;
+  }
+  const chatIdRaw = parsed.searchParams.get('chatId');
+  const chatId = typeof chatIdRaw === 'string' && chatIdRaw.trim().length > 0
+    ? chatIdRaw.trim()
+    : undefined;
+  const includeUnassignedRaw = parsed.searchParams.get('includeUnassigned');
+  const includeUnassigned = includeUnassignedRaw === '1' || includeUnassignedRaw === 'true';
+  return {
+    sessionId,
+    ...(chatId ? { chatId } : {}),
+    ...(includeUnassigned ? { includeUnassigned } : {}),
+  };
+}
+
+function isAuthorizedUpgrade(request: IncomingMessage, token: string): boolean {
+  const header = request.headers.authorization;
+  const auth = Array.isArray(header) ? header[0] : header;
+  if (auth === `Bearer ${token}`) {
+    return true;
+  }
+  const parsed = new URL(request.url ?? '/', 'http://localhost');
+  return parsed.searchParams.get('token') === token;
+}
+
+function rejectUpgrade(socket: Duplex, status: 400 | 401 | 404): void {
+  const statusText = status === 401
+    ? 'Unauthorized'
+    : status === 404
+      ? 'Not Found'
+      : 'Bad Request';
+  socket.write(`HTTP/1.1 ${status} ${statusText}\r\n\r\n`);
+  socket.destroy();
+}
+
+function sendJson(ws: WebSocket, payload: unknown): void {
+  if (ws.readyState !== WebSocket.OPEN) {
+    return;
+  }
+  ws.send(JSON.stringify(payload));
+}
+
+export function installRuntimeRealtimeWebSocketGateway(
+  app: FastifyInstance,
+  store: RuntimeStore,
+  token: string,
+): void {
+  const wss = new WebSocketServer({ noServer: true });
+  const heartbeatTimers = new WeakMap<WebSocket, NodeJS.Timeout>();
+
+  wss.on('connection', (ws: WebSocket, _request: IncomingMessage, context: UpgradeContext) => {
+    sendJson(ws, {
+      type: 'ready',
+      sessionId: context.sessionId,
+      ...(context.chatId ? { chatId: context.chatId } : {}),
+      now: new Date().toISOString(),
+    });
+
+    const unsubscribe = store.subscribeRealtimeChannel(context, (event: RuntimeRealtimeChannelEvent) => {
+      sendJson(ws, event);
+    });
+
+    const heartbeat = setInterval(() => {
+      sendJson(ws, { type: 'heartbeat', now: new Date().toISOString() });
+    }, HEARTBEAT_INTERVAL_MS);
+    heartbeat.unref();
+    heartbeatTimers.set(ws, heartbeat);
+
+    ws.on('close', () => {
+      unsubscribe();
+      clearInterval(heartbeat);
+      heartbeatTimers.delete(ws);
+    });
+  });
+
+  app.server.on('upgrade', (request, socket, head) => {
+    const context = parseUpgradeContext(request.url);
+    if (!context) {
+      return;
+    }
+    if (!token || !isAuthorizedUpgrade(request, token)) {
+      rejectUpgrade(socket, 401);
+      return;
+    }
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      wss.emit('connection', ws, request, context);
+    });
+  });
+
+  app.addHook('onClose', (_instance, done) => {
+    for (const client of wss.clients) {
+      const heartbeat = heartbeatTimers.get(client);
+      if (heartbeat) {
+        clearInterval(heartbeat);
+      }
+      client.close(1001, 'server closing');
+    }
+    wss.close(() => done());
+  });
+}

--- a/services/aris-backend/src/runtime/runtimeCore.ts
+++ b/services/aris-backend/src/runtime/runtimeCore.ts
@@ -3237,6 +3237,14 @@ export class RuntimeCore {
     return this.realtimeEventBus.list(sessionId, options);
   }
 
+  subscribeRealtimeEvents(
+    sessionId: string,
+    options: { chatId?: string } = {},
+    listener: (record: { cursor: number; event: RuntimeMessage }) => void,
+  ): () => void {
+    return this.realtimeEventBus.subscribe(sessionId, options, listener);
+  }
+
   private async listAllMessages(sessionId: string): Promise<HappyBackendMessage[]> {
     let afterSeq = 0;
     const allMessages: HappyBackendMessage[] = [];

--- a/services/aris-backend/src/server.ts
+++ b/services/aris-backend/src/server.ts
@@ -2,6 +2,7 @@ import Fastify, { type FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { requireBearerToken } from './auth.js';
 import { RuntimeStore } from './store.js';
+import { installRuntimeRealtimeWebSocketGateway } from './runtime/realtimeWebSocketGateway.js';
 
 type RequestBucket = {
   windowStartAt: number;
@@ -250,6 +251,7 @@ export function buildServer(config: ServerConfig) {
     config.RUNTIME_API_TOKEN,
   );
   Object.assign(app, { arisRuntimeStore: store });
+  installRuntimeRealtimeWebSocketGateway(app, store, config.RUNTIME_API_TOKEN);
   const rateLimitBuckets = new Map<string, RequestBucket>();
 
   const isRateLimitExceeded = (path: string, ip: string): boolean => {

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -107,6 +107,37 @@ type CreatePermissionInput = {
   risk: PermissionRisk;
 };
 
+export type RuntimeRealtimeChannelEvent =
+  | {
+      type: 'event.appended';
+      sessionId: string;
+      chatId?: string;
+      event: RuntimeMessage;
+      cursor?: number;
+      source: 'mutation' | 'runtime';
+    }
+  | {
+      type: 'session.created' | 'session.updated' | 'session.action';
+      sessionId: string;
+      chatId?: string;
+      session?: RuntimeSession;
+      action?: SessionAction;
+    }
+  | {
+      type: 'permission.created' | 'permission.updated';
+      sessionId: string;
+      chatId?: string;
+      permission: PermissionRequest;
+    };
+
+export type RuntimeRealtimeChannelFilter = {
+  sessionId: string;
+  chatId?: string;
+  includeUnassigned?: boolean;
+};
+
+export type RuntimeRealtimeChannelListener = (event: RuntimeRealtimeChannelEvent) => void;
+
 interface RuntimeStoreBackend {
   listSessions(): Promise<RuntimeSession[]>;
   getSession(sessionId: string): Promise<RuntimeSession | null>;
@@ -136,6 +167,7 @@ type RuntimeExecutor = Pick<
   | 'createPermission'
   | 'decidePermission'
   | 'getGeminiSessionCapabilities'
+  | 'subscribeRealtimeEvents'
   | 'beginShutdownDrain'
   | 'awaitDrain'
 >;
@@ -499,6 +531,10 @@ class MockRuntimeStore implements RuntimeStoreBackend {
 export class RuntimeStore {
   private readonly delegate: RuntimeStoreBackend;
   private readonly runtimeExecutor: RuntimeExecutor | null;
+  private readonly realtimeSubscribers = new Set<{
+    filter: RuntimeRealtimeChannelFilter;
+    listener: RuntimeRealtimeChannelListener;
+  }>();
 
   constructor(
     defaultProjectPath: string,
@@ -575,12 +611,24 @@ export class RuntimeStore {
       });
     }
 
+    this.emitRealtimeChannel({
+      type: 'session.created',
+      sessionId: session.id,
+      session,
+    });
+
     return session;
   }
 
   async updateApprovalPolicy(sessionId: string, approvalPolicy: ApprovalPolicy) {
     if (typeof this.delegate.updateApprovalPolicy === 'function') {
-      return this.delegate.updateApprovalPolicy(sessionId, approvalPolicy);
+      const session = await this.delegate.updateApprovalPolicy(sessionId, approvalPolicy);
+      this.emitRealtimeChannel({
+        type: 'session.updated',
+        sessionId,
+        session,
+      });
+      return session;
     }
     throw new Error('UPDATE_APPROVAL_POLICY_NOT_SUPPORTED');
   }
@@ -597,12 +645,27 @@ export class RuntimeStore {
   }
 
   async appendMessage(sessionId: string, input: AppendMessageInput) {
-    return this.delegate.appendMessage(sessionId, input);
+    const event = await this.delegate.appendMessage(sessionId, input);
+    this.emitRealtimeChannel({
+      type: 'event.appended',
+      sessionId,
+      ...extractEventChatScope(event),
+      event,
+      source: 'mutation',
+    });
+    return event;
   }
 
   async submitUserPrompt(sessionId: string, input: AppendMessageInput) {
     const promptInput = asUserPromptInput(input);
     const created = await this.delegate.appendMessage(sessionId, promptInput);
+    this.emitRealtimeChannel({
+      type: 'event.appended',
+      sessionId,
+      ...extractEventChatScope(created),
+      event: created,
+      source: 'mutation',
+    });
     if (this.runtimeExecutor) {
       await this.runtimeExecutor.triggerPersistedUserMessage(sessionId, promptInput);
     }
@@ -614,7 +677,15 @@ export class RuntimeStore {
     input: AppendChatEventInput,
   ) {
     if (typeof this.delegate.appendChatEvent === 'function') {
-      return this.delegate.appendChatEvent(chatId, input);
+      const event = await this.delegate.appendChatEvent(chatId, input);
+      this.emitRealtimeChannel({
+        type: 'event.appended',
+        sessionId: input.sessionId,
+        chatId,
+        event,
+        source: 'mutation',
+      });
+      return event;
     }
     throw new Error('APPEND_CHAT_EVENT_NOT_SUPPORTED');
   }
@@ -626,6 +697,13 @@ export class RuntimeStore {
 
     const promptInput = asChatUserPromptInput(chatId, input);
     const created = await this.delegate.appendChatEvent(chatId, promptInput);
+    this.emitRealtimeChannel({
+      type: 'event.appended',
+      sessionId: promptInput.sessionId,
+      chatId,
+      event: created,
+      source: 'mutation',
+    });
     if (this.runtimeExecutor) {
       await this.runtimeExecutor.triggerPersistedUserMessage(promptInput.sessionId, {
         type: promptInput.type,
@@ -710,16 +788,23 @@ export class RuntimeStore {
         if (latestUserMessage) {
           await this.runtimeExecutor.triggerPersistedUserMessage(sessionId, latestUserMessage);
         }
+        this.emitRealtimeChannel({ type: 'session.action', sessionId, ...(chatId ? { chatId } : {}), action });
         return result;
       }
       if (action === 'kill') {
         await this.runtimeExecutor.applySessionAction(sessionId, 'abort');
-        return this.delegate.applySessionAction(sessionId, action, chatId);
+        const result = await this.delegate.applySessionAction(sessionId, action, chatId);
+        this.emitRealtimeChannel({ type: 'session.action', sessionId, ...(chatId ? { chatId } : {}), action });
+        return result;
       }
       await this.runtimeExecutor.applySessionAction(sessionId, action, chatId);
-      return this.delegate.applySessionAction(sessionId, action, chatId);
+      const result = await this.delegate.applySessionAction(sessionId, action, chatId);
+      this.emitRealtimeChannel({ type: 'session.action', sessionId, ...(chatId ? { chatId } : {}), action });
+      return result;
     }
-    return this.delegate.applySessionAction(sessionId, action, chatId);
+    const result = await this.delegate.applySessionAction(sessionId, action, chatId);
+    this.emitRealtimeChannel({ type: 'session.action', sessionId, ...(chatId ? { chatId } : {}), action });
+    return result;
   }
 
   async isSessionRunning(sessionId: string, chatId?: string) {
@@ -759,10 +844,18 @@ export class RuntimeStore {
   }
 
   async createPermission(input: CreatePermissionInput) {
-    if (this.runtimeExecutor) {
-      return this.runtimeExecutor.createPermission(input);
-    }
-    return this.delegate.createPermission(input);
+    const permission = this.runtimeExecutor
+      ? await this.runtimeExecutor.createPermission(input)
+      : await this.delegate.createPermission(input);
+    this.emitRealtimeChannel({
+      type: 'permission.created',
+      sessionId: permission.sessionId,
+      ...(typeof permission.chatId === 'string' && permission.chatId.trim().length > 0
+        ? { chatId: permission.chatId.trim() }
+        : {}),
+      permission,
+    });
+    return permission;
   }
 
   async decidePermission(permissionId: string, decision: PermissionDecision) {
@@ -783,9 +876,78 @@ export class RuntimeStore {
           }
         }
       }
+      this.emitRealtimeChannel({
+        type: 'permission.updated',
+        sessionId: updated.sessionId,
+        ...(normalizedChatId ? { chatId: normalizedChatId } : {}),
+        permission: updated,
+      });
       return updated;
     }
-    return this.delegate.decidePermission(permissionId, decision);
+    const updated = await this.delegate.decidePermission(permissionId, decision);
+    const normalizedChatId = typeof updated.chatId === 'string' && updated.chatId.trim().length > 0
+      ? updated.chatId.trim()
+      : undefined;
+    this.emitRealtimeChannel({
+      type: 'permission.updated',
+      sessionId: updated.sessionId,
+      ...(normalizedChatId ? { chatId: normalizedChatId } : {}),
+      permission: updated,
+    });
+    return updated;
+  }
+
+  subscribeRealtimeChannel(
+    filter: RuntimeRealtimeChannelFilter,
+    listener: RuntimeRealtimeChannelListener,
+  ): () => void {
+    const subscription = {
+      filter: normalizeRealtimeChannelFilter(filter),
+      listener,
+    };
+    this.realtimeSubscribers.add(subscription);
+    const runtimeEventFilter = subscription.filter.chatId && !subscription.filter.includeUnassigned
+      ? { chatId: subscription.filter.chatId }
+      : {};
+    const unsubscribeRuntime = this.runtimeExecutor?.subscribeRealtimeEvents?.(
+      subscription.filter.sessionId,
+      runtimeEventFilter,
+      (record) => {
+        const eventChatScope = extractEventChatScope(record.event);
+        this.deliverRealtimeChannelEvent(subscription, {
+          type: 'event.appended',
+          sessionId: record.event.sessionId,
+          ...eventChatScope,
+          event: record.event,
+          cursor: record.cursor,
+          source: 'runtime',
+        });
+      },
+    );
+
+    return () => {
+      this.realtimeSubscribers.delete(subscription);
+      unsubscribeRuntime?.();
+    };
+  }
+
+  private emitRealtimeChannel(event: RuntimeRealtimeChannelEvent): void {
+    for (const subscription of this.realtimeSubscribers) {
+      this.deliverRealtimeChannelEvent(subscription, event);
+    }
+  }
+
+  private deliverRealtimeChannelEvent(
+    subscription: {
+      filter: RuntimeRealtimeChannelFilter;
+      listener: RuntimeRealtimeChannelListener;
+    },
+    event: RuntimeRealtimeChannelEvent,
+  ): void {
+    if (!matchesRealtimeChannelFilter(subscription.filter, event)) {
+      return;
+    }
+    subscription.listener(event);
   }
 
   resolveExecutionCwd(cwdHint?: string, branch?: string): string {
@@ -797,4 +959,42 @@ export class RuntimeStore {
     }
     return cwdHint || '';
   }
+}
+
+function normalizeRealtimeChannelFilter(filter: RuntimeRealtimeChannelFilter): RuntimeRealtimeChannelFilter {
+  const sessionId = filter.sessionId.trim();
+  const chatId = typeof filter.chatId === 'string' && filter.chatId.trim().length > 0
+    ? filter.chatId.trim()
+    : undefined;
+  return {
+    sessionId,
+    ...(chatId ? { chatId } : {}),
+    ...(filter.includeUnassigned ? { includeUnassigned: true } : {}),
+  };
+}
+
+function extractEventChatScope(event: RuntimeMessage): { chatId?: string } {
+  const chatId = typeof event.meta?.chatId === 'string' && event.meta.chatId.trim().length > 0
+    ? event.meta.chatId.trim()
+    : undefined;
+  return chatId ? { chatId } : {};
+}
+
+function matchesRealtimeChannelFilter(
+  filter: RuntimeRealtimeChannelFilter,
+  event: RuntimeRealtimeChannelEvent,
+): boolean {
+  if (filter.sessionId !== event.sessionId) {
+    return false;
+  }
+  if (!filter.chatId) {
+    return true;
+  }
+  const eventChatId = typeof event.chatId === 'string' && event.chatId.trim().length > 0
+    ? event.chatId.trim()
+    : undefined;
+  if (eventChatId) {
+    return eventChatId === filter.chatId;
+  }
+  return filter.includeUnassigned === true;
 }

--- a/services/aris-backend/tests/realtimeEventBus.test.ts
+++ b/services/aris-backend/tests/realtimeEventBus.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RealtimeEventBus } from '../src/runtime/orchestration/realtimeEventBus.js';
+import type { RuntimeMessage, RuntimeSession } from '../src/types.js';
+
+function buildSession(id = 'session-1'): RuntimeSession {
+  return {
+    id,
+    metadata: {
+      flavor: 'codex',
+      path: '/workspace',
+      approvalPolicy: 'on-request',
+    },
+    state: { status: 'running' },
+    updatedAt: '2026-05-10T00:00:00.000Z',
+    riskScore: 20,
+  };
+}
+
+function buildEvent(overrides: Partial<RuntimeMessage> = {}): RuntimeMessage {
+  return {
+    id: overrides.id ?? 'event-1',
+    sessionId: overrides.sessionId ?? 'session-1',
+    type: overrides.type ?? 'message',
+    title: overrides.title ?? 'Text Reply',
+    text: overrides.text ?? 'hello',
+    createdAt: overrides.createdAt ?? '2026-05-10T00:00:01.000Z',
+    meta: {
+      chatId: 'chat-1',
+      ...(overrides.meta ?? {}),
+    },
+  };
+}
+
+describe('RealtimeEventBus subscriptions', () => {
+  it('pushes appended events to active session subscribers with the cursor', () => {
+    const bus = new RealtimeEventBus({
+      getSession: vi.fn().mockResolvedValue(buildSession()),
+    });
+    const listener = vi.fn();
+
+    bus.subscribe('session-1', {}, listener);
+    const event = buildEvent();
+    bus.append('session-1', event);
+
+    expect(listener).toHaveBeenCalledWith({
+      cursor: 1,
+      event,
+    });
+  });
+
+  it('filters subscriber events by chatId and stops after unsubscribe', () => {
+    const bus = new RealtimeEventBus({
+      getSession: vi.fn().mockResolvedValue(buildSession()),
+    });
+    const listener = vi.fn();
+
+    const unsubscribe = bus.subscribe('session-1', { chatId: 'chat-1' }, listener);
+    bus.append('session-1', buildEvent({ id: 'other', meta: { chatId: 'chat-2' } }));
+    bus.append('session-1', buildEvent({ id: 'match', meta: { chatId: 'chat-1' } }));
+    unsubscribe();
+    bus.append('session-1', buildEvent({ id: 'after-unsubscribe', meta: { chatId: 'chat-1' } }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0]?.[0].event.id).toBe('match');
+  });
+});

--- a/services/aris-backend/tests/realtimeWebSocket.test.ts
+++ b/services/aris-backend/tests/realtimeWebSocket.test.ts
@@ -1,0 +1,120 @@
+import { AddressInfo } from 'node:net';
+import { once } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WebSocket from 'ws';
+import { buildServer } from '../src/server.js';
+
+const TOKEN = 'test-runtime-token';
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${TOKEN}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+async function waitForMessage<T>(
+  ws: WebSocket,
+  predicate: (message: T) => boolean,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error('timed out waiting for websocket message'));
+    }, 2_000);
+
+    const onMessage = (data: WebSocket.RawData) => {
+      const parsed = JSON.parse(data.toString()) as T;
+      if (!predicate(parsed)) {
+        return;
+      }
+      cleanup();
+      resolve(parsed);
+    };
+
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      ws.off('message', onMessage);
+      ws.off('error', onError);
+    };
+
+    ws.on('message', onMessage);
+    ws.on('error', onError);
+  });
+}
+
+describe('runtime realtime WebSocket channel', () => {
+  let app: ReturnType<typeof buildServer>;
+  let baseUrl = '';
+
+  beforeEach(async () => {
+    app = buildServer({
+      HOST: '127.0.0.1',
+      PORT: 0,
+      RUNTIME_API_TOKEN: TOKEN,
+      RUNTIME_BACKEND: 'mock',
+      DEFAULT_PROJECT_PATH: '/workspace',
+      LOG_LEVEL: 'silent',
+    });
+    await app.listen({ host: '127.0.0.1', port: 0 });
+    const address = app.server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('pushes mutation broadcasts to subscribed websocket clients', async () => {
+    const createResponse = await fetch(`${baseUrl}/v1/sessions`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        path: '/workspace',
+        flavor: 'codex',
+      }),
+    });
+    const created = (await createResponse.json()) as { session: { id: string } };
+    const sessionId = created.session.id;
+    const ws = new WebSocket(
+      `${baseUrl.replace('http:', 'ws:')}/v1/sessions/${encodeURIComponent(sessionId)}/realtime-events/ws?chatId=chat-1`,
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+    );
+
+    try {
+      await once(ws, 'open');
+      const broadcastPromise = waitForMessage<{
+        type: string;
+        event?: { text?: string };
+        chatId?: string;
+      }>(ws, (message) => message.type === 'event.appended');
+
+      const appendResponse = await fetch(`${baseUrl}/v1/chats/chat-1/events`, {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify({
+          sessionId,
+          type: 'message',
+          text: 'hello over websocket',
+          meta: {
+            role: 'user',
+            chatId: 'chat-1',
+          },
+        }),
+      });
+      expect(appendResponse.status).toBe(201);
+
+      const broadcast = await broadcastPromise;
+
+      expect(broadcast.chatId).toBe('chat-1');
+      expect(broadcast.event?.text).toBe('hello over websocket');
+    } finally {
+      ws.close();
+    }
+  });
+});

--- a/services/aris-backend/tests/store.test.ts
+++ b/services/aris-backend/tests/store.test.ts
@@ -8,9 +8,11 @@ function buildRuntimeStore(input: {
   const store = Object.create(RuntimeStore.prototype) as RuntimeStore & {
     delegate: Record<string, unknown>;
     runtimeExecutor: Record<string, unknown> | null;
+    realtimeSubscribers: Set<(event: unknown) => void>;
   };
   store.delegate = input.delegate;
   store.runtimeExecutor = input.runtimeExecutor ?? null;
+  store.realtimeSubscribers = new Set();
   return store;
 }
 
@@ -31,6 +33,46 @@ describe('RuntimeStore.isSessionRunning', () => {
 });
 
 describe('RuntimeStore.appendChatEvent', () => {
+  it('broadcasts appended chat events immediately to realtime channel subscribers', async () => {
+    const event = {
+      id: 'event-1',
+      sessionId: 'session-1',
+      type: 'message',
+      title: 'User Instruction',
+      text: 'continue',
+      createdAt: '2026-05-10T00:00:00.000Z',
+      meta: {
+        role: 'user',
+        chatId: 'chat-1',
+      },
+    };
+    const delegate = {
+      appendChatEvent: vi.fn().mockResolvedValue(event),
+    };
+    const store = buildRuntimeStore({ delegate });
+    const listener = vi.fn();
+
+    store.subscribeRealtimeChannel({ sessionId: 'session-1', chatId: 'chat-1' }, listener);
+    await store.appendChatEvent('chat-1', {
+      sessionId: 'session-1',
+      type: 'message',
+      title: 'User Instruction',
+      text: 'continue',
+      meta: {
+        role: 'user',
+        chatId: 'chat-1',
+      },
+    });
+
+    expect(listener).toHaveBeenCalledWith({
+      type: 'event.appended',
+      sessionId: 'session-1',
+      chatId: 'chat-1',
+      event,
+      source: 'mutation',
+    });
+  });
+
   it('does not wake an agent turn for terminal-authored command events', async () => {
     const delegate = {
       appendChatEvent: vi.fn().mockResolvedValue({
@@ -212,7 +254,104 @@ describe('RuntimeStore.applySessionAction', () => {
   });
 });
 
+describe('RuntimeStore.subscribeRealtimeChannel', () => {
+  it('keeps runtime fanout broad when chat subscribers include unassigned events', () => {
+    const runtimeUnsubscribe = vi.fn();
+    const runtimeExecutor = {
+      subscribeRealtimeEvents: vi.fn((_sessionId: string, _options: object, listener: (record: unknown) => void) => {
+        listener({
+          cursor: 1,
+          event: {
+            id: 'event-unassigned',
+            sessionId: 'session-1',
+            type: 'tool',
+            title: 'Unassigned',
+            text: 'workspace update',
+            createdAt: '2026-05-10T00:00:00.000Z',
+            meta: {},
+          },
+        });
+        listener({
+          cursor: 2,
+          event: {
+            id: 'event-chat-1',
+            sessionId: 'session-1',
+            type: 'message',
+            title: 'Chat',
+            text: 'chat update',
+            createdAt: '2026-05-10T00:00:01.000Z',
+            meta: { chatId: 'chat-1' },
+          },
+        });
+        listener({
+          cursor: 3,
+          event: {
+            id: 'event-chat-2',
+            sessionId: 'session-1',
+            type: 'message',
+            title: 'Other chat',
+            text: 'other update',
+            createdAt: '2026-05-10T00:00:02.000Z',
+            meta: { chatId: 'chat-2' },
+          },
+        });
+        return runtimeUnsubscribe;
+      }),
+    };
+    const store = buildRuntimeStore({ delegate: {}, runtimeExecutor });
+    const listener = vi.fn();
+
+    const unsubscribe = store.subscribeRealtimeChannel({
+      sessionId: 'session-1',
+      chatId: 'chat-1',
+      includeUnassigned: true,
+    }, listener);
+
+    expect(runtimeExecutor.subscribeRealtimeEvents).toHaveBeenCalledWith('session-1', {}, expect.any(Function));
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls.map(([event]) => (event as { event: { id: string } }).event.id)).toEqual([
+      'event-unassigned',
+      'event-chat-1',
+    ]);
+
+    unsubscribe();
+    expect(runtimeUnsubscribe).toHaveBeenCalled();
+  });
+});
+
 describe('RuntimeStore.decidePermission', () => {
+  it('broadcasts permission updates to realtime channel subscribers', async () => {
+    const updatedPermission = {
+      id: 'perm-1',
+      sessionId: 'session-1',
+      chatId: 'chat-1',
+      agent: 'codex',
+      command: 'curl -I https://example.com',
+      reason: 'network approval',
+      risk: 'medium',
+      state: 'approved',
+      decision: 'allow_once',
+      requestedAt: '2026-05-10T00:00:00.000Z',
+    };
+    const runtimeExecutor = {
+      decidePermission: vi.fn().mockResolvedValue(updatedPermission),
+      isSessionRunning: vi.fn().mockResolvedValue(true),
+      triggerPersistedUserMessage: vi.fn(),
+    };
+    const store = buildRuntimeStore({ delegate: {}, runtimeExecutor });
+    const listener = vi.fn();
+
+    store.subscribeRealtimeChannel({ sessionId: 'session-1', chatId: 'chat-1' }, listener);
+    await store.decidePermission('perm-1', 'allow_once');
+
+    expect(listener).toHaveBeenCalledWith({
+      type: 'permission.updated',
+      sessionId: 'session-1',
+      chatId: 'chat-1',
+      permission: updatedPermission,
+    });
+  });
+
   it('replays the latest persisted user message when approval is granted after the active run is gone', async () => {
     const delegate = {
       getLatestUserMessageForAction: vi.fn().mockResolvedValue({

--- a/services/aris-web/app/layout.tsx
+++ b/services/aris-web/app/layout.tsx
@@ -33,7 +33,12 @@ const proxyAwareClientRoutingScript = `
     return url.origin === window.location.origin
       && url.pathname !== basePath
       && !url.pathname.startsWith(basePath + '/')
-      && (url.pathname === '/api' || url.pathname.startsWith('/api/'));
+      && (
+        url.pathname === '/api'
+        || url.pathname.startsWith('/api/')
+        || url.pathname === '/ws'
+        || url.pathname.startsWith('/ws/')
+      );
   };
 
   const rewrite = (value) => {
@@ -80,6 +85,14 @@ const proxyAwareClientRoutingScript = `
       return config === undefined ? new NativeEventSource(rewrite(url)) : new NativeEventSource(rewrite(url), config);
     };
     window.EventSource.prototype = NativeEventSource.prototype;
+  }
+
+  const NativeWebSocket = window.WebSocket;
+  if (typeof NativeWebSocket === 'function') {
+    window.WebSocket = function(url, protocols) {
+      return protocols === undefined ? new NativeWebSocket(rewrite(url)) : new NativeWebSocket(rewrite(url), protocols);
+    };
+    window.WebSocket.prototype = NativeWebSocket.prototype;
   }
 })();
 `;

--- a/services/aris-web/lib/hooks/runtimeEventChannel.ts
+++ b/services/aris-web/lib/hooks/runtimeEventChannel.ts
@@ -1,0 +1,50 @@
+export type RuntimeEventChannelMessage = {
+  type?: string;
+  source?: string;
+  [key: string]: unknown;
+};
+
+type RuntimeEventChannelUrlInput = {
+  sessionId: string;
+  chatId?: string | null;
+  includeUnassigned?: boolean;
+  location?: Pick<Location, 'protocol' | 'host'>;
+};
+
+function resolveLocation(input?: Pick<Location, 'protocol' | 'host'>): Pick<Location, 'protocol' | 'host'> {
+  if (input) {
+    return input;
+  }
+  if (typeof window !== 'undefined' && window.location) {
+    return window.location;
+  }
+  return { protocol: 'http:', host: 'localhost' };
+}
+
+export function buildRuntimeEventChannelUrl(input: RuntimeEventChannelUrlInput): string {
+  const location = resolveLocation(input.location);
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const params = new URLSearchParams();
+  const chatId = typeof input.chatId === 'string' && input.chatId.trim().length > 0
+    ? input.chatId.trim()
+    : '';
+  if (chatId) {
+    params.set('chatId', chatId);
+    if (input.includeUnassigned) {
+      params.set('includeUnassigned', '1');
+    }
+  }
+  const query = params.toString();
+  return `${protocol}//${location.host}/ws/runtime/events/${encodeURIComponent(input.sessionId)}${query ? `?${query}` : ''}`;
+}
+
+export function shouldRefreshPermissionsForRuntimeMessage(message: RuntimeEventChannelMessage): boolean {
+  return message.type === 'permission.created' || message.type === 'permission.updated';
+}
+
+export function shouldRefreshRuntimeForRuntimeMessage(message: RuntimeEventChannelMessage): boolean {
+  if (message.type === 'session.action' || message.type === 'session.updated' || message.type === 'session.created') {
+    return true;
+  }
+  return message.type === 'event.appended' && message.source === 'mutation';
+}

--- a/services/aris-web/lib/hooks/usePermissions.ts
+++ b/services/aris-web/lib/hooks/usePermissions.ts
@@ -2,6 +2,11 @@ import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import type { PermissionRequest, PermissionDecision } from '@/lib/happy/types';
 import { redirectToLoginWithNext } from '@/lib/hooks/authRedirect';
 import { isPermissionForChat, normalizePermissionChatId } from '@/lib/happy/permissions';
+import {
+  buildRuntimeEventChannelUrl,
+  shouldRefreshPermissionsForRuntimeMessage,
+  type RuntimeEventChannelMessage,
+} from '@/lib/hooks/runtimeEventChannel';
 
 const POLL_INTERVAL_MS = 10000;
 const isDocumentVisible = () => typeof document === 'undefined' || document.visibilityState === 'visible';
@@ -156,6 +161,44 @@ export function usePermissions(
       window.removeEventListener('focus', syncWhenVisible);
     };
   }, [enabled, refreshPermissions]);
+
+  useEffect(() => {
+    if (!enabled || typeof WebSocket !== 'function') {
+      return undefined;
+    }
+
+    let disposed = false;
+    const socket = new WebSocket(buildRuntimeEventChannelUrl({
+      sessionId,
+      chatId: activeChatId,
+      includeUnassigned: includeUnassignedForActiveChat,
+    }));
+
+    socket.addEventListener('message', (raw) => {
+      if (disposed || !isDocumentVisible()) {
+        return;
+      }
+      try {
+        const payload = JSON.parse(String((raw as MessageEvent).data)) as RuntimeEventChannelMessage;
+        if (shouldRefreshPermissionsForRuntimeMessage(payload)) {
+          void refreshPermissions();
+        }
+      } catch {
+        // Ignore malformed realtime payloads; polling remains the fallback.
+      }
+    });
+
+    socket.addEventListener('error', () => {
+      if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+        socket.close();
+      }
+    });
+
+    return () => {
+      disposed = true;
+      socket.close();
+    };
+  }, [enabled, sessionId, activeChatId, includeUnassignedForActiveChat, refreshPermissions]);
 
   const scopedPermissions = useMemo(
     () => permissions.filter((item) => isPermissionForChat(item, activeChatId, includeUnassignedForActiveChat)),

--- a/services/aris-web/lib/hooks/useSessionEvents.ts
+++ b/services/aris-web/lib/hooks/useSessionEvents.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SessionEventsPage, UiEvent } from '@/lib/happy/types';
 import { redirectToLoginWithNext } from '@/lib/hooks/authRedirect';
+import {
+  buildRuntimeEventChannelUrl,
+  type RuntimeEventChannelMessage,
+} from '@/lib/hooks/runtimeEventChannel';
 
 const SAFETY_RECONCILE_INTERVAL_MS = 15000;
 const FALLBACK_POLL_INTERVAL_MS = 4000;
@@ -57,6 +61,14 @@ function mergeEvents(events: UiEvent[]): UiEvent[] {
   );
 }
 
+function isUiEvent(value: unknown): value is UiEvent {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && typeof (value as UiEvent).id === 'string'
+      && typeof (value as UiEvent).timestamp === 'string',
+  );
+}
 
 function readTrimmedStreamEvent(event: UiEvent): string {
   return typeof event.meta?.streamEvent === 'string'
@@ -729,6 +741,7 @@ export function useSessionEvents(
   useEffect(() => {
     let disposed = false;
     let eventSource: EventSource | null = null;
+    let eventSocket: WebSocket | null = null;
     let pollTimer: number | null = null;
     let pollDelayTimer: number | null = null;
     let reconnectTimer: number | null = null;
@@ -841,39 +854,38 @@ export function useSessionEvents(
     };
 
     const closeStream = () => {
-      if (eventSource) {
-        eventSource.close();
+      if (eventSource !== null) {
+        const stream = eventSource;
         eventSource = null;
+        stream.close();
+      }
+      if (eventSocket !== null) {
+        const socket = eventSocket;
+        eventSocket = null;
+        socket.close();
       }
     };
 
-    const startSafetyReconcile = () => {
-      if (!enabled) {
+    const appendStreamEvent = (event: UiEvent, streamChatId: string | null) => {
+      // 채팅 전환 후 이전 연결에서 도착하는 이벤트를 무시.
+      if (activeChatIdRef.current !== streamChatId) {
         return;
       }
-      if (reconcileTimer !== null) {
-        return;
+      const { trimmedCount } = appendIncomingEvents([event]);
+      if (trimmedCount > 0) {
+        setHasMoreBefore(true);
       }
-      reconcileTimer = window.setInterval(() => {
-        void refreshEvents().catch((error) => {
-          handleRefreshError(error, '백엔드 이벤트 동기화를 확인하세요.');
-        });
-      }, SAFETY_RECONCILE_INTERVAL_MS);
+      setSyncError(null);
     };
 
-    const connect = () => {
-      if (disposed || terminalStatusRef.current === 404) {
-        return;
-      }
-      if (!isDocumentVisible()) {
+    const openEventSource = (streamChatId: string | null) => {
+      if (disposed || terminalStatusRef.current === 404 || !isDocumentVisible()) {
         return;
       }
 
-      closeStream();
       const latestId = findLatestPersistedCursorEventId(eventsRef.current);
-      const streamChatId = chatId;
       const params = new URLSearchParams();
-      appendChatFilters(params, chatId, includeUnassigned);
+      appendChatFilters(params, streamChatId, includeUnassigned);
       if (latestId) {
         params.set('after', latestId);
       }
@@ -891,20 +903,12 @@ export function useSessionEvents(
       });
 
       stream.addEventListener('event', (raw) => {
-        // 채팅 전환 후 이전 SSE 연결에서 도착하는 이벤트를 무시.
-        if (activeChatIdRef.current !== streamChatId) {
-          return;
-        }
         try {
           const payload = JSON.parse((raw as MessageEvent).data) as { event?: UiEvent };
           if (!payload.event) {
             return;
           }
-          const { trimmedCount } = appendIncomingEvents([payload.event!]);
-          if (trimmedCount > 0) {
-            setHasMoreBefore(true);
-          }
-          setSyncError(null);
+          appendStreamEvent(payload.event, streamChatId);
         } catch {
           // Ignore malformed stream payloads and continue receiving subsequent events.
         }
@@ -974,6 +978,99 @@ export function useSessionEvents(
           }, nextReconnectDelayMs());
         }
       });
+    };
+
+    const openWebSocket = (streamChatId: string | null) => {
+      if (typeof WebSocket !== 'function') {
+        return false;
+      }
+
+      const socket = new WebSocket(buildRuntimeEventChannelUrl({
+        sessionId,
+        chatId: streamChatId,
+        includeUnassigned,
+      }));
+      eventSocket = socket;
+      let opened = false;
+
+      socket.addEventListener('open', () => {
+        opened = true;
+        setSyncError(null);
+        stopPolling();
+      });
+
+      socket.addEventListener('message', (raw) => {
+        if (activeChatIdRef.current !== streamChatId) {
+          return;
+        }
+        try {
+          const payload = JSON.parse(String((raw as MessageEvent).data)) as RuntimeEventChannelMessage;
+          if (payload.type === 'event.appended' && isUiEvent(payload.event)) {
+            appendStreamEvent(payload.event, streamChatId);
+          }
+        } catch {
+          // Ignore malformed realtime payloads and keep the channel open.
+        }
+      });
+
+      socket.addEventListener('close', () => {
+        if (disposed || eventSocket !== socket) {
+          return;
+        }
+        eventSocket = null;
+        if (terminalStatusRef.current === 404) {
+          stopPolling();
+          closeStream();
+          return;
+        }
+        setSyncError(opened ? '실시간 채널이 끊겨 재연결 중입니다.' : '실시간 채널 연결 지연으로 SSE 모드로 전환했습니다.');
+        startPolling();
+        openEventSource(streamChatId);
+        if (reconnectTimer === null) {
+          reconnectTimer = window.setTimeout(() => {
+            reconnectTimer = null;
+            connect();
+          }, nextReconnectDelayMs());
+        }
+      });
+
+      socket.addEventListener('error', () => {
+        if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+          socket.close();
+        }
+      });
+
+      return true;
+    };
+
+    const startSafetyReconcile = () => {
+      if (!enabled) {
+        return;
+      }
+      if (reconcileTimer !== null) {
+        return;
+      }
+      reconcileTimer = window.setInterval(() => {
+        void refreshEvents().catch((error) => {
+          handleRefreshError(error, '백엔드 이벤트 동기화를 확인하세요.');
+        });
+      }, SAFETY_RECONCILE_INTERVAL_MS);
+    };
+
+    const connect = () => {
+      if (disposed || terminalStatusRef.current === 404) {
+        return;
+      }
+      if (!isDocumentVisible()) {
+        return;
+      }
+
+      closeStream();
+      const streamChatId = chatId;
+      if (openWebSocket(streamChatId)) {
+        return;
+      }
+      openEventSource(streamChatId);
     };
 
     startSafetyReconcile();

--- a/services/aris-web/lib/hooks/useSessionRuntime.ts
+++ b/services/aris-web/lib/hooks/useSessionRuntime.ts
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { redirectToLoginWithNext } from '@/lib/hooks/authRedirect';
+import {
+  buildRuntimeEventChannelUrl,
+  shouldRefreshRuntimeForRuntimeMessage,
+  type RuntimeEventChannelMessage,
+} from '@/lib/hooks/runtimeEventChannel';
 
 const RUNTIME_POLL_INTERVAL_MS = 3000;
 const runtimeStateCache = new Map<string, boolean>();
@@ -54,6 +59,7 @@ export function useSessionRuntime(sessionId: string, chatId?: string | null, ena
     let disposed = false;
     let inFlight = false;
     let stopped = false;
+    let realtimeSocket: WebSocket | null = null;
     lastKnownRunningRef.current = runtimeStateCache.get(cacheKey) ?? false;
     setIsRunning(lastKnownRunningRef.current);
     setRuntimeError(null);
@@ -128,6 +134,28 @@ export function useSessionRuntime(sessionId: string, chatId?: string | null, ena
       }
     };
 
+    if (typeof WebSocket === 'function') {
+      realtimeSocket = new WebSocket(buildRuntimeEventChannelUrl({ sessionId, chatId }));
+      realtimeSocket.addEventListener('message', (raw) => {
+        if (disposed || stopped || !isDocumentVisible()) {
+          return;
+        }
+        try {
+          const payload = JSON.parse(String((raw as MessageEvent).data)) as RuntimeEventChannelMessage;
+          if (shouldRefreshRuntimeForRuntimeMessage(payload)) {
+            void refresh();
+          }
+        } catch {
+          // Ignore malformed realtime payloads; polling remains the fallback.
+        }
+      });
+      realtimeSocket.addEventListener('error', () => {
+        if (realtimeSocket?.readyState === WebSocket.OPEN || realtimeSocket?.readyState === WebSocket.CONNECTING) {
+          realtimeSocket.close();
+        }
+      });
+    }
+
     void refresh();
     const timer = window.setInterval(() => {
       void refresh();
@@ -144,6 +172,7 @@ export function useSessionRuntime(sessionId: string, chatId?: string | null, ena
 
     return () => {
       disposed = true;
+      realtimeSocket?.close();
       window.clearInterval(timer);
       document.removeEventListener('visibilitychange', syncWhenVisible);
       window.removeEventListener('focus', syncWhenVisible);

--- a/services/aris-web/server.mjs
+++ b/services/aris-web/server.mjs
@@ -147,6 +147,55 @@ function filterProxyRequestHeaders(headers) {
   return nextHeaders;
 }
 
+function readFirstQueryValue(value) {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return typeof value === 'string' ? value : null;
+}
+
+function parseRuntimeEventsRequest(reqUrl) {
+  const parsed = parse(reqUrl, true);
+  const pathname = parsed.pathname || '';
+  const match = pathname.match(/^\/ws\/runtime\/events\/([^/]+)$/);
+  if (!match) {
+    return null;
+  }
+
+  const params = new URLSearchParams();
+  const chatId = readFirstQueryValue(parsed.query.chatId);
+  if (chatId?.trim()) {
+    params.set('chatId', chatId.trim());
+  }
+
+  const includeUnassigned = readFirstQueryValue(parsed.query.includeUnassigned);
+  if (includeUnassigned === '1' || includeUnassigned === 'true') {
+    params.set('includeUnassigned', '1');
+  }
+
+  return {
+    sessionId: decodeURIComponent(match[1]),
+    query: params.toString(),
+  };
+}
+
+function runtimeApiWebSocketBase() {
+  const base = RUNTIME_API_URL.replace(/\/+$/, '');
+  if (base.startsWith('https://')) {
+    return `wss://${base.slice('https://'.length)}`;
+  }
+  if (base.startsWith('http://')) {
+    return `ws://${base.slice('http://'.length)}`;
+  }
+  return base;
+}
+
+function buildRuntimeEventsUpstreamUrl(runtimeRequest) {
+  return `${runtimeApiWebSocketBase()}/v1/sessions/${encodeURIComponent(runtimeRequest.sessionId)}/realtime-events/ws${
+    runtimeRequest.query ? `?${runtimeRequest.query}` : ''
+  }`;
+}
+
 async function getStoredLocalPreviewPanel(userId, sessionId, panelId) {
   const workspace = await prisma.workspace.findFirst({
     where: {
@@ -174,6 +223,17 @@ async function getStoredLocalPreviewPanel(userId, sessionId, panelId) {
     port: port ?? 3305,
     path: normalizeLocalPreviewPath(typeof config.path === 'string' ? config.path : '/'),
   };
+}
+
+async function canAccessWorkspace(userId, sessionId) {
+  const workspace = await prisma.workspace.findFirst({
+    where: {
+      id: sessionId,
+      userId,
+    },
+    select: { id: true },
+  });
+  return Boolean(workspace);
 }
 
 async function resolveLocalPreviewTarget(userId, reqUrl) {
@@ -351,6 +411,7 @@ function spawnSshPty(settings, sessionId, sessionCwd) {
 // ── WebSocket 서버 ──────────────────────────────────────────────────────────
 const wss = new WebSocketServer({ noServer: true });
 const localPreviewWss = new WebSocketServer({ noServer: true });
+const runtimeEventsWss = new WebSocketServer({ noServer: true });
 
 wss.on('connection', async (ws, _req, { sessionId, sessionCwd }) => {
   const settings = await getSshSettings();
@@ -446,6 +507,57 @@ localPreviewWss.on('connection', async (ws, req, { userId }) => {
   });
 });
 
+runtimeEventsWss.on('connection', (ws, req, { runtimeRequest }) => {
+  if (!RUNTIME_API_TOKEN) {
+    ws.close(1011, 'runtime_api_token_missing');
+    return;
+  }
+
+  const upstream = new WebSocket(buildRuntimeEventsUpstreamUrl(runtimeRequest), {
+    headers: {
+      Authorization: `Bearer ${RUNTIME_API_TOKEN}`,
+    },
+  });
+
+  upstream.on('open', () => {
+    ws.on('message', (data, isBinary) => {
+      if (upstream.readyState === upstream.OPEN) {
+        upstream.send(data, { binary: isBinary });
+      }
+    });
+  });
+
+  upstream.on('message', (data, isBinary) => {
+    if (ws.readyState === ws.OPEN) {
+      ws.send(data, { binary: isBinary });
+    }
+  });
+
+  upstream.on('close', (code, reason) => {
+    if (ws.readyState === ws.OPEN) {
+      ws.close(code, reason.toString() || 'runtime_events_closed');
+    }
+  });
+
+  upstream.on('error', () => {
+    if (ws.readyState === ws.OPEN) {
+      ws.close(1011, 'runtime_events_upstream_error');
+    }
+  });
+
+  ws.on('close', () => {
+    if (upstream.readyState === upstream.OPEN || upstream.readyState === upstream.CONNECTING) {
+      upstream.close();
+    }
+  });
+
+  ws.on('error', () => {
+    if (upstream.readyState === upstream.OPEN || upstream.readyState === upstream.CONNECTING) {
+      upstream.close();
+    }
+  });
+});
+
 // ── Next.js + HTTP 서버 ─────────────────────────────────────────────────────
 const app = next({ dev, hostname, port });
 const handle = app.getRequestHandler();
@@ -512,6 +624,36 @@ app.prepare().then(() => {
       } finally {
         req.url = originalUrl;
       }
+      return;
+    }
+
+    const runtimeRequest = parseRuntimeEventsRequest(req.url);
+    if (runtimeRequest) {
+      const cookies = parseCookies(req.headers.cookie);
+      const token = cookies[AUTH_COOKIE_NAME];
+      if (!token) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      const payload = await verifyToken(token);
+      if (!payload?.sub) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      const hasAccess = await canAccessWorkspace(payload.sub, runtimeRequest.sessionId);
+      if (!hasAccess) {
+        socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      runtimeEventsWss.handleUpgrade(req, socket, head, (ws) => {
+        runtimeEventsWss.emit('connection', ws, req, { runtimeRequest, userId: payload.sub });
+      });
       return;
     }
 

--- a/services/aris-web/tests/runtimeEventChannel.test.ts
+++ b/services/aris-web/tests/runtimeEventChannel.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildRuntimeEventChannelUrl,
+  shouldRefreshPermissionsForRuntimeMessage,
+  shouldRefreshRuntimeForRuntimeMessage,
+} from '@/lib/hooks/runtimeEventChannel';
+
+describe('runtime event channel helpers', () => {
+  it('builds a same-origin websocket URL with chat filters', () => {
+    const url = buildRuntimeEventChannelUrl({
+      sessionId: 'session 1',
+      chatId: 'chat/1',
+      includeUnassigned: true,
+      location: {
+        protocol: 'https:',
+        host: 'lawdigest.cloud',
+      },
+    });
+
+    expect(url).toBe('wss://lawdigest.cloud/ws/runtime/events/session%201?chatId=chat%2F1&includeUnassigned=1');
+  });
+
+  it('refreshes permissions only for permission broadcasts', () => {
+    expect(shouldRefreshPermissionsForRuntimeMessage({ type: 'permission.created' })).toBe(true);
+    expect(shouldRefreshPermissionsForRuntimeMessage({ type: 'permission.updated' })).toBe(true);
+    expect(shouldRefreshPermissionsForRuntimeMessage({ type: 'event.appended' })).toBe(false);
+  });
+
+  it('refreshes runtime status for session actions and persisted mutation events', () => {
+    expect(shouldRefreshRuntimeForRuntimeMessage({ type: 'session.action' })).toBe(true);
+    expect(shouldRefreshRuntimeForRuntimeMessage({ type: 'event.appended', source: 'mutation' })).toBe(true);
+    expect(shouldRefreshRuntimeForRuntimeMessage({ type: 'event.appended', source: 'runtime' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## 요약

- backend에 세션별 WebSocket realtime event gateway를 추가했습니다.
- RuntimeStore mutation 경로에서 `event.appended`, `permission.*`, `session.*` broadcast를 발행하도록 연결했습니다.
- web custom server가 인증된 `/ws/runtime/events/:sessionId` 요청을 backend WebSocket으로 프록시하도록 추가했습니다.
- 채팅 이벤트, 권한 요청, 런타임 상태 hook이 WebSocket push를 우선 사용하고 기존 폴링/SSE는 안전망으로 유지합니다.

## 검증

- `npm --prefix services/aris-backend test -- realtimeWebSocket realtimeEventBus store`
- `npm --prefix services/aris-backend run typecheck`
- `npm --prefix services/aris-web test -- runtimeEventChannel sessionRuntime sessionEvents`
- `cd services/aris-web && npx tsc --noEmit`
- `node --check services/aris-web/server.mjs`
- `git diff --check`

## dev server

- 사용자 요청에 따라 dev server는 유지하지 않았습니다.

## 배포

- production 배포는 수행하지 않았습니다.
