### PR TITLE
fix(chat): stream-event 리더 중복 제거로 케이스 처리 드리프트 해소

### DIFF
--- a/services/aris-web/lib/hooks/useSessionEvents.ts
+++ b/services/aris-web/lib/hooks/useSessionEvents.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SessionEventsPage, UiEvent } from '@/lib/happy/types';
 import { redirectToLoginWithNext } from '@/lib/hooks/authRedirect';
+import { readUiEventStreamEvent } from '@/lib/happy/chatRuntime';
 import {
   buildRuntimeEventChannelUrl,
   type RuntimeEventChannelMessage,
@@ -70,33 +71,27 @@ function isUiEvent(value: unknown): value is UiEvent {
   );
 }
 
-function readTrimmedStreamEvent(event: UiEvent): string {
-  return typeof event.meta?.streamEvent === 'string'
-    ? event.meta.streamEvent.trim()
-    : '';
-}
-
 function readTrimmedMetaString(event: UiEvent, key: string): string {
   const value = event.meta?.[key];
   return typeof value === 'string' ? value.trim() : '';
 }
 
 function isGeminiPendingActionEvent(event: UiEvent): boolean {
-  return readTrimmedStreamEvent(event) === 'gemini_action_pending';
+  return readUiEventStreamEvent(event) === 'gemini_action_pending';
 }
 
 function isGeminiFinalActionEvent(event: UiEvent): boolean {
   return event.meta?.agent === 'gemini'
-    && readTrimmedStreamEvent(event) === 'agent_stream_action';
+    && readUiEventStreamEvent(event) === 'agent_stream_action';
 }
 
 function isGeminiRealtimeTextEvent(event: UiEvent): boolean {
-  const streamEvent = readTrimmedStreamEvent(event);
+  const streamEvent = readUiEventStreamEvent(event);
   return streamEvent === 'agent_message_partial' || streamEvent === 'agent_commentary_partial';
 }
 
 function isGeminiPersistedTextEvent(event: UiEvent): boolean {
-  const streamEvent = readTrimmedStreamEvent(event);
+  const streamEvent = readUiEventStreamEvent(event);
   return (
     streamEvent === 'agent_message'
     || streamEvent === 'agent_message_recovered'
@@ -109,7 +104,7 @@ function readGeminiTextEventIdentity(event: UiEvent): string | null {
     return null;
   }
 
-  const streamEvent = readTrimmedStreamEvent(event);
+  const streamEvent = readUiEventStreamEvent(event);
   const messagePhase = readTrimmedMetaString(event, 'messagePhase');
   const phase = (
     streamEvent === 'agent_commentary_partial'
@@ -132,7 +127,7 @@ function readGeminiTextEventIdentity(event: UiEvent): string | null {
 }
 
 function isRealtimeOnlyEvent(event: UiEvent): boolean {
-  const streamEvent = readTrimmedStreamEvent(event);
+  const streamEvent = readUiEventStreamEvent(event);
   return (
     streamEvent === 'gemini_action_pending'
     || streamEvent === 'agent_message_partial'


### PR DESCRIPTION
## 요약
- `useSessionEvents.ts`의 로컬 `readTrimmedStreamEvent`는 trim만 하고 lowercase를 하지 않는 반면, `chatRuntime.ts`의 `readUiEventStreamEvent`는 trim+lowercase를 모두 수행 — 같은 `meta.streamEvent` 필드를 두 곳에서 다르게 읽고 있었습니다.
- 백엔드 전수 조사(`runtimeCore.ts`, `codexRuntime.ts`, `claudeEventBridge.ts`, `geminiEventBridge.ts` 등) 결과 현재 모든 emitter가 소문자 리터럴만 사용해 지금 당장 재현되는 버그는 아니지만, 중복 구현이 방치되면 다음 프로바이더 추가 시 조용히 갈릴 위험이 있어 정리했습니다.
- `useSessionEvents.ts`의 로컬 함수를 제거하고 `chatRuntime.ts`의 `readUiEventStreamEvent`를 재사용하도록 변경.

관련: #362 (프론트엔드 리팩토링 진단, 항목 1)

## 검증
- `npx tsc --noEmit` 통과
- `npx vitest run tests/chatRuntime.test.ts` 20개 통과
- `npx vitest run` 전체: 실패 7건은 메인 브랜치에도 동일하게 존재하는 기존 실패로 확인(회귀 아님)