### PR TITLE
fix(project-chat): 워크스페이스 채팅 기록 카드가 컴포저를 밀어내는 문제 수정

### DIFF
--- a/services/aris-web/app/styles/project-chat.css
+++ b/services/aris-web/app/styles/project-chat.css
@@ -606,6 +606,7 @@
   grid-area: workspace;
   border-left: 1px solid var(--border-subtle);
   min-width: 0;
+  min-height: 0;
   background: var(--surface);
 }
 

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -704,6 +704,14 @@ describe('project list surface', () => {
     expect(exactCssBlock('.pc-proto .ws')).toContain('background: var(--surface);');
   });
 
+  it('keeps the workspace column from growing the shell row when chat history entries expand', () => {
+    // Grid items default to min-height: auto (content-based); without an explicit
+    // override, an expanded chist__text entry can stretch the whole .shell row and
+    // push the composer in .shell__main below the viewport.
+    expect(exactCssBlock('.pc-proto .shell__main')).toContain('min-height: 0;');
+    expect(exactCssBlock('.pc-proto .shell__workspace')).toContain('min-height: 0;');
+  });
+
   it('keeps the project filter chips attached to the search field instead of the screen edge', () => {
     const toolbar = cssBlock('.proj-list-toolbar');
     const chips = cssBlock('.proj-list-chips');


### PR DESCRIPTION
## Summary
- `.shell` 그리드는 `.shell__main`/`.shell__workspace` 두 열을 한 행에서 공유하는데, `.shell__workspace`에 `min-height: 0`이 없어서 워크스페이스 사이드바 안의 Chat history 카드(`.chturn`) 첫 turn을 펼치면(`data-open="true"`) `.chturn__text`의 line-clamp가 풀리며 콘텐츠가 무제한으로 길어질 수 있었습니다.
- 그리드 아이템의 기본 `min-height: auto`(content-based) 때문에 이 콘텐츠 높이가 `.shell` 행 전체를 늘려서, 같은 행의 `.shell__main` 안에 있는 채팅 컴포저가 뷰포트 밖으로 밀려나는 문제가 있었습니다.
- `.shell__main`과 동일하게 `.shell__workspace`에 `min-height: 0`을 추가해, 내부 `.ws__body`의 `overflow-y: auto`가 실제로 스크롤을 흡수하도록 했습니다.

## Test plan
- [x] `npx vitest run tests/projectListSurface.test.ts` (38/38 통과, `.shell__main`/`.shell__workspace` `min-height: 0` 회귀 테스트 추가)
- [x] `npx vitest run tests/mobileOverflowLayout.test.ts tests/parallelChatDragSurface.test.ts tests/designSystemV1Implementation.test.ts tests/designSystemV3Implementation.test.ts tests/projectLayoutProviderLogos.test.ts` (40/40 통과)
- [ ] 실제 브라우저 시각 확인은 진행하지 않음 (dev 서버 기동에 prod 자격 증명이 필요해 사용자가 테스트만으로 마무리하기로 결정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)