### PR TITLE
fix(sidebar): pin context trigger to right edge + fix popover anchor

### DIFF
--- a/services/aris-web/components/layout/SidebarFooterMenu.module.css
+++ b/services/aris-web/components/layout/SidebarFooterMenu.module.css
@@ -1,4 +1,9 @@
-.root { position: relative; }
+.root {
+  position: relative;
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
+}
 
 /* ── Footer row: account trigger + small context trigger ─────── */
 .row {
@@ -40,6 +45,7 @@
   width: 32px;
   height: 32px;
   align-self: center;
+  margin-left: auto;
   border-radius: 8px;
   background: transparent;
   border: 1px solid transparent;


### PR DESCRIPTION
## Problem (from user screenshots)

1. \`...\` (context) trigger 가 footer 오른쪽 끝까지 못 가고 중간쯤에 떠있음
2. 컨텍스트 popover 가 잘못된 위치에 뜸 (좌측까지 늘어진 듯 보임)

## Root cause

두 문제 모두 **공통 원인**: \`.root\` div 가 부모 \`.m-sb__footer\` (flex 컨테이너) 의 자식인데 \`flex\`/\`width\` 가 없어서 content 크기로 축소됨. 결과:
- \`.row { width: 100% }\` 가 \`.root\` 폭 (= content 폭) 만큼만 펼쳐짐
- \`.contextTrigger\` 가 \`.row\` 끝에 붙긴 하지만 그 끝이 footer 오른쪽 끝이 아님
- \`.contextPanel { right: 8px }\` 가 \`.root\` 우측 기준이라 popover 가 footer 우측에 안 맞춰짐

## Fix

- \`.root\`: \`flex: 1 1 auto; width: 100%; min-width: 0\`
- \`.contextTrigger\`: \`margin-left: auto\` (방어적 — \`.accountTrigger\` 가 어떤 이유로 grow 못해도 trigger 가 끝까지 감)

🤖 Generated with [Claude Code](https://claude.com/claude-code)