### PR TITLE
fix(project-chat): Files 탭 파일 클릭 시 실제 미리보기 렌더링

### DIFF
--- a/services/aris-web/app/styles/project-chat.css
+++ b/services/aris-web/app/styles/project-chat.css
@@ -3288,6 +3288,75 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
   backdrop-filter: blur(6px);
 }
 
+/* File preview modal (rendered via portal to document.body, so it sits outside .pc-proto) */
+.pc-file-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--sp-8);
+  background: rgba(15, 17, 23, .44);
+  backdrop-filter: blur(6px);
+}
+
+.pc-file-preview-card {
+  display: flex;
+  flex-direction: column;
+  width: 92%;
+  max-width: 1040px;
+  height: 88%;
+  overflow: hidden;
+  background: var(--surface);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-xl);
+}
+
+.pc-file-preview-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-3);
+  height: 100%;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.pc-file-preview-spin {
+  animation: pc-spin 1s linear infinite;
+}
+
+.pc-file-preview-blocked {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  padding: var(--sp-8);
+}
+
+.pc-file-preview-blocked__head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.pc-file-preview-close {
+  margin-left: auto;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-full);
+  color: var(--text-secondary);
+}
+
+.pc-file-preview-close:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
 .pc-proto[data-preview="open"] .overlay {
   display: flex;
 }

--- a/services/aris-web/components/project-chat/ProjectChatSurface.tsx
+++ b/services/aris-web/components/project-chat/ProjectChatSurface.tsx
@@ -13,8 +13,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { createPortal } from 'react-dom';
 import {
   AlertCircle,
+  AlertTriangle,
   ArrowDown,
   AtSign,
   Check,
@@ -27,6 +29,7 @@ import {
   File as FileIcon,
   FileText,
   FolderOpen,
+  Loader2,
   Maximize2,
   MessageSquareText,
   Mic,
@@ -43,6 +46,7 @@ import {
   X,
 } from 'lucide-react';
 import { ProviderLogo, type ProviderLogoProvider } from '@/components/ui/ProviderLogo';
+import { WorkspaceFileEditor } from '@/components/files/WorkspaceFileEditor';
 import { isTerminalRunStatus, readUiEventRunStatus } from '@/lib/happy/chatRuntime';
 import { hydratePersistedPermissions, mergeRenderablePermissions } from '@/lib/happy/permissions';
 import { withAppBasePath } from '@/lib/routing/appPath';
@@ -1745,6 +1749,16 @@ export function ProjectChatSurface({
   const [expandedTurnId, setExpandedTurnId] = useState<ExpandedTurnState>(null);
   const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
   const [selectedWorkspaceFile, setSelectedWorkspaceFile] = useState('');
+  const [workspaceFilePreview, setWorkspaceFilePreview] = useState<{
+    path: string;
+    name: string;
+    content: string;
+    rawUrl?: string;
+    blockedReason?: 'binary' | 'large';
+    sizeBytes?: number;
+  } | null>(null);
+  const [workspaceFilePreviewLoading, setWorkspaceFilePreviewLoading] = useState(false);
+  const [workspaceFilePreviewSaving, setWorkspaceFilePreviewSaving] = useState(false);
   const [draftTerminalCommand, setDraftTerminalCommand] = useState('npm test -- --run tests/projectListSurface.test.ts');
   const [previewDevice, setPreviewDevice] = useState<'1200' | '768' | '390'>('1200');
   const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
@@ -1854,6 +1868,86 @@ export function ProjectChatSurface({
       showTransientFeedback(copied ? `${label} copied` : `${label} ready`);
     });
   };
+
+  const buildFsRequestUrl = useCallback((basePath: string, filePath: string) => {
+    const params = new URLSearchParams();
+    params.set('path', filePath);
+    if (projectId) {
+      params.set('projectId', projectId);
+      if (activeWorkspacePanelId) {
+        params.set('workspacePanelId', activeWorkspacePanelId);
+      }
+    }
+    return `${basePath}?${params.toString()}`;
+  }, [projectId, activeWorkspacePanelId]);
+
+  const openWorkspaceFilePreview = useCallback((file: WorkspaceFileItem) => {
+    setSelectedWorkspaceFile(file.path);
+    const ext = file.name.split('.').pop()?.toLowerCase();
+    if (ext === 'pdf') {
+      setWorkspaceFilePreview({
+        path: file.path,
+        name: file.name,
+        content: '',
+        rawUrl: buildFsRequestUrl('/api/fs/raw', file.path),
+      });
+      return;
+    }
+
+    setWorkspaceFilePreviewLoading(true);
+    setWorkspaceFilePreview(null);
+    void (async () => {
+      try {
+        const response = await fetch(buildFsRequestUrl('/api/fs/read', file.path), { cache: 'no-store' });
+        const data = await response.json().catch(() => ({})) as {
+          content?: string;
+          error?: string;
+          blockedReason?: 'binary' | 'large';
+          sizeBytes?: number;
+        };
+        if (!response.ok) {
+          throw new Error(data.error ?? '파일을 읽을 수 없습니다.');
+        }
+        setWorkspaceFilePreview({
+          path: file.path,
+          name: file.name,
+          content: data.content ?? '',
+          blockedReason: data.blockedReason,
+          sizeBytes: data.sizeBytes,
+        });
+      } catch (err) {
+        showTransientFeedback(err instanceof Error ? err.message : '파일을 읽을 수 없습니다.');
+      } finally {
+        setWorkspaceFilePreviewLoading(false);
+      }
+    })();
+  }, [buildFsRequestUrl]);
+
+  const saveWorkspaceFilePreview = useCallback(() => {
+    if (!workspaceFilePreview) return;
+    setWorkspaceFilePreviewSaving(true);
+    void (async () => {
+      try {
+        const response = await fetch('/api/fs/write', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            path: workspaceFilePreview.path,
+            content: workspaceFilePreview.content,
+            projectId,
+            workspacePanelId: activeWorkspacePanelId,
+          }),
+        });
+        if (!response.ok) throw new Error('저장에 실패했습니다.');
+        showTransientFeedback('파일이 저장되었습니다');
+        workspaceFiles.refresh();
+      } catch (err) {
+        showTransientFeedback(err instanceof Error ? err.message : '저장에 실패했습니다.');
+      } finally {
+        setWorkspaceFilePreviewSaving(false);
+      }
+    })();
+  }, [workspaceFilePreview, projectId, activeWorkspacePanelId, workspaceFiles]);
 
   const updateJumpToLatestVisibility = useCallback(() => {
     const node = timelineRef.current;
@@ -3121,7 +3215,7 @@ export function ProjectChatSurface({
                         if (file.isDirectory) {
                           workspaceFiles.cdInto(file);
                         } else {
-                          setSelectedWorkspaceFile(file.path);
+                          openWorkspaceFilePreview(file);
                         }
                       }}
                     >
@@ -3637,8 +3731,7 @@ export function ProjectChatSurface({
                       if (file.isDirectory) {
                         workspaceFiles.cdInto(file);
                       } else {
-                        setSelectedWorkspaceFile(file.path);
-                        setPreviewState('dock');
+                        openWorkspaceFilePreview(file);
                       }
                     }}
                   >
@@ -3834,6 +3927,51 @@ export function ProjectChatSurface({
       </>
       )}
       {copyFeedback && <div className="pc-toast" data-copy-feedback role="status">{copyFeedback}</div>}
+      {typeof document !== 'undefined' && (workspaceFilePreview || workspaceFilePreviewLoading) && createPortal(
+        <div
+          className="pc-file-preview-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="File preview"
+          onClick={() => setWorkspaceFilePreview(null)}
+        >
+          <div className="pc-file-preview-card" onClick={(event) => event.stopPropagation()}>
+            {workspaceFilePreviewLoading && !workspaceFilePreview ? (
+              <div className="pc-file-preview-state">
+                <Loader2 size={16} className="pc-file-preview-spin" />
+                파일을 불러오는 중…
+              </div>
+            ) : workspaceFilePreview?.blockedReason ? (
+              <div className="pc-file-preview-blocked">
+                <div className="pc-file-preview-blocked__head">
+                  <AlertTriangle size={16} />
+                  <span>{workspaceFilePreview.name}</span>
+                  <button type="button" className="pc-file-preview-close" aria-label="닫기" onClick={() => setWorkspaceFilePreview(null)}>
+                    <X size={14} />
+                  </button>
+                </div>
+                <p>
+                  {workspaceFilePreview.blockedReason === 'binary'
+                    ? '바이너리 파일은 미리보기를 지원하지 않습니다.'
+                    : `파일이 너무 큽니다 (${Math.round((workspaceFilePreview.sizeBytes ?? 0) / 1024)}KB).`}
+                </p>
+              </div>
+            ) : workspaceFilePreview ? (
+              <WorkspaceFileEditor
+                fileName={workspaceFilePreview.name}
+                filePath={workspaceFilePreview.path}
+                content={workspaceFilePreview.content}
+                rawUrl={workspaceFilePreview.rawUrl}
+                isSaving={workspaceFilePreviewSaving}
+                onChange={(nextContent) => setWorkspaceFilePreview((current) => (current ? { ...current, content: nextContent } : current))}
+                onSave={() => saveWorkspaceFilePreview()}
+                onClose={() => setWorkspaceFilePreview(null)}
+              />
+            ) : null}
+          </div>
+        </div>,
+        document.body,
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Files 탭에서 파일 클릭 시 `setPreviewState('dock')`를 호출했는데, 이 상태값은 원래 배포된 웹앱을 기기 크기별로 미리보는 "라이브 URL 미리보기" 기능용이었음. 그 결과 실제 파일 내용과 무관한 하드코딩된 pill(`preview-dock`)만 화면에 뜨는 버그가 있었음.
- 파일 클릭 핸들러를 `/api/fs/read`로 실제 파일 내용을 읽어오고, 기존 공유 컴포넌트 `components/files/WorkspaceFileEditor`(문법 강조/마크다운/PDF 지원, `_legacy`의 WorkspaceShell·CustomizationFileModal에서 이미 검증되어 사용 중)로 렌더링하도록 변경.
- 저장은 `/api/fs/write`로 위임(기존 FileExplorer 패턴과 동일).
- 일반 워크스페이스 모드와 병렬 워크스페이스 모드(parallel panel) 양쪽 Files 탭에 동일하게 적용.
- 기존 "라이브 URL 미리보기"(`previewState`/`.preview-dock`/`.preview-frame`, 기기 크기 토글 등)는 파일 미리보기와 무관한 별개 기능이라 그대로 유지.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `next lint` — no new warnings introduced by this change
- [ ] 실제 브라우저에서 Files 탭 파일 클릭 확인 — 로컬 dev 서버 실행이 자동 모드 안전장치(프로덕션 env 파일 사용)에 3차례 차단되어 라이브 검증은 수행하지 못함. 병합 후 프로덕션에서 직접 확인 필요.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>