### PR TITLE
feat(sidebar): split footer into account + context triggers; vertical theme

### DIFF
--- a/services/aris-web/components/layout/SidebarFooterMenu.module.css
+++ b/services/aris-web/components/layout/SidebarFooterMenu.module.css
@@ -1,24 +1,66 @@
 .root { position: relative; }
 
-.trigger {
+/* ── Footer row: account trigger + small context trigger ─────── */
+.row {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  width: 100%;
+}
+
+.accountTrigger {
+  flex: 1 1 auto;
   display: grid;
-  grid-template-columns: 28px 1fr 14px;
+  grid-template-columns: 28px 1fr;
   gap: 10px;
   align-items: center;
-  width: 100%;
-  padding: 8px 10px;
+  min-width: 0;
+  padding: 6px 8px;
   border-radius: 10px;
   background: transparent;
   border: 1px solid transparent;
   color: var(--text-primary);
   cursor: pointer;
+  text-align: left;
 }
-.trigger:hover { background: var(--surface-hover); }
-.trigger[aria-expanded='true'] {
+.accountTrigger:hover { background: var(--surface-hover); }
+.accountTrigger:focus-visible {
+  outline: 2px solid var(--primary, #2f6bff);
+  outline-offset: -2px;
+}
+.accountTrigger[aria-expanded='true'] {
   background: var(--surface-hover);
   border-color: var(--line);
 }
 
+.contextTrigger {
+  flex: 0 0 32px;
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  align-self: center;
+  border-radius: 8px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+.contextTrigger:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+.contextTrigger:focus-visible {
+  outline: 2px solid var(--primary, #2f6bff);
+  outline-offset: -2px;
+}
+.contextTrigger[aria-expanded='true'] {
+  background: var(--surface-hover);
+  border-color: var(--line);
+  color: var(--text-primary);
+}
+
+/* ── Account trigger interior ──────────────────────────────── */
 .avatar {
   width: 28px;
   height: 28px;
@@ -58,14 +100,10 @@
   color: var(--text-tertiary);
   font-family: var(--font-mono, ui-monospace, monospace);
 }
-.chev {
-  color: var(--text-tertiary);
-  flex-shrink: 0;
-}
 
+/* ── Shared popover panel ──────────────────────────────────── */
 .panel {
   position: absolute;
-  left: 8px;
   bottom: calc(100% + 6px);
   min-width: 232px;
   background: var(--surface-elevated, var(--surface));
@@ -79,7 +117,13 @@
   flex-direction: column;
   gap: 2px;
 }
+.accountPanel { left: 8px; }
+.contextPanel {
+  right: 8px;
+  min-width: 200px;
+}
 
+/* ── Menu items / sections ─────────────────────────────────── */
 .item {
   display: inline-flex;
   align-items: center;
@@ -102,6 +146,12 @@
   outline-offset: -2px;
 }
 
+.divider {
+  height: 1px;
+  background: var(--line);
+  margin: 4px 6px;
+}
+
 .section {
   padding: 8px 4px 4px;
   margin-top: 4px;
@@ -114,46 +164,100 @@
   text-transform: uppercase;
   color: var(--text-tertiary);
   margin: 0 0 6px;
-  padding: 0 6px;
+  padding: 0 8px;
 }
 
+/* ── Account list row (current account read-only) ──────────── */
+.accountRow {
+  display: grid;
+  grid-template-columns: 24px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: var(--surface-hover);
+}
+.avatarSmall {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #ffb74d, #f57c00);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+}
+.accountInfo {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.accountEmail {
+  font-size: var(--text-xs, 12px);
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.accountRole {
+  font-size: var(--text-2xs, 11px);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+.accountCheck {
+  color: var(--success-fg, #16a34a);
+  flex-shrink: 0;
+}
+
+/* ── Theme: vertical radio list ────────────────────────────── */
+.themeColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
 .themeRow {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 4px;
-}
-.themeChip {
-  display: inline-flex;
-  flex-direction: column;
+  grid-template-columns: 18px 1fr 14px;
   align-items: center;
-  justify-content: center;
-  gap: 4px;
-  padding: 8px 4px;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
   border-radius: 8px;
-  border: 1px solid var(--line);
   background: transparent;
+  border: 1px solid transparent;
   color: var(--text-primary);
   font: inherit;
-  font-size: var(--text-2xs, 11px);
+  font-size: var(--text-sm, 13px);
   line-height: 1;
-  min-height: 52px;
+  text-align: left;
   cursor: pointer;
 }
-.themeChip:hover { background: var(--surface-hover); }
-.themeChip:focus-visible {
+.themeRow:hover { background: var(--surface-hover); }
+.themeRow:focus-visible {
   outline: 2px solid var(--primary, #2f6bff);
   outline-offset: -2px;
 }
-.themeChipActive {
+.themeRowActive {
   background: var(--surface-active, var(--surface-hover));
   border-color: var(--line-strong, var(--line));
-  color: var(--text-primary);
+}
+.themeIcon { color: var(--text-tertiary); }
+.themeRowActive .themeIcon { color: var(--text-primary); }
+.themeLabel {
+  letter-spacing: -0.005em;
+}
+.themeCheck {
+  color: var(--primary, #2f6bff);
+  justify-self: end;
 }
 
+/* ── Sign out ──────────────────────────────────────────────── */
 .signoutForm {
-  margin: 4px 0 0;
-  padding-top: 4px;
-  border-top: 1px solid var(--line);
+  margin: 0;
 }
 .signout { color: var(--danger-fg, #ef4444); }
 .signout:hover { background: var(--danger-bg, rgba(239, 68, 68, 0.08)); }

--- a/services/aris-web/components/layout/SidebarFooterMenu.tsx
+++ b/services/aris-web/components/layout/SidebarFooterMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { LogOut, Settings, Sun, Moon, Monitor, MoreHorizontal } from 'lucide-react';
+import { Check, LogOut, MoreHorizontal, Monitor, Moon, Settings, Sun, UserCog } from 'lucide-react';
 import { withAppBasePath } from '@/lib/routing/appPath';
 import type { ThemeMode } from '@/lib/theme/clientTheme';
 import styles from './SidebarFooterMenu.module.css';
@@ -13,6 +13,8 @@ interface Props {
   onOpenSettings: () => void;
 }
 
+type ActivePopover = 'account' | 'context' | null;
+
 const THEME_ITEMS: Array<{ mode: ThemeMode; label: string; Icon: typeof Sun }> = [
   { mode: 'light', label: '라이트', Icon: Sun },
   { mode: 'dark', label: '다크', Icon: Moon },
@@ -20,53 +22,113 @@ const THEME_ITEMS: Array<{ mode: ThemeMode; label: string; Icon: typeof Sun }> =
 ];
 
 export function SidebarFooterMenu({ user, themeMode, onThemeChange, onOpenSettings }: Props) {
-  const [open, setOpen] = useState(false);
+  const [activePopover, setActivePopover] = useState<ActivePopover>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const userInitial = (user.email?.trim()?.[0] ?? 'A').toUpperCase();
+  const accountName = user.email.split('@')[0] || 'ARIS';
 
   useEffect(() => {
-    if (!open) return;
+    if (activePopover === null) return;
     const onClick = (e: MouseEvent) => {
-      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+      if (!rootRef.current?.contains(e.target as Node)) setActivePopover(null);
     };
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setActivePopover(null);
+    };
     window.addEventListener('mousedown', onClick);
     window.addEventListener('keydown', onKey);
     return () => {
       window.removeEventListener('mousedown', onClick);
       window.removeEventListener('keydown', onKey);
     };
-  }, [open]);
+  }, [activePopover]);
+
+  const toggle = (next: 'account' | 'context') => {
+    setActivePopover((current) => (current === next ? null : next));
+  };
 
   return (
     <div className={styles.root} ref={rootRef}>
-      <button
-        type="button"
-        className={styles.trigger}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-      >
-        <span className={styles.avatar}>{userInitial}</span>
-        <span className={styles.identity}>
-          <span className={styles.name}>{user.email.split('@')[0] || 'ARIS'}</span>
-          <span className={styles.meta}>{user.role}</span>
-        </span>
-        <MoreHorizontal size={14} className={styles.chev} />
-      </button>
-      {open && (
-        <div className={styles.panel} role="menu" aria-label="사용자 메뉴">
+      <div className={styles.row}>
+        <button
+          type="button"
+          className={styles.accountTrigger}
+          aria-haspopup="menu"
+          aria-expanded={activePopover === 'account'}
+          aria-controls="sidebar-footer-account-panel"
+          onClick={() => toggle('account')}
+        >
+          <span className={styles.avatar}>{userInitial}</span>
+          <span className={styles.identity}>
+            <span className={styles.name}>{accountName}</span>
+            <span className={styles.meta}>{user.role}</span>
+          </span>
+        </button>
+        <button
+          type="button"
+          className={styles.contextTrigger}
+          aria-label="환경 메뉴"
+          aria-haspopup="menu"
+          aria-expanded={activePopover === 'context'}
+          aria-controls="sidebar-footer-context-panel"
+          onClick={() => toggle('context')}
+        >
+          <MoreHorizontal size={16} aria-hidden />
+        </button>
+      </div>
+
+      {activePopover === 'account' && (
+        <div
+          id="sidebar-footer-account-panel"
+          className={`${styles.panel} ${styles.accountPanel}`}
+          role="menu"
+          aria-label="계정 메뉴"
+        >
+          <div className={styles.sectionLabel}>Account List</div>
+          <div className={styles.accountRow} role="presentation">
+            <span className={styles.avatarSmall} aria-hidden>{userInitial}</span>
+            <span className={styles.accountInfo}>
+              <span className={styles.accountEmail}>{user.email}</span>
+              <span className={styles.accountRole}>{user.role}</span>
+            </span>
+            <Check size={14} className={styles.accountCheck} aria-label="현재 계정" />
+          </div>
+          <div className={styles.divider} role="presentation" />
           <button
             type="button"
             role="menuitem"
             className={styles.item}
-            onClick={() => { setOpen(false); onOpenSettings(); }}
+            onClick={() => { setActivePopover(null); onOpenSettings(); }}
           >
-            <Settings size={14} /> Settings
+            <UserCog size={14} aria-hidden /> Account Settings
+          </button>
+          <div className={styles.divider} role="presentation" />
+          <form action={withAppBasePath('/api/auth/logout')} method="POST" className={styles.signoutForm}>
+            <button type="submit" role="menuitem" className={`${styles.item} ${styles.signout}`}>
+              <LogOut size={14} aria-hidden /> Sign Out
+            </button>
+          </form>
+        </div>
+      )}
+
+      {activePopover === 'context' && (
+        <div
+          id="sidebar-footer-context-panel"
+          className={`${styles.panel} ${styles.contextPanel}`}
+          role="menu"
+          aria-label="환경 메뉴"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            className={styles.item}
+            onClick={() => { setActivePopover(null); onOpenSettings(); }}
+          >
+            <Settings size={14} aria-hidden /> Settings
           </button>
           <div className={styles.section} role="group" aria-label="테마">
             <div className={styles.sectionLabel}>테마</div>
-            <div className={styles.themeRow}>
+            <div className={styles.themeColumn}>
               {THEME_ITEMS.map(({ mode, label, Icon }) => {
                 const active = themeMode === mode;
                 return (
@@ -75,20 +137,17 @@ export function SidebarFooterMenu({ user, themeMode, onThemeChange, onOpenSettin
                     type="button"
                     role="menuitemradio"
                     aria-checked={active}
-                    className={`${styles.themeChip}${active ? ' ' + styles.themeChipActive : ''}`}
+                    className={`${styles.themeRow} ${active ? styles.themeRowActive : ''}`}
                     onClick={() => onThemeChange(mode)}
                   >
-                    <Icon size={12} /> {label}
+                    <Icon size={14} aria-hidden className={styles.themeIcon} />
+                    <span className={styles.themeLabel}>{label}</span>
+                    {active ? <Check size={14} aria-hidden className={styles.themeCheck} /> : null}
                   </button>
                 );
               })}
             </div>
           </div>
-          <form action={withAppBasePath('/api/auth/logout')} method="POST" className={styles.signoutForm}>
-            <button type="submit" role="menuitem" className={`${styles.item} ${styles.signout}`}>
-              <LogOut size={14} /> Sign out
-            </button>
-          </form>
         </div>
       )}
     </div>


### PR DESCRIPTION
## User requests

1. 왼쪽 계정명 영역 클릭 → Account 메뉴 (Account List, Account Settings, Sign Out)
2. 우측 별도 버튼 → 컨텍스트 메뉴 (Settings, Theme)
3. 컨텍스트 메뉴 Theme 수직 배열

## Implementation

- 단일 trigger를 두 개로 분리:
  - **accountTrigger** (큰 영역, avatar + identity)
  - **contextTrigger** (32×32, kebab icon)
- 단일 상태 \`ActivePopover = 'account' | 'context' | null\` — 두 popover 동시 오픈 불가
- **Account popover**: \`Account List\` 헤더 + 현재 계정 read-only row (avatar + email + role + ✓) → divider → Account Settings → divider → Sign Out (form)
- **Context popover**: Settings menuitem + Theme section (수직 menuitemradio: icon | label | check)
- 두 popover는 같은 ESC/outside-click 핸들러 공유

## Verification

- [x] tsc 관련 에러 0
- [x] 키보드 접근성: \`role=menu/menuitem/menuitemradio\`, \`aria-haspopup/expanded/controls\`, ESC closes
- [ ] 라이브에서 라이트·다크 양쪽 확인 (배포 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)