### PR TITLE
fix(sidebar): flip footer popover to prevent left-edge viewport overflow

### DIFF
--- a/services/aris-web/components/layout/SidebarFooterMenu.tsx
+++ b/services/aris-web/components/layout/SidebarFooterMenu.tsx
@@ -30,6 +30,8 @@ const THEME_ITEMS: Array<{ mode: ThemeMode; label: string; Icon: typeof Sun }> =
 ];
 
 const POPOVER_GAP = 6;
+const POPOVER_MIN_WIDTH = 240; // mirrors .panel min-width in module css
+const VIEWPORT_PADDING = 8;
 
 export function SidebarFooterMenu({ user, themeMode, onThemeChange, onOpenSettings }: Props) {
   const [activePopover, setActivePopover] = useState<ActivePopover>(null);
@@ -51,18 +53,29 @@ export function SidebarFooterMenu({ user, themeMode, onThemeChange, onOpenSettin
     const trigger = next === 'account' ? accountTriggerRef.current : contextTriggerRef.current;
     if (!trigger) return null;
     const rect = trigger.getBoundingClientRect();
+    const top = rect.top - POPOVER_GAP;
+
     if (next === 'account') {
-      return {
-        top: rect.top - POPOVER_GAP,
-        left: rect.left,
-        anchorSide: 'left' as AnchorSide,
-      };
+      // Anchor at trigger's left, extending right. Clamp so it doesn't
+      // overflow the viewport's right edge on narrow displays.
+      const maxLeft = window.innerWidth - POPOVER_MIN_WIDTH - VIEWPORT_PADDING;
+      const left = Math.max(VIEWPORT_PADDING, Math.min(rect.left, maxLeft));
+      return { top, left, anchorSide: 'left' as AnchorSide };
     }
-    return {
-      top: rect.top - POPOVER_GAP,
-      right: window.innerWidth - rect.right,
-      anchorSide: 'right' as AnchorSide,
-    };
+
+    // Context popover: prefer right-anchor (popover extends LEFT from
+    // trigger's right edge). When the trigger sits too close to the
+    // viewport's left edge (narrow sidebar), that would push the popover
+    // off-screen to the left — flip to a left-anchor (extends RIGHT from
+    // trigger's left edge).
+    const wouldOverflowLeft = rect.right - POPOVER_MIN_WIDTH < VIEWPORT_PADDING;
+    if (wouldOverflowLeft) {
+      const maxLeft = window.innerWidth - POPOVER_MIN_WIDTH - VIEWPORT_PADDING;
+      const left = Math.max(VIEWPORT_PADDING, Math.min(rect.left, maxLeft));
+      return { top, left, anchorSide: 'left' as AnchorSide };
+    }
+    const right = Math.max(VIEWPORT_PADDING, window.innerWidth - rect.right);
+    return { top, right, anchorSide: 'right' as AnchorSide };
   }, []);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Problem (user screenshot)

좁은 사이드바 (~232px) 에서 context popover (Settings + Theme) 가 좌측 viewport 가장자리로 튀어나가 'S'/'라' 첫 글자들이 잘림.

## Root cause

이전 PR(#350)에서 portal 도입 후 context popover 를 \`right: window.innerWidth - rect.right\` 로 우측 anchor 했음. 사이드바가 좁으면 trigger.right ≈ 220 인데 popover min-width 240 이므로 popover left edge ≈ -20 (off-screen).

## Fix

\`computePosition\` 에 단순 flip 추가:
- account popover: 항상 trigger.left 에 anchor (extends right), 우측 viewport 초과 시 clamp
- context popover: 기본 우측 anchor; \`rect.right - POPOVER_MIN_WIDTH < 8\` 이면 left anchor 로 flip (trigger.left 에서 우측으로 펼침)
- 양쪽 모두 viewport padding 8px 보장

\`@floating-ui/react\` 라이브러리 도입 없이 단일 축 flip 만 인라인 구현.

🤖 Generated with [Claude Code](https://claude.com/claude-code)