### PR TITLE
fix(sidebar): clamp footer popovers to footer width (no overflow)

### DIFF
--- a/services/aris-web/components/layout/SidebarFooterMenu.module.css
+++ b/services/aris-web/components/layout/SidebarFooterMenu.module.css
@@ -108,10 +108,16 @@
 }
 
 /* ── Shared popover panel ──────────────────────────────────── */
+/* Both popovers anchor to both sides so they fit exactly within the
+ * sidebar footer's horizontal bounds (footer width minus 16px). This
+ * prevents the popover from spilling past the sidebar's right edge on
+ * narrow sidebars. */
 .panel {
   position: absolute;
+  left: 8px;
+  right: 8px;
   bottom: calc(100% + 6px);
-  min-width: 232px;
+  min-width: 0;
   background: var(--surface-elevated, var(--surface));
   color: var(--text-primary);
   border: 1px solid var(--line);
@@ -123,11 +129,10 @@
   flex-direction: column;
   gap: 2px;
 }
-.accountPanel { left: 8px; }
-.contextPanel {
-  right: 8px;
-  min-width: 200px;
-}
+/* Modifiers retained for future per-popover tuning (e.g., portal-based
+ * positioning). They intentionally inherit base anchoring for now. */
+.accountPanel {}
+.contextPanel {}
 
 /* ── Menu items / sections ─────────────────────────────────── */
 .item {


### PR DESCRIPTION
## Problem

Account popover 가 사이드바 우측 가장자리를 넘어 main content 영역으로 overflow 됨.

## Root cause

\`.panel\` 베이스 룰에 \`min-width: 232px\` 가 있고 popover 들은 한쪽만 anchor (account: \`left: 8px\`, context: \`right: 8px\`)였음. 사이드바가 좁아 footer 폭이 232px 미만이 되면 popover 가 그 floor 폭만큼 늘어나 한쪽으로 튀어나감.

## Fix

\`.panel\` 자체에 \`left: 8px; right: 8px; min-width: 0\` 을 박아 두 popover 모두 footer 의 가로 경계 안에 정확히 들어가게 함. \`.accountPanel\`/\`.contextPanel\` 빈 hook 은 향후 portal 기반 위치 조정에 대비해 남겨둠.

🤖 Generated with [Claude Code](https://claude.com/claude-code)