### PR TITLE
fix(cmd): treat rtk as prefix wrapper

### DIFF
--- a/services/aris-web/lib/cmd/__tests__/parseCommand.test.ts
+++ b/services/aris-web/lib/cmd/__tests__/parseCommand.test.ts
@@ -11,11 +11,15 @@ describe('parseShellCommand', () => {
   it('skips leading env-var assignments', () => {
     expect(parseShellCommand('NODE_ENV=production FOO=bar npm start').head).toBe('npm');
   });
-  it('skips sudo/cd/time/env prefixes', () => {
+  it('skips sudo/cd/time/env/rtk prefixes', () => {
     expect(parseShellCommand('sudo rm -rf /tmp/x').head).toBe('rm');
     expect(parseShellCommand('cd services/aris-web && npm test').head).toBe('npm');
     expect(parseShellCommand('time npm test').head).toBe('npm');
     expect(parseShellCommand('env NODE_ENV=prod npm start').head).toBe('npm');
+    // rtk (Rust Token Killer) is a Claude Code hook wrapper; transparent to user intent.
+    expect(parseShellCommand('rtk git status').head).toBe('git');
+    expect(parseShellCommand('rtk npm test -- foo').tone).toBe('pkg');
+    expect(parseShellCommand('rtk cat services/aris-web/middleware.ts').tone).toBe('read');
   });
   it('uses first segment for && / || / ;', () => {
     expect(parseShellCommand('git add . && git commit -m "foo"').head).toBe('git');

--- a/services/aris-web/lib/cmd/parseCommand.ts
+++ b/services/aris-web/lib/cmd/parseCommand.ts
@@ -1,7 +1,13 @@
 import type { CmdToken, FileArg, ParsedCommand } from './types';
 import { resolveCmdTone } from './cmdToneMap';
 
-const PREFIX_NAMES = new Set(['sudo', 'cd', 'time', 'env']);
+/**
+ * Command prefixes that wrap the actual command (transparent to the user's intent).
+ * `rtk` is the Rust Token Killer proxy installed via Claude Code hook — every Bash
+ * call gets rewritten to `rtk <real-cmd>`. Without skipping, every badge would show
+ * up as the fallback `cmd` tone instead of git/npm/cat/etc.
+ */
+const PREFIX_NAMES = new Set(['sudo', 'cd', 'time', 'env', 'rtk']);
 
 function isEnvAssign(tok: string): boolean { return /^[A-Z_][A-Z0-9_]*=/.test(tok); }
 function isFlag(tok: string): boolean { return /^-{1,2}[A-Za-z0-9_-]+/.test(tok); }


### PR DESCRIPTION
## Summary

Claude Code hook가 모든 Bash 호출을 `rtk <원본cmd>` 형태로 재작성해 저장하기 때문에, action card 배지가 전부 fallback `cmd` 톤(>_ icon)으로 표시되던 문제.

`sudo` / `cd` / `time` / `env` 와 동일하게 `rtk`를 `PREFIX_NAMES` 에 추가해서 skip.

## Test plan

- [x] `npx vitest run lib/cmd/__tests__/parseCommand.test.ts` → 15/15 pass (기존 13 + rtk 케이스 3 추가)
- 검증 명령:
  - `rtk git status` → head=git, tone=git
  - `rtk npm test` → tone=pkg
  - `rtk cat <file>` → tone=read

🤖 Generated with [Claude Code](https://claude.com/claude-code)
