### PR TITLE
fix(web): 모바일 채팅 뷰포트 스크롤 버그 수정 (--app-vh 미반영)

### DIFF
--- a/services/aris-web/app/styles/ia-shell.css
+++ b/services/aris-web/app/styles/ia-shell.css
@@ -845,11 +845,11 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
 
 .m-main-scroll--project-chat-detail .pc-proto {
   height: 100%;
-  min-height: calc(100vh - 48px);
+  min-height: calc(var(--app-vh, 100dvh) - 48px);
 }
 
 .m-main-scroll--project-chat-detail .pc-proto .shell {
-  height: calc(100vh - 48px);
+  height: calc(var(--app-vh, 100dvh) - 48px);
   min-height: 0;
 }
 


### PR DESCRIPTION
## Summary
- 모바일 채팅 화면(헤더+메시지 목록+컴포저)이 위아래로 스크롤되는 버그를 수정했습니다.
- `ia-shell.css`의 `.m-main-scroll--project-chat-detail .pc-proto` / `.shell` 규칙이 정적인 `100vh`로 높이를 고정하고 있었고, 이 셀렉터의 CSS 명시도가 `ui-responsive.css`의 모바일용 `--app-vh` 기반 오버라이드보다 높아서 항상 우선 적용되고 있었습니다.
- 그 결과 `ViewportHeightSync`가 실시간으로 갱신하는 `--app-vh`(실제 보이는 뷰포트 높이, 키보드/주소창 상태 반영)가 채팅 셸에 전혀 반영되지 않았고, 모바일 브라우저 주소창이 보이는 상태에서는 셸이 실제 보이는 영역보다 크게 렌더링되어 바깥 페이지에 유령 스크롤 여유가 생겼습니다. 이것이 헤더/컴포저가 위아래로 흔들리며 스크롤되는 것처럼 보이는 원인이었습니다.
- `100vh` → `var(--app-vh, 100dvh)`로 단위만 교체했습니다 (셀렉터 명시도/적용 범위는 그대로 유지).

## Root cause verification
- 실제 프로젝트 CSS(`tokens.css`, `layout.css`, `ia-shell.css`, `project-chat.css`, `ui-responsive.css`)를 그대로 로드하는 정적 fixture를 만들어 Playwright(모바일/데스크톱 뷰포트)로 `.shell`의 실제 계산된 높이를 측정했습니다.
- 수정 전: `--app-vh`를 강제로 바꿔도 `.shell`의 렌더링 높이가 전혀 반응하지 않음 (612px로 고정 → 버그 확인).
- 수정 후: `--app-vh` 변경에 맞춰 `.shell` 높이가 정확히 추적됨. 모바일/데스크톱 양쪽에서 회귀 없음을 확인.
- 코드만 읽고 추정하지 않고 실제 런타임 측정으로 원인을 검증했습니다.

## Test plan
- [x] `git diff --check`
- [x] `npx tsc --noEmit`
- [x] Playwright 기반 정적 fixture로 모바일(390x844)/데스크톱(1280x800) 뷰포트에서 `.shell` 높이가 `--app-vh` 변경에 반응하는지 확인 (수정 전/후 비교)
- [x] `tests/mobileOverflowLayout.test.ts`, `tests/mobileScrollAutoHide.test.ts`, `tests/chatMobileScrollOwnership.test.ts` 실행 — `chatMobileScrollOwnership.test.ts`의 3개 실패는 `main`에서도 동일하게 재현되는 기존 이슈로, 이번 변경과 무관함을 `git stash`로 확인 (별도 이슈로 등록 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)