### PR TITLE
feat(sidebar): resizable left rail + portal-rendered footer popovers

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -50,6 +50,7 @@ import {
 } from 'lucide-react';
 import { BottomNav, TabType } from '@/components/layout/BottomNav';
 import { SidebarFooterMenu } from '@/components/layout/SidebarFooterMenu';
+import { SidebarResizer } from '@/components/layout/SidebarResizer';
 import { SettingsSurface } from '@/components/settings/SettingsSurface';
 import { BackendNotice } from '@/components/ui/BackendNotice';
 import { ProviderLogo, type ProviderLogoProvider } from '@/components/ui/ProviderLogo';
@@ -62,6 +63,7 @@ import type { SessionChat, SessionStatus, SessionSummary, UiEvent } from '@/lib/
 import { buildProjectChatCollectionPath } from '@/lib/projectRuntimeAdapter';
 import { abortActiveChat } from '@/lib/runtime/abortChat';
 import { useSessionRuntime } from '@/lib/hooks/useSessionRuntime';
+import { useSidebarWidth } from '@/lib/hooks/useSidebarWidth';
 import { useWorkspaceFiles, type WorkspaceFileItem } from '@/lib/hooks/useWorkspaceFiles';
 import {
   buildChatTitleFromFirstPrompt,
@@ -2276,6 +2278,7 @@ export default function HomePageWrapper({
   const [selectedProjectChatId, setSelectedProjectChatId] = useState<string | null>(null);
   const [metrics, setMetrics] = useState<RuntimeMetrics | null>(null);
   const [themeMode, setThemeMode] = useState<ThemeMode>('system');
+  const [sidebarWidth, setSidebarWidth] = useSidebarWidth();
 
   useEffect(() => {
     const mode = readThemeMode();
@@ -2448,7 +2451,10 @@ export default function HomePageWrapper({
   };
 
   return (
-    <div className={`app-shell app-shell-ia${shouldShowBottomNav ? '' : ' app-shell-ia--chat-screen'}${projectSurfaceMode === 'panel' ? ' app-shell-ia--project-panel' : ''}`}>
+    <div
+      className={`app-shell app-shell-ia${shouldShowBottomNav ? '' : ' app-shell-ia--chat-screen'}${projectSurfaceMode === 'panel' ? ' app-shell-ia--project-panel' : ''}`}
+      style={{ '--m-sb-width': `${sidebarWidth}px` } as React.CSSProperties}
+    >
       <div className="aris-ia-shell">
         <Sidebar
           activeProjectChatId={selectedProjectChatId}
@@ -2462,6 +2468,7 @@ export default function HomePageWrapper({
           themeMode={themeMode}
           onThemeChange={changeThemeMode}
         />
+        <SidebarResizer width={sidebarWidth} onWidthChange={setSidebarWidth} />
         <main className="m-main">
           <Topbar
             activeTab={activeTab}

--- a/services/aris-web/app/styles/ui.css
+++ b/services/aris-web/app/styles/ui.css
@@ -323,7 +323,8 @@
 
 .aris-ia-shell {
   display: grid;
-  grid-template-columns: 240px minmax(0, 1fr);
+  grid-template-columns: var(--m-sb-width, 240px) minmax(0, 1fr);
+  position: relative;
   min-height: var(--app-vh, 100dvh);
   background: var(--canvas);
   color: var(--text-primary);

--- a/services/aris-web/components/layout/SidebarFooterMenu.module.css
+++ b/services/aris-web/components/layout/SidebarFooterMenu.module.css
@@ -108,29 +108,24 @@
 }
 
 /* ── Shared popover panel ──────────────────────────────────── */
-/* Both popovers anchor to both sides so they fit exactly within the
- * sidebar footer's horizontal bounds (footer width minus 16px). This
- * prevents the popover from spilling past the sidebar's right edge on
- * narrow sidebars. */
+/* Rendered via React portal into <body> with position: fixed. Inline
+ * style provides top + (left | right). Width is no longer constrained
+ * to the sidebar's horizontal bounds. */
 .panel {
-  position: absolute;
-  left: 8px;
-  right: 8px;
-  bottom: calc(100% + 6px);
-  min-width: 0;
+  position: fixed;
+  min-width: 240px;
+  max-width: 320px;
   background: var(--surface-elevated, var(--surface));
   color: var(--text-primary);
   border: 1px solid var(--line);
   border-radius: var(--radius-md, 10px);
   padding: 6px;
   box-shadow: var(--shadow-md, 0 18px 40px rgba(0, 0, 0, 0.18));
-  z-index: 40;
+  z-index: 1000;
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
-/* Modifiers retained for future per-popover tuning (e.g., portal-based
- * positioning). They intentionally inherit base anchoring for now. */
 .accountPanel {}
 .contextPanel {}
 

--- a/services/aris-web/components/layout/SidebarFooterMenu.tsx
+++ b/services/aris-web/components/layout/SidebarFooterMenu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Check, LogOut, MoreHorizontal, Monitor, Moon, Settings, Sun, UserCog } from 'lucide-react';
 import { withAppBasePath } from '@/lib/routing/appPath';
 import type { ThemeMode } from '@/lib/theme/clientTheme';
@@ -14,6 +15,13 @@ interface Props {
 }
 
 type ActivePopover = 'account' | 'context' | null;
+type AnchorSide = 'left' | 'right';
+interface PopoverPosition {
+  top: number;
+  left?: number;
+  right?: number;
+  anchorSide: AnchorSide;
+}
 
 const THEME_ITEMS: Array<{ mode: ThemeMode; label: string; Icon: typeof Sun }> = [
   { mode: 'light', label: '라이트', Icon: Sun },
@@ -21,16 +29,68 @@ const THEME_ITEMS: Array<{ mode: ThemeMode; label: string; Icon: typeof Sun }> =
   { mode: 'system', label: '시스템', Icon: Monitor },
 ];
 
+const POPOVER_GAP = 6;
+
 export function SidebarFooterMenu({ user, themeMode, onThemeChange, onOpenSettings }: Props) {
   const [activePopover, setActivePopover] = useState<ActivePopover>(null);
+  const [position, setPosition] = useState<PopoverPosition | null>(null);
+  const [mounted, setMounted] = useState(false);
+
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const accountTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const contextTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
   const userInitial = (user.email?.trim()?.[0] ?? 'A').toUpperCase();
   const accountName = user.email.split('@')[0] || 'ARIS';
+
+  useEffect(() => { setMounted(true); }, []);
+
+  const computePosition = useCallback((next: ActivePopover) => {
+    if (next === null) return null;
+    const trigger = next === 'account' ? accountTriggerRef.current : contextTriggerRef.current;
+    if (!trigger) return null;
+    const rect = trigger.getBoundingClientRect();
+    if (next === 'account') {
+      return {
+        top: rect.top - POPOVER_GAP,
+        left: rect.left,
+        anchorSide: 'left' as AnchorSide,
+      };
+    }
+    return {
+      top: rect.top - POPOVER_GAP,
+      right: window.innerWidth - rect.right,
+      anchorSide: 'right' as AnchorSide,
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    if (activePopover === null) {
+      setPosition(null);
+      return;
+    }
+    setPosition(computePosition(activePopover));
+  }, [activePopover, computePosition]);
+
+  useEffect(() => {
+    if (activePopover === null) return;
+    const update = () => setPosition(computePosition(activePopover));
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [activePopover, computePosition]);
 
   useEffect(() => {
     if (activePopover === null) return;
     const onClick = (e: MouseEvent) => {
-      if (!rootRef.current?.contains(e.target as Node)) setActivePopover(null);
+      const target = e.target as Node;
+      if (rootRef.current?.contains(target)) return;
+      if (panelRef.current?.contains(target)) return;
+      setActivePopover(null);
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setActivePopover(null);
@@ -47,43 +107,10 @@ export function SidebarFooterMenu({ user, themeMode, onThemeChange, onOpenSettin
     setActivePopover((current) => (current === next ? null : next));
   };
 
-  return (
-    <div className={styles.root} ref={rootRef}>
-      <div className={styles.row}>
-        <button
-          type="button"
-          className={styles.accountTrigger}
-          aria-haspopup="menu"
-          aria-expanded={activePopover === 'account'}
-          aria-controls="sidebar-footer-account-panel"
-          onClick={() => toggle('account')}
-        >
-          <span className={styles.avatar}>{userInitial}</span>
-          <span className={styles.identity}>
-            <span className={styles.name}>{accountName}</span>
-            <span className={styles.meta}>{user.role}</span>
-          </span>
-        </button>
-        <button
-          type="button"
-          className={styles.contextTrigger}
-          aria-label="환경 메뉴"
-          aria-haspopup="menu"
-          aria-expanded={activePopover === 'context'}
-          aria-controls="sidebar-footer-context-panel"
-          onClick={() => toggle('context')}
-        >
-          <MoreHorizontal size={16} aria-hidden />
-        </button>
-      </div>
-
-      {activePopover === 'account' && (
-        <div
-          id="sidebar-footer-account-panel"
-          className={`${styles.panel} ${styles.accountPanel}`}
-          role="menu"
-          aria-label="계정 메뉴"
-        >
+  const renderPanelContent = () => {
+    if (activePopover === 'account') {
+      return (
+        <>
           <div className={styles.sectionLabel}>Account List</div>
           <div className={styles.accountRow} role="presentation">
             <span className={styles.avatarSmall} aria-hidden>{userInitial}</span>
@@ -108,16 +135,12 @@ export function SidebarFooterMenu({ user, themeMode, onThemeChange, onOpenSettin
               <LogOut size={14} aria-hidden /> Sign Out
             </button>
           </form>
-        </div>
-      )}
-
-      {activePopover === 'context' && (
-        <div
-          id="sidebar-footer-context-panel"
-          className={`${styles.panel} ${styles.contextPanel}`}
-          role="menu"
-          aria-label="환경 메뉴"
-        >
+        </>
+      );
+    }
+    if (activePopover === 'context') {
+      return (
+        <>
           <button
             type="button"
             role="menuitem"
@@ -148,8 +171,65 @@ export function SidebarFooterMenu({ user, themeMode, onThemeChange, onOpenSettin
               })}
             </div>
           </div>
-        </div>
-      )}
+        </>
+      );
+    }
+    return null;
+  };
+
+  const panelStyle: React.CSSProperties | undefined = position
+    ? position.anchorSide === 'left'
+      ? { top: position.top, left: position.left, transform: 'translateY(-100%)' }
+      : { top: position.top, right: position.right, transform: 'translateY(-100%)' }
+    : undefined;
+
+  return (
+    <div className={styles.root} ref={rootRef}>
+      <div className={styles.row}>
+        <button
+          ref={accountTriggerRef}
+          type="button"
+          className={styles.accountTrigger}
+          aria-haspopup="menu"
+          aria-expanded={activePopover === 'account'}
+          aria-controls="sidebar-footer-account-panel"
+          onClick={() => toggle('account')}
+        >
+          <span className={styles.avatar}>{userInitial}</span>
+          <span className={styles.identity}>
+            <span className={styles.name}>{accountName}</span>
+            <span className={styles.meta}>{user.role}</span>
+          </span>
+        </button>
+        <button
+          ref={contextTriggerRef}
+          type="button"
+          className={styles.contextTrigger}
+          aria-label="환경 메뉴"
+          aria-haspopup="menu"
+          aria-expanded={activePopover === 'context'}
+          aria-controls="sidebar-footer-context-panel"
+          onClick={() => toggle('context')}
+        >
+          <MoreHorizontal size={16} aria-hidden />
+        </button>
+      </div>
+
+      {mounted && activePopover !== null && position
+        ? createPortal(
+            <div
+              ref={panelRef}
+              id={activePopover === 'account' ? 'sidebar-footer-account-panel' : 'sidebar-footer-context-panel'}
+              className={`${styles.panel} ${activePopover === 'account' ? styles.accountPanel : styles.contextPanel}`}
+              role="menu"
+              aria-label={activePopover === 'account' ? '계정 메뉴' : '환경 메뉴'}
+              style={panelStyle}
+            >
+              {renderPanelContent()}
+            </div>,
+            document.body,
+          )
+        : null}
     </div>
   );
 }

--- a/services/aris-web/components/layout/SidebarResizer.module.css
+++ b/services/aris-web/components/layout/SidebarResizer.module.css
@@ -1,0 +1,44 @@
+/* Sits at the right edge of the sidebar column. Position computed via
+ * inline style left: calc(var(--m-sb-width, 240px) - 3px) at the call site,
+ * OR via this module if rendered as a child of .aris-ia-shell with
+ * position: relative on the shell. We use the latter.
+ */
+.handle {
+  position: absolute;
+  top: 0;
+  left: calc(var(--m-sb-width, 240px) - 3px);
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  background: transparent;
+  z-index: 30;
+  border: 0;
+  padding: 0;
+  transition: background-color var(--t-fast, 120ms ease);
+}
+
+.handle::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 2px;
+  width: 2px;
+  background: transparent;
+  transition: background-color var(--t-fast, 120ms ease);
+}
+
+.handle:hover { background-color: var(--surface-hover); }
+.handle:hover::before,
+.handle:focus-visible::before {
+  background-color: var(--primary, #2f6bff);
+}
+.handle:focus-visible {
+  outline: none;
+  background-color: var(--surface-hover);
+}
+
+/* Touch devices: do not show the handle (drag-resize is desktop-first) */
+@media (hover: none), (max-width: 720px) {
+  .handle { display: none; }
+}

--- a/services/aris-web/components/layout/SidebarResizer.tsx
+++ b/services/aris-web/components/layout/SidebarResizer.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useRef } from 'react';
+import { SIDEBAR_WIDTH_MAX, SIDEBAR_WIDTH_MIN } from '@/lib/hooks/useSidebarWidth';
+import styles from './SidebarResizer.module.css';
+
+interface Props {
+  width: number;
+  onWidthChange: (next: number) => void;
+}
+
+export function SidebarResizer({ width, onWidthChange }: Props) {
+  const draggingRef = useRef(false);
+  const startWidthRef = useRef(width);
+  const startXRef = useRef(0);
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    draggingRef.current = true;
+    startWidthRef.current = width;
+    startXRef.current = e.clientX;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!draggingRef.current) return;
+    const delta = e.clientX - startXRef.current;
+    onWidthChange(startWidthRef.current + delta);
+  };
+
+  const onPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!draggingRef.current) return;
+    draggingRef.current = false;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const step = e.shiftKey ? 24 : 8;
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      onWidthChange(width - step);
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      onWidthChange(width + step);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      onWidthChange(SIDEBAR_WIDTH_MIN);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      onWidthChange(SIDEBAR_WIDTH_MAX);
+    }
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-valuenow={width}
+      aria-valuemin={SIDEBAR_WIDTH_MIN}
+      aria-valuemax={SIDEBAR_WIDTH_MAX}
+      aria-label="사이드바 폭 조절"
+      tabIndex={0}
+      className={styles.handle}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      onKeyDown={onKeyDown}
+    />
+  );
+}

--- a/services/aris-web/lib/hooks/useSidebarWidth.ts
+++ b/services/aris-web/lib/hooks/useSidebarWidth.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export const SIDEBAR_WIDTH_MIN = 200;
+export const SIDEBAR_WIDTH_MAX = 400;
+export const SIDEBAR_WIDTH_DEFAULT = 240;
+const STORAGE_KEY = 'aris-sidebar-width';
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function useSidebarWidth(): readonly [number, (next: number) => void] {
+  const [width, setWidth] = useState<number>(SIDEBAR_WIDTH_DEFAULT);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw === null) return;
+      const parsed = Number.parseInt(raw, 10);
+      if (Number.isFinite(parsed)) {
+        setWidth(clamp(parsed, SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX));
+      }
+    } catch {
+      // localStorage may throw in private/quota contexts; ignore
+    }
+  }, []);
+
+  const setAndPersist = useCallback((next: number) => {
+    const clamped = clamp(Math.round(next), SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX);
+    setWidth(clamped);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(clamped));
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  return [width, setAndPersist] as const;
+}


### PR DESCRIPTION
## Two related changes

### 1. Resizable left sidebar
- Drag handle 6px wide overlay at sidebar's right edge (`SidebarResizer` component)
- Width clamped [200, 400] px, default 240
- Persisted in `localStorage` (`aris-sidebar-width`)
- Keyboard: ArrowLeft/Right (Shift = larger step), Home/End to clamp endpoints
- `role="separator"` + full `aria-valuenow/min/max` + `aria-orientation`
- Hidden on touch / mobile (`max-width: 720px`)
- CSS variable `--m-sb-width` drives `.aris-ia-shell` grid first column

### 2. Footer popovers via React portal
- `createPortal(panel, document.body)` so popovers escape the sidebar's horizontal bounds
- Position computed via `getBoundingClientRect()` of each trigger; popover positioned with `position: fixed` + inline `top` / `left` (account) or `top` / `right` (context) + `translateY(-100%)` to render above
- Recompute on `resize` and capturing `scroll`
- Outside-click handler checks **both** `rootRef` and `panelRef` so portal clicks aren't treated as outside (React-tree-vs-DOM-tree gotcha)
- `min-width: 240px; max-width: 320px; z-index: 1000`

## Files

**Created**
- `services/aris-web/lib/hooks/useSidebarWidth.ts`
- `services/aris-web/components/layout/SidebarResizer.tsx` + `.module.css`

**Modified**
- `services/aris-web/app/styles/ui.css` — `.aris-ia-shell` grid uses `var(--m-sb-width, 240px)`, `position: relative`
- `services/aris-web/app/HomePageClient.tsx` — hook + style injection + `<SidebarResizer />` between Sidebar and main
- `services/aris-web/components/layout/SidebarFooterMenu.tsx` — portal + fixed positioning
- `services/aris-web/components/layout/SidebarFooterMenu.module.css` — `.panel` switched to `position: fixed`, dropped left/right anchors

## Verification

- [x] tsc 관련 신규 에러 0 (15 pre-existing 잔존, 무관)
- [x] tests/{useProviderModels, modelPolicy, chatModelPreferences} 10/10 pass
- [ ] 라이브에서 드래그 / 폭 영속화 / popover 위치 확인 (배포 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)