### PR TITLE
fix(settings): Claude-style minimal rail + responsive header wrap

### DIFF
--- a/services/aris-web/components/settings/ModelsSection.module.css
+++ b/services/aris-web/components/settings/ModelsSection.module.css
@@ -93,13 +93,14 @@
 
 .groupHead {
   display: flex;
-  align-items: flex-start;
-  gap: var(--sp-12);
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--sp-4);
   margin-bottom: var(--sp-8);
+  min-width: 0;
 }
 
 .groupHeadText {
-  flex: 1;
   min-width: 0;
 }
 
@@ -112,6 +113,8 @@
   text-transform: uppercase;
   color: var(--text-tertiary);
   margin-bottom: var(--sp-2);
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 .groupTitle {
@@ -120,6 +123,8 @@
   font-weight: 600;
   color: var(--text-primary);
   letter-spacing: -0.01em;
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 .groupSubtitle {
@@ -128,12 +133,16 @@
   line-height: 1.55;
   color: var(--text-secondary);
   max-width: 70ch;
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 .groupTrailing {
   display: flex;
   align-items: center;
-  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: var(--sp-3);
+  min-width: 0;
 }
 
 /* ── Row list ── home-feed-row scaled up */
@@ -624,6 +633,22 @@
   to { transform: rotate(360deg); }
 }
 
+/* ── Toolbar: always wrap-friendly + search grows to fill row ── */
+.toolbar {
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.searchWrap {
+  flex: 1 1 200px;
+  min-width: 0;
+}
+
+.searchInput {
+  width: 100%;
+  min-width: 0;
+}
+
 /* ── Tablet ── */
 @media (max-width: 920px) {
   .group {
@@ -632,26 +657,6 @@
 
   .providerStrip {
     padding: var(--sp-6) var(--sp-12);
-  }
-
-  .groupHead {
-    flex-direction: column;
-    gap: var(--sp-4);
-  }
-
-  .groupTrailing {
-    width: 100%;
-  }
-
-  .toolbar {
-    justify-content: flex-start;
-    width: 100%;
-  }
-
-  .searchInput {
-    flex: 1;
-    width: auto;
-    min-width: 0;
   }
 }
 

--- a/services/aris-web/components/settings/SettingsSurface.module.css
+++ b/services/aris-web/components/settings/SettingsSurface.module.css
@@ -1,5 +1,6 @@
-/* Settings — 2-column panels (sticky left rail + independently scrolling right pane).
- * No card chrome. Hairline dividers only. Designed to scale to many future sections.
+/* Settings — minimal 2-column shell inspired by Claude.ai settings.
+ * Plain title at top of rail, label-only nav with subtle active pill.
+ * Right pane scrolls independently.
  */
 
 .shell {
@@ -15,51 +16,34 @@
 /* ── Left rail ─────────────────────────────────────────────── */
 .rail {
   flex: 0 0 auto;
-  width: 260px;
+  width: 232px;
   display: flex;
   flex-direction: column;
+  padding: var(--sp-10) var(--sp-4) var(--sp-6);
   background: var(--surface);
   border-right: 1px solid var(--border-subtle);
   overflow-y: auto;
 }
 
-.railHeader {
-  padding: var(--sp-12) var(--sp-8) var(--sp-8);
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-.eyebrow {
-  display: block;
-  font-family: var(--font-mono);
-  font-size: var(--text-2xs);
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--text-tertiary);
-}
-
 .title {
-  margin: var(--sp-2) 0 0;
+  margin: 0 var(--sp-3) var(--sp-6);
   font-size: var(--text-h2);
   font-weight: 700;
-  line-height: 1.15;
-  letter-spacing: -0.015em;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
   color: var(--text-primary);
 }
 
 .nav {
   display: flex;
   flex-direction: column;
-  padding: var(--sp-4) var(--sp-3);
-  gap: var(--sp-1);
+  gap: 2px;
 }
 
 .navItem {
-  position: relative;
-  display: grid;
-  grid-template-columns: 18px 1fr;
+  display: inline-flex;
   align-items: center;
-  gap: var(--sp-3);
+  gap: var(--sp-2);
   width: 100%;
   padding: var(--sp-3) var(--sp-4);
   background: transparent;
@@ -67,6 +51,7 @@
   border-radius: var(--r-md);
   font: inherit;
   font-size: var(--text-sm);
+  font-weight: 500;
   color: var(--text-secondary);
   text-align: left;
   cursor: pointer;
@@ -80,56 +65,28 @@
 
 .navItem:focus-visible {
   outline: none;
-  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--b-500) 38%, transparent);
-}
-
-.navIcon {
-  color: var(--text-tertiary);
-  transition: color var(--t-fast);
-}
-
-.navBody {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  line-height: 1.25;
-}
-
-.navLabel {
-  font-weight: 600;
-  letter-spacing: -0.005em;
-  color: inherit;
-}
-
-.navHint {
-  margin-top: 2px;
-  font-family: var(--font-mono);
-  font-size: var(--text-2xs);
-  letter-spacing: 0.04em;
-  color: var(--text-tertiary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--b-500) 36%, transparent);
 }
 
 .navItemActive {
   background: var(--surface-active);
   color: var(--text-primary);
+  font-weight: 600;
 }
 
-.navItemActive .navIcon {
-  color: var(--b-600);
+.navLabel {
+  letter-spacing: -0.005em;
 }
 
-.navItemActive::before {
-  content: '';
-  position: absolute;
-  left: -3px;
-  top: 8px;
-  bottom: 8px;
-  width: 3px;
-  border-radius: 3px;
-  background: var(--b-600);
+.navBadge {
+  margin-left: auto;
+  padding: 2px var(--sp-2);
+  border-radius: var(--r-full);
+  background: var(--surface-hover);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
 }
 
 /* ── Right pane ────────────────────────────────────────────── */
@@ -145,43 +102,36 @@
 }
 
 .paneHeader {
-  padding: var(--sp-16) var(--sp-16) var(--sp-8);
+  padding: var(--sp-12) var(--sp-12) var(--sp-6);
   border-bottom: 1px solid var(--border-subtle);
 }
 
-.paneEyebrow {
-  display: block;
-  font-family: var(--font-mono);
-  font-size: var(--text-2xs);
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-tertiary);
-}
-
 .paneTitle {
-  margin: var(--sp-2) 0 0;
+  margin: 0;
   font-size: var(--text-h1);
   font-weight: 700;
-  line-height: 1.1;
+  line-height: 1.15;
   letter-spacing: -0.02em;
   color: var(--text-primary);
+  word-break: keep-all;
 }
 
 .paneBody {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-width: 0;
 }
 
 /* ── Tablet ────────────────────────────────────────────────── */
 @media (max-width: 960px) {
   .rail {
-    width: 220px;
+    width: 200px;
+    padding: var(--sp-8) var(--sp-3) var(--sp-5);
   }
 
   .paneHeader {
-    padding: var(--sp-12) var(--sp-12) var(--sp-6);
+    padding: var(--sp-10) var(--sp-10) var(--sp-5);
   }
 
   .paneTitle {
@@ -189,7 +139,7 @@
   }
 }
 
-/* ── Mobile: stack rail above pane, nav becomes chip row ───── */
+/* ── Mobile: rail collapses to horizontal scrolling chip row ── */
 @media (max-width: 720px) {
   .shell {
     flex-direction: column;
@@ -199,32 +149,29 @@
   .rail {
     width: 100%;
     flex: 0 0 auto;
+    padding: var(--sp-6) var(--sp-6) var(--sp-3);
     border-right: 0;
     border-bottom: 1px solid var(--border-subtle);
     overflow-y: visible;
   }
 
-  .railHeader {
-    padding: var(--sp-10) var(--sp-8) var(--sp-6);
-  }
-
   .title {
+    margin: 0 0 var(--sp-4);
     font-size: var(--text-h3);
   }
 
   .nav {
     flex-direction: row;
     gap: var(--sp-2);
-    padding: var(--sp-3) var(--sp-8) var(--sp-6);
     overflow-x: auto;
     scrollbar-width: none;
+    padding-bottom: var(--sp-2);
   }
 
   .nav::-webkit-scrollbar { display: none; }
 
   .navItem {
     flex: 0 0 auto;
-    grid-template-columns: 16px auto;
     padding: var(--sp-2) var(--sp-4);
     border-radius: var(--r-full);
     border: 1px solid var(--border-subtle);
@@ -235,20 +182,12 @@
     border-color: var(--b-600);
   }
 
-  .navItemActive::before {
-    display: none;
-  }
-
-  .navHint {
-    display: none;
-  }
-
   .pane {
     overflow: visible;
     flex: 1 1 auto;
   }
 
   .paneHeader {
-    padding: var(--sp-8) var(--sp-8) var(--sp-4);
+    padding: var(--sp-6) var(--sp-6) var(--sp-3);
   }
 }

--- a/services/aris-web/components/settings/SettingsSurface.tsx
+++ b/services/aris-web/components/settings/SettingsSurface.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { Cpu, KeyRound } from 'lucide-react';
 import { ModelsSection } from './ModelsSection';
 import { SshSection } from './SshSection';
 import styles from './SettingsSurface.module.css';
@@ -11,13 +10,12 @@ type Section = 'models' | 'ssh';
 type NavItem = {
   id: Section;
   label: string;
-  hint: string;
-  Icon: typeof Cpu;
+  badge?: string;
 };
 
 const ITEMS: NavItem[] = [
-  { id: 'models', label: 'Models', hint: 'API keys · catalog · defaults', Icon: Cpu },
-  { id: 'ssh', label: 'SSH', hint: 'Terminal credentials', Icon: KeyRound },
+  { id: 'models', label: 'Models' },
+  { id: 'ssh', label: 'SSH' },
 ];
 
 export function SettingsSurface() {
@@ -27,12 +25,9 @@ export function SettingsSurface() {
   return (
     <div className={styles.shell}>
       <aside className={styles.rail} aria-label="Settings navigation">
-        <header className={styles.railHeader}>
-          <span className={styles.eyebrow}>Workspace</span>
-          <h1 className={styles.title}>Settings</h1>
-        </header>
+        <h1 className={styles.title}>설정</h1>
         <nav className={styles.nav} role="tablist" aria-orientation="vertical">
-          {ITEMS.map(({ id, label, hint, Icon }) => {
+          {ITEMS.map(({ id, label, badge }) => {
             const isActive = section === id;
             return (
               <button
@@ -46,11 +41,8 @@ export function SettingsSurface() {
                 className={`${styles.navItem} ${isActive ? styles.navItemActive : ''}`}
                 onClick={() => setSection(id)}
               >
-                <Icon size={16} aria-hidden className={styles.navIcon} />
-                <span className={styles.navBody}>
-                  <span className={styles.navLabel}>{label}</span>
-                  <span className={styles.navHint}>{hint}</span>
-                </span>
+                <span className={styles.navLabel}>{label}</span>
+                {badge ? <span className={styles.navBadge}>{badge}</span> : null}
               </button>
             );
           })}
@@ -64,7 +56,6 @@ export function SettingsSurface() {
         aria-labelledby={`settings-tab-${section}`}
       >
         <header className={styles.paneHeader}>
-          <span className={styles.paneEyebrow}>{activeItem.hint}</span>
           <h2 className={styles.paneTitle}>{activeItem.label}</h2>
         </header>
         <div className={styles.paneBody}>


### PR DESCRIPTION
## Fixes from user feedback

1. **가로 narrow일 때 한글이 한 글자씩 세로 stacking** 버그
2. **레일이 너무 무겁다** — Claude.ai 설정처럼 더 심플하게

## Changes

- `SettingsSurface`: 레일에서 아이콘·힌트 카피 제거. plain "설정" 타이틀 + label만 있는 nav 항목. active = subtle pill 배경
- `ModelsSection`: `.groupHead`가 항상 column으로 스택되도록 변경 (제목 위, 툴바 아래) — 가로 좁을 때 옆으로 짓눌리는 문제 해결
- `.searchWrap`가 `flex: 1 1 200px`로 행 잔여 폭을 채움. 툴바는 wrap 가능
- 한글이 포함된 모든 헤딩에 `word-break: keep-all; overflow-wrap: break-word` — 단어 단위 줄바꿈

향후 설정 항목 추가: `ITEMS` 배열에 `{ id, label, badge? }` 한 줄 추가만 하면 자동 노출 (badge로 "베타" 같은 pill 가능).

🤖 Generated with [Claude Code](https://claude.com/claude-code)