### PR TITLE
Realtime WebSocket 관측 로그 추가

### DIFF
--- a/services/aris-backend/src/runtime/realtimeWebSocketGateway.ts
+++ b/services/aris-backend/src/runtime/realtimeWebSocketGateway.ts
@@ -62,6 +62,14 @@ function sendJson(ws: WebSocket, payload: unknown): void {
   ws.send(JSON.stringify(payload));
 }
 
+function isAbnormalWebSocketClose(code: number): boolean {
+  return ![1000, 1001, 1005].includes(code);
+}
+
+function closeReasonText(reason: Buffer): string {
+  return reason.toString('utf8').slice(0, 160);
+}
+
 export function installRuntimeRealtimeWebSocketGateway(
   app: FastifyInstance,
   store: RuntimeStore,
@@ -71,6 +79,12 @@ export function installRuntimeRealtimeWebSocketGateway(
   const heartbeatTimers = new WeakMap<WebSocket, NodeJS.Timeout>();
 
   wss.on('connection', (ws: WebSocket, _request: IncomingMessage, context: UpgradeContext) => {
+    app.log.debug({
+      sessionId: context.sessionId,
+      chatId: context.chatId,
+      includeUnassigned: context.includeUnassigned,
+    }, 'runtime realtime websocket connected');
+
     sendJson(ws, {
       type: 'ready',
       sessionId: context.sessionId,
@@ -88,10 +102,28 @@ export function installRuntimeRealtimeWebSocketGateway(
     heartbeat.unref();
     heartbeatTimers.set(ws, heartbeat);
 
-    ws.on('close', () => {
+    ws.on('close', (code: number, reason: Buffer) => {
       unsubscribe();
       clearInterval(heartbeat);
       heartbeatTimers.delete(ws);
+      if (isAbnormalWebSocketClose(code)) {
+        app.log.warn({
+          sessionId: context.sessionId,
+          chatId: context.chatId,
+          includeUnassigned: context.includeUnassigned,
+          code,
+          reason: closeReasonText(reason),
+        }, 'runtime realtime websocket closed abnormally');
+      }
+    });
+
+    ws.on('error', (error) => {
+      app.log.warn({
+        err: error,
+        sessionId: context.sessionId,
+        chatId: context.chatId,
+        includeUnassigned: context.includeUnassigned,
+      }, 'runtime realtime websocket error');
     });
   });
 
@@ -101,6 +133,11 @@ export function installRuntimeRealtimeWebSocketGateway(
       return;
     }
     if (!token || !isAuthorizedUpgrade(request, token)) {
+      app.log.warn({
+        sessionId: context.sessionId,
+        chatId: context.chatId,
+        includeUnassigned: context.includeUnassigned,
+      }, 'runtime realtime websocket unauthorized upgrade');
       rejectUpgrade(socket, 401);
       return;
     }

--- a/services/aris-web/server.mjs
+++ b/services/aris-web/server.mjs
@@ -196,6 +196,18 @@ function buildRuntimeEventsUpstreamUrl(runtimeRequest) {
   }`;
 }
 
+function isAbnormalWebSocketClose(code) {
+  return ![1000, 1001, 1005].includes(code);
+}
+
+function safeCloseReason(reason) {
+  return String(reason || '').slice(0, 160);
+}
+
+function logRuntimeEventsWarning(message, details = {}) {
+  console.warn(`[runtime-events-ws] ${message}`, JSON.stringify(details));
+}
+
 async function getStoredLocalPreviewPanel(userId, sessionId, panelId) {
   const workspace = await prisma.workspace.findFirst({
     where: {
@@ -507,8 +519,9 @@ localPreviewWss.on('connection', async (ws, req, { userId }) => {
   });
 });
 
-runtimeEventsWss.on('connection', (ws, req, { runtimeRequest }) => {
+runtimeEventsWss.on('connection', (ws, _req, { runtimeRequest, userId }) => {
   if (!RUNTIME_API_TOKEN) {
+    logRuntimeEventsWarning('missing runtime api token', { sessionId: runtimeRequest.sessionId });
     ws.close(1011, 'runtime_api_token_missing');
     return;
   }
@@ -534,24 +547,50 @@ runtimeEventsWss.on('connection', (ws, req, { runtimeRequest }) => {
   });
 
   upstream.on('close', (code, reason) => {
+    if (isAbnormalWebSocketClose(code)) {
+      logRuntimeEventsWarning('upstream closed abnormally', {
+        sessionId: runtimeRequest.sessionId,
+        userId,
+        code,
+        reason: safeCloseReason(reason),
+      });
+    }
     if (ws.readyState === ws.OPEN) {
       ws.close(code, reason.toString() || 'runtime_events_closed');
     }
   });
 
-  upstream.on('error', () => {
+  upstream.on('error', (error) => {
+    logRuntimeEventsWarning('upstream error', {
+      sessionId: runtimeRequest.sessionId,
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
     if (ws.readyState === ws.OPEN) {
       ws.close(1011, 'runtime_events_upstream_error');
     }
   });
 
-  ws.on('close', () => {
+  ws.on('close', (code, reason) => {
+    if (isAbnormalWebSocketClose(code)) {
+      logRuntimeEventsWarning('client closed abnormally', {
+        sessionId: runtimeRequest.sessionId,
+        userId,
+        code,
+        reason: safeCloseReason(reason),
+      });
+    }
     if (upstream.readyState === upstream.OPEN || upstream.readyState === upstream.CONNECTING) {
       upstream.close();
     }
   });
 
-  ws.on('error', () => {
+  ws.on('error', (error) => {
+    logRuntimeEventsWarning('client socket error', {
+      sessionId: runtimeRequest.sessionId,
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
     if (upstream.readyState === upstream.OPEN || upstream.readyState === upstream.CONNECTING) {
       upstream.close();
     }
@@ -632,6 +671,7 @@ app.prepare().then(() => {
       const cookies = parseCookies(req.headers.cookie);
       const token = cookies[AUTH_COOKIE_NAME];
       if (!token) {
+        logRuntimeEventsWarning('upgrade rejected: missing auth cookie', { sessionId: runtimeRequest.sessionId });
         socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
         socket.destroy();
         return;
@@ -639,6 +679,7 @@ app.prepare().then(() => {
 
       const payload = await verifyToken(token);
       if (!payload?.sub) {
+        logRuntimeEventsWarning('upgrade rejected: invalid auth cookie', { sessionId: runtimeRequest.sessionId });
         socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
         socket.destroy();
         return;
@@ -646,6 +687,10 @@ app.prepare().then(() => {
 
       const hasAccess = await canAccessWorkspace(payload.sub, runtimeRequest.sessionId);
       if (!hasAccess) {
+        logRuntimeEventsWarning('upgrade rejected: workspace access denied', {
+          sessionId: runtimeRequest.sessionId,
+          userId: payload.sub,
+        });
         socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
         socket.destroy();
         return;


### PR DESCRIPTION
## 요약

- backend realtime WebSocket gateway에 unauthorized upgrade, socket error, abnormal close 로그를 추가했습니다.
- web `/ws/runtime/events/:sessionId` 프록시에 auth/access rejection, upstream error, abnormal close 로그를 추가했습니다.
- 정상 close는 로그 소음을 줄이기 위해 기록하지 않고 장애 신호만 남깁니다.

## 검증

- `node --check services/aris-web/server.mjs`
- `npm --prefix services/aris-backend run typecheck`
- `npm --prefix services/aris-backend test -- realtimeWebSocket realtimeEventBus store`
- `npm --prefix services/aris-web test -- runtimeEventChannel sessionRuntime sessionEvents`
- `cd services/aris-web && npx tsc --noEmit`
- `git diff --check`
