### PR TITLE
fix(sidebar): make footer menu legible (theme chips + colors)

### DIFF
--- a/services/aris-web/components/layout/SidebarFooterMenu.module.css
+++ b/services/aris-web/components/layout/SidebarFooterMenu.module.css
@@ -1,47 +1,130 @@
 .root { position: relative; }
+
 .trigger {
-  display: grid; grid-template-columns: 28px 1fr 14px; gap: 10px; align-items: center;
-  width: 100%; padding: 8px 10px; border-radius: 10px;
-  background: transparent; border: 1px solid transparent; color: inherit; cursor: pointer;
+  display: grid;
+  grid-template-columns: 28px 1fr 14px;
+  gap: 10px;
+  align-items: center;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--m-sb-text, rgba(255, 255, 255, 0.92));
+  cursor: pointer;
 }
-.trigger:hover { background: var(--m-sb-hover, rgba(255,255,255,0.04)); }
+.trigger:hover { background: var(--m-sb-hover, rgba(255, 255, 255, 0.04)); }
+
 .avatar {
-  width: 28px; height: 28px; border-radius: 50%;
-  display: inline-flex; align-items: center; justify-content: center;
-  background: var(--m-sb-avatar, #2b2b2b); font-size: 12px; color: #fff;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--m-sb-avatar, #2b2b2b);
+  font-size: 12px;
+  color: #fff;
 }
-.identity { display: flex; flex-direction: column; align-items: flex-start; min-width: 0; }
+.identity {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  min-width: 0;
+}
 .name { font-size: 12.5px; font-weight: 600; line-height: 1.2; }
 .meta { font-size: 10.5px; opacity: 0.6; line-height: 1.2; margin-top: 2px; }
 .chev { opacity: 0.55; }
+
 .panel {
-  position: absolute; left: 8px; right: 8px; bottom: calc(100% + 6px);
+  position: absolute;
+  left: 8px;
+  bottom: calc(100% + 6px);
+  min-width: 232px;
   background: var(--m-sb-panel-bg, #14141a);
-  border: 1px solid var(--m-sb-panel-border, rgba(255,255,255,0.08));
-  border-radius: 10px; padding: 6px;
-  box-shadow: 0 18px 40px rgba(0,0,0,0.45);
+  color: var(--m-sb-panel-text, rgba(255, 255, 255, 0.94));
+  border: 1px solid var(--m-sb-panel-border, rgba(255, 255, 255, 0.1));
+  border-radius: 10px;
+  padding: 6px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
   z-index: 40;
-  display: flex; flex-direction: column; gap: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
+
 .item {
-  display: inline-flex; align-items: center; gap: 8px;
-  width: 100%; padding: 8px 10px; border-radius: 8px;
-  background: transparent; border: none; color: inherit;
-  font: inherit; text-align: left; cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 10px;
+  border-radius: 8px;
+  background: transparent;
+  border: none;
+  color: var(--m-sb-panel-text, rgba(255, 255, 255, 0.94));
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.2;
+  text-align: left;
+  cursor: pointer;
 }
-.item:hover { background: rgba(255,255,255,0.05); }
-.section { padding: 6px 8px 4px; }
-.sectionLabel { font-size: 10.5px; opacity: 0.55; margin-bottom: 6px; }
-.themeRow { display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px; }
+.item:hover { background: rgba(255, 255, 255, 0.06); }
+.item:focus-visible {
+  outline: 2px solid rgba(120, 170, 255, 0.6);
+  outline-offset: -2px;
+}
+
+.section {
+  padding: 8px 4px 4px;
+  margin-top: 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+.sectionLabel {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.55;
+  margin: 0 0 6px;
+  padding: 0 6px;
+}
+.themeRow {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+}
 .themeChip {
-  display: inline-flex; align-items: center; justify-content: center; gap: 4px;
-  padding: 6px 4px; border-radius: 6px;
-  border: 1px solid rgba(255,255,255,0.08);
-  background: transparent; color: inherit; font-size: 11px; cursor: pointer;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 8px 4px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: transparent;
+  color: var(--m-sb-panel-text, rgba(255, 255, 255, 0.94));
+  font: inherit;
+  font-size: 11px;
+  line-height: 1;
+  min-height: 52px;
+  cursor: pointer;
+}
+.themeChip:hover { background: rgba(255, 255, 255, 0.04); }
+.themeChip:focus-visible {
+  outline: 2px solid rgba(120, 170, 255, 0.6);
+  outline-offset: -2px;
 }
 .themeChipActive {
-  background: rgba(255,255,255,0.08);
-  border-color: rgba(255,255,255,0.18);
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.22);
 }
-.signoutForm { margin: 0; }
+
+.signoutForm {
+  margin: 4px 0 0;
+  padding-top: 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
 .signout { color: #ff8585; }
+.signout:hover { background: rgba(255, 100, 100, 0.08); }


### PR DESCRIPTION
## Problem

이전 PR #334 머지 후 사이드바 푸터 메뉴를 열면:
- Settings 텍스트가 거의 안 보임 (`color: inherit`이 어두운 panel 위에서 실패)
- Theme chips ("라이트/다크/시스템")의 폭이 너무 좁아 Korean 한 글자씩 세로 stacking
- 전반적으로 dark-on-dark

## Fix

- Panel `min-width: 232px`로 폭 확보 (사이드바 폭에 갇히지 않도록 `right: auto`)
- Theme chip을 `flex-direction: column`으로 바꿔 icon 위, 라벨 아래로 stack → 3-글자 한글도 한 줄에 들어감
- 모든 텍스트에 `color: inherit` 대신 명시적 `rgba(255, 255, 255, 0.94)` (+ var fallback)
- chip min-height 52px, item font-size 13px, focus-visible outline 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)