### PR TITLE
fix(web): 모바일 채팅 컴포저 키보드 포커스 시 최상단 점프 버그 수정

### DIFF
--- a/services/aris-web/app/styles/ia-shell.css
+++ b/services/aris-web/app/styles/ia-shell.css
@@ -859,6 +859,32 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
   min-height: 0;
 }
 
+/* Mobile + on-screen keyboard open: fit the whole chat screen to the VISIBLE
+   viewport so the composer pins directly above the keyboard instead of forcing a
+   page scroll. ViewportHeightSync intentionally locks --app-vh to the pre-keyboard
+   height (to avoid reflow on the legacy surface), so the redesigned chat surface
+   must switch to --visual-viewport-height, which does shrink with the keyboard.
+   Without this, the document stays full height while only the reduced area is
+   visible, and the browser scrolls the focused composer up to the top. */
+@media (max-width: 960px) {
+  html[data-keyboard-open='true'] .app-shell-ia--chat-screen,
+  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .aris-ia-shell,
+  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main {
+    height: var(--visual-viewport-height, 100dvh);
+    min-height: var(--visual-viewport-height, 100dvh);
+    overflow: hidden;
+  }
+
+  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main-scroll--project-chat-detail .pc-proto {
+    height: 100%;
+    min-height: calc(var(--visual-viewport-height, 100dvh) - 48px);
+  }
+
+  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main-scroll--project-chat-detail .pc-proto .shell {
+    height: calc(var(--visual-viewport-height, 100dvh) - 48px);
+  }
+}
+
 .app-shell-ia--project-panel .aris-ia-shell {
   grid-template-columns: minmax(0, 1fr);
 }


### PR DESCRIPTION
## 배경
직전 PR #369(모바일 채팅 뷰포트 스크롤 수정)로 스크롤은 정상화됐으나, **컴포저 입력창을 탭해 가상 키보드가 뜨는 순간 컴포저가 화면 최상단까지 튀어 올라가는** 회귀가 확인되었습니다.

## 근본 원인 (런타임 재현으로 검증)
- `ViewportHeightSync`는 키보드가 열리면 `--app-vh`를 **키보드가 열리기 직전 높이로 잠급니다**(레거시 화면 reflow 방지 목적, `ViewportHeightSync.tsx:83`).
- 재디자인된 채팅 화면은 컨테이너 체인(`app-shell-ia--chat-screen` → `aris-ia-shell` → `m-main` → `pc-proto` → `shell`) 전체를 `--app-vh` 기준으로 잡습니다.
- 그래서 키보드가 열려도 문서 높이는 그대로(예: 664px)인데 실제 보이는 영역은 축소(예: 360px)되어, 포커스된 컴포저가 보이는 영역 밖(키보드 뒤)에 위치합니다.
- 브라우저가 포커스된 컴포저를 화면에 넣으려 **페이지 전체를 스크롤**하면서 컴포저/헤더가 위로 튀어 오릅니다.
- 재디자인된 `project-chat` CSS는 `data-keyboard-open` / `--visual-viewport-height`를 **전혀 소비하지 않아** 키보드 인식이 없었습니다.

## 수정
`ia-shell.css`에 **모바일(`max-width: 960px`) + `html[data-keyboard-open='true']`** 상태에서만 적용되는 오버라이드를 추가했습니다. 이 상태에서는 채팅 화면 체인이 `--app-vh` 대신 **`--visual-viewport-height`(키보드에 맞춰 실제로 줄어드는 값)** 를 따릅니다. 결과적으로 화면 전체가 보이는 영역에 딱 맞아:
- 컴포저가 키보드 바로 위에 고정됨
- 타임라인(`.tl`)이 유일한 내부 스크롤러가 됨
- 페이지 스크롤 여지가 사라져 브라우저가 튀어 오를 곳이 없음

`ViewportHeightSync`의 전역 `--app-vh` 잠금(레거시 화면 의존)은 건드리지 않았고, 오버라이드는 모바일 + 키보드 오픈으로 엄격히 스코프되어 키보드 닫힘/데스크톱 레이아웃에는 영향이 없습니다.

## 재현·검증 방법
실제 CSS + `ViewportHeightSync`를 충실히 포팅한 정적 fixture를 390px 폭에서 Playwright로 측정:
- **수정 전**: 키보드 오픈 시 문서 664px vs 보이는 영역 360px → 페이지 스크롤 가능, 컴포저가 보이는 영역 밖
- **수정 후**: 문서가 360px로 축소, `windowScrollY=0`, 컴포저 bottom ≈ 345px(키보드 바로 위 고정), 헤더 top=48 유지, 타임라인 185px로 축소되어 내부 스크롤

## Test plan
- [x] `git diff --check`
- [x] `npx tsc --noEmit`
- [x] Playwright 정적 fixture로 키보드 오픈/닫힘 상태의 문서 높이·스크롤·컴포저 위치 측정 (수정 전/후 비교)
- [x] `tests/mobileOverflowLayout.test.ts`, `tests/mobileScrollAutoHide.test.ts` (18 passed)
- [ ] 실기기(iOS Safari/Chrome) 확인 권장 — 네이티브 키보드 애니메이션은 헤드리스로 완전 재현 불가

🤖 Generated with [Claude Code](https://claude.com/claude-code)