### PR TITLE
fix(import): 서브에이전트 import 숨김 및 네이티브 채팅 중복 방지

### DIFF
--- a/services/aris-backend/package.json
+++ b/services/aris-backend/package.json
@@ -9,6 +9,7 @@
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "reconcile:agent-imports": "tsx scripts/reconcile-agent-session-imports.ts",
     "postinstall": "prisma generate"
   },
   "dependencies": {

--- a/services/aris-backend/prisma/schema.prisma
+++ b/services/aris-backend/prisma/schema.prisma
@@ -32,6 +32,9 @@ model SessionChat {
   isPinned             Boolean
   isDefault            Boolean
   threadId             String?
+  parentChatId         String?
+  subagentType         String?
+  subagentStatus       String?
   model                String?
   geminiMode           String?
   modelReasoningEffort String?
@@ -51,6 +54,7 @@ model SessionChat {
 
   @@index([sessionId, userId, isPinned, lastActivityAt], map: "Chat_projectId_userId_isPinned_lastActivityAt_idx")
   @@index([userId, updatedAt], map: "Chat_userId_updatedAt_idx")
+  @@index([parentChatId], map: "Chat_parentChatId_idx")
   @@map("Chat")
 }
 

--- a/services/aris-backend/scripts/reconcile-agent-session-imports.ts
+++ b/services/aris-backend/scripts/reconcile-agent-session-imports.ts
@@ -1,0 +1,277 @@
+import { readFile } from 'node:fs/promises';
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import {
+  deriveSubagentStatus,
+  isSubagentPath,
+  readSubagentMeta,
+} from '../src/runtime/import/agentSessionImportWorker.js';
+import { parseClaudeSessionLog } from '../src/runtime/import/providerSessionImportParsers.js';
+
+type OwnerChat = {
+  id: string;
+  sessionId: string;
+  isImported: boolean;
+  importedSourcePath?: string | null;
+};
+
+type Action = {
+  kind: 'link-subagent' | 'mark-native-duplicate';
+  importId: string;
+  sourcePath: string;
+  chatId?: string | null;
+  targetChatId?: string | null;
+  reason: string;
+};
+
+const apply = process.argv.includes('--apply');
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL is required');
+}
+
+const adapter = new PrismaPg({ connectionString: databaseUrl });
+const db = new PrismaClient({ adapter });
+
+async function assertSchemaReady(): Promise<void> {
+  const rows = await db.$queryRaw<Array<{ column_name: string }>>`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'Chat'
+      AND column_name IN ('parentChatId', 'subagentType', 'subagentStatus')
+  `;
+  const found = new Set(rows.map((row) => row.column_name));
+  const missing = ['parentChatId', 'subagentType', 'subagentStatus'].filter((name) => !found.has(name));
+  if (missing.length > 0) {
+    throw new Error(`Chat subagent migration is not applied. Missing columns: ${missing.join(', ')}`);
+  }
+}
+
+function fallbackSessionId(sourcePath: string): string {
+  return sourcePath.replace(/\.jsonl$/, '').split('/').at(-1) ?? sourcePath;
+}
+
+async function readClaudeProviderSessionId(sourcePath: string): Promise<string | null> {
+  try {
+    const contents = await readFile(sourcePath, 'utf8');
+    return parseClaudeSessionLog(contents, {
+      sourcePath,
+      fallbackSessionId: fallbackSessionId(sourcePath),
+    }).providerSessionId;
+  } catch {
+    return null;
+  }
+}
+
+async function ownerFromChat(chatId: string): Promise<OwnerChat | null> {
+  const chat = await db.sessionChat.findFirst({
+    where: { id: chatId, parentChatId: null },
+    select: { id: true, sessionId: true },
+  });
+  if (!chat) {
+    return null;
+  }
+  const imported = await db.importedAgentSession.findFirst({
+    where: { chatId: chat.id },
+    select: { sourcePath: true },
+  });
+  return {
+    id: chat.id,
+    sessionId: chat.sessionId,
+    isImported: Boolean(imported),
+    importedSourcePath: imported?.sourcePath ?? null,
+  };
+}
+
+async function findOwnerChat(providerSessionId: string, options: {
+  excludeChatId?: string | null;
+  preferNative?: boolean;
+} = {}): Promise<OwnerChat | null> {
+  const trimmed = providerSessionId.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const ids = new Set<string>();
+  const byThread = await db.sessionChat.findMany({
+    where: {
+      threadId: trimmed,
+      parentChatId: null,
+      ...(options.excludeChatId ? { id: { not: options.excludeChatId } } : {}),
+    },
+    orderBy: { lastActivityAt: 'desc' },
+    select: { id: true },
+  });
+  for (const row of byThread) {
+    ids.add(row.id);
+  }
+
+  const byEvent = await db.sessionChatEvent.findMany({
+    where: { meta: { path: ['threadId'], equals: trimmed } },
+    orderBy: { createdAt: 'desc' },
+    select: { chatId: true },
+    take: 50,
+  });
+  for (const row of byEvent) {
+    if (row.chatId !== options.excludeChatId) {
+      ids.add(row.chatId);
+    }
+  }
+
+  const owners: OwnerChat[] = [];
+  for (const id of ids) {
+    const owner = await ownerFromChat(id);
+    if (owner && !isSubagentPath(owner.importedSourcePath ?? '')) {
+      owners.push(owner);
+    }
+  }
+
+  if (options.preferNative) {
+    return owners.find((owner) => !owner.isImported) ?? null;
+  }
+  return owners.find((owner) => !owner.isImported) ?? owners[0] ?? null;
+}
+
+async function reconcileSubagents(actions: Action[]): Promise<void> {
+  const rows = await db.importedAgentSession.findMany({
+    where: {
+      provider: 'claude',
+      sourcePath: { contains: '/subagents/' },
+      chatId: { not: null },
+    },
+    orderBy: { updatedAt: 'desc' },
+  });
+  const parentReadCache = new Map<string, string>();
+
+  for (const row of rows) {
+    const providerSessionId = await readClaudeProviderSessionId(row.sourcePath);
+    if (!providerSessionId) {
+      actions.push({
+        kind: 'link-subagent',
+        importId: row.id,
+        sourcePath: row.sourcePath,
+        chatId: row.chatId,
+        reason: 'skip: cannot read provider session id',
+      });
+      continue;
+    }
+    const owner = await findOwnerChat(providerSessionId, { excludeChatId: row.chatId });
+    if (!owner) {
+      actions.push({
+        kind: 'link-subagent',
+        importId: row.id,
+        sourcePath: row.sourcePath,
+        chatId: row.chatId,
+        reason: 'skip: parent chat not found',
+      });
+      continue;
+    }
+    const meta = await readSubagentMeta(row.sourcePath);
+    const status = await deriveSubagentStatus(row.sourcePath, meta.toolUseId, parentReadCache);
+    actions.push({
+      kind: 'link-subagent',
+      importId: row.id,
+      sourcePath: row.sourcePath,
+      chatId: row.chatId,
+      targetChatId: owner.id,
+      reason: `link to parent chat, status=${status}`,
+    });
+    if (apply) {
+      await db.sessionChat.update({
+        where: { id: row.chatId ?? '' },
+        data: {
+          parentChatId: owner.id,
+          subagentType: meta.agentType ?? null,
+          subagentStatus: status,
+          ...(meta.description ? { title: meta.description.trim().slice(0, 120) } : {}),
+        },
+      });
+      await db.importedAgentSession.update({
+        where: { id: row.id },
+        data: {
+          arisSessionId: owner.sessionId,
+          status: 'linked',
+          lastImportedAt: new Date(),
+        },
+      });
+    }
+  }
+}
+
+async function reconcileNativeDuplicates(actions: Action[]): Promise<void> {
+  const rows = await db.importedAgentSession.findMany({
+    where: {
+      sourcePath: { not: { contains: '/subagents/' } },
+      status: { not: 'native' },
+      chatId: { not: null },
+    },
+    orderBy: { updatedAt: 'desc' },
+  });
+
+  for (const row of rows) {
+    const owner = await findOwnerChat(row.providerSessionId, {
+      excludeChatId: row.chatId,
+      preferNative: true,
+    });
+    if (!owner || owner.isImported) {
+      continue;
+    }
+    actions.push({
+      kind: 'mark-native-duplicate',
+      importId: row.id,
+      sourcePath: row.sourcePath,
+      chatId: row.chatId,
+      targetChatId: owner.id,
+      reason: 'provider session already belongs to a native ARIS chat',
+    });
+    if (apply) {
+      await db.importedAgentSession.update({
+        where: { id: row.id },
+        data: {
+          arisSessionId: owner.sessionId,
+          chatId: owner.id,
+          status: 'native',
+          lastImportedAt: new Date(),
+        },
+      });
+      if (row.chatId && row.chatId !== owner.id) {
+        await db.sessionChat.update({
+          where: { id: row.chatId },
+          data: { subagentStatus: 'native_duplicate' },
+        });
+      }
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  await assertSchemaReady();
+  const actions: Action[] = [];
+  await reconcileSubagents(actions);
+  await reconcileNativeDuplicates(actions);
+
+  const summary = actions.reduce<Record<string, number>>((acc, action) => {
+    acc[action.kind] = (acc[action.kind] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  console.log(JSON.stringify({
+    mode: apply ? 'apply' : 'dry-run',
+    summary,
+    actions,
+  }, null, 2));
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(JSON.stringify({
+    mode: apply ? 'apply' : 'dry-run',
+    error: error instanceof Error ? error.message : String(error),
+  }, null, 2));
+  process.exitCode = 1;
+} finally {
+  await db.$disconnect();
+}

--- a/services/aris-backend/src/index.ts
+++ b/services/aris-backend/src/index.ts
@@ -25,7 +25,10 @@ async function bootstrap() {
       cleanupEmptyChats: (maxAgeMs: number) => Promise<number>;
       discoverImportedAgentSession: Parameters<typeof runAgentSessionImportOnce>[0]['store']['discoverImportedAgentSession'];
       resolveProjectSessionIdByPath: Parameters<typeof runAgentSessionImportOnce>[0]['store']['resolveProjectSessionIdByPath'];
+      findOwningChat: Parameters<typeof runAgentSessionImportOnce>[0]['store']['findOwningChat'];
       ensureImportedAgentChat: Parameters<typeof runAgentSessionImportOnce>[0]['store']['ensureImportedAgentChat'];
+      markImportedAgentSessionNative: Parameters<typeof runAgentSessionImportOnce>[0]['store']['markImportedAgentSessionNative'];
+      updateSubagentChatMeta: Parameters<typeof runAgentSessionImportOnce>[0]['store']['updateSubagentChatMeta'];
       appendImportedAgentEvents: Parameters<typeof runAgentSessionImportOnce>[0]['store']['appendImportedAgentEvents'];
       listImportedAgentSessionsForBackfill: Parameters<typeof runAgentSessionImportOnce>[0]['store']['listImportedAgentSessionsForBackfill'];
       loadOlderImportedAgentEvents: Parameters<typeof runAgentSessionImportOnce>[0]['store']['loadOlderImportedAgentEvents'];

--- a/services/aris-backend/src/runtime/import/agentSessionImportWorker.ts
+++ b/services/aris-backend/src/runtime/import/agentSessionImportWorker.ts
@@ -36,14 +36,44 @@ type ImportedAgentSessionStore = {
     oldestCursorOffset?: bigint | null;
     newestCursorOffset?: bigint | null;
     hasMoreBefore: boolean;
+    status?: string;
   }>;
   resolveProjectSessionIdByPath(projectPath: string): Promise<string | null>;
+  /**
+   * Find an existing top-level chat (parentChatId IS NULL, i.e. not a subagent)
+   * that already owns a provider session id — matched by Chat.threadId or by any
+   * of its events' meta.threadId. Used to (a) detect ARIS-originated transcripts
+   * that must not be re-imported as duplicate chats, and (b) resolve the parent
+   * chat a subagent belongs to. `isImported` is true when that chat is itself an
+   * imported agent session (vs a native ARIS chat).
+   */
+  findOwningChat?(providerSessionId: string): Promise<{ chatId: string; isImported: boolean } | null>;
   ensureImportedAgentChat(input: {
     importId: string;
     arisSessionId: string;
     userId: string;
     title: string;
+    parentChatId?: string | null;
+    subagentType?: string | null;
+    subagentStatus?: string | null;
   }): Promise<{ chatId: string }>;
+  /**
+   * Mark an imported session as ARIS-native: link it to the existing native chat
+   * without creating a duplicate chat and without importing its events (the live
+   * ARIS runtime already owns them). Idempotent.
+   */
+  markImportedAgentSessionNative?(input: {
+    importId: string;
+    arisSessionId: string;
+    chatId: string;
+  }): Promise<void>;
+  /** Refresh subagent metadata (type/status) on an already-linked subagent chat. */
+  updateSubagentChatMeta?(input: {
+    chatId: string;
+    parentChatId?: string | null;
+    subagentType?: string | null;
+    subagentStatus?: string | null;
+  }): Promise<void>;
   appendImportedAgentEvents(input: {
     importId: string;
     provider: ImportedAgentProvider;
@@ -99,7 +129,82 @@ type CandidateFile = {
   size: bigint;
   mtimeMs: bigint;
   fallbackSessionId?: string;
+  isSubagent?: boolean;
+  subagentType?: string;
+  subagentDescription?: string;
+  subagentToolUseId?: string;
 };
+
+/** A Claude Code subagent transcript lives under `<parentSessionId>/subagents/`. */
+export function isSubagentPath(path: string): boolean {
+  return path.includes('/subagents/');
+}
+
+/**
+ * Sidecar metadata Claude Code writes next to each subagent transcript:
+ * `agent-<id>.jsonl` -> `agent-<id>.meta.json` with { agentType, description, toolUseId }.
+ */
+export async function readSubagentMeta(subagentPath: string): Promise<{
+  agentType?: string;
+  description?: string;
+  toolUseId?: string;
+}> {
+  const metaPath = subagentPath.replace(/\.jsonl$/, '.meta.json');
+  try {
+    const raw = await readFile(metaPath, 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      ...(typeof parsed.agentType === 'string' ? { agentType: parsed.agentType } : {}),
+      ...(typeof parsed.description === 'string' ? { description: parsed.description } : {}),
+      ...(typeof parsed.toolUseId === 'string' ? { toolUseId: parsed.toolUseId } : {}),
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Resolve the parent session transcript for a subagent file.
+ * `.../projects/<projectId>/<parentSessionId>/subagents/agent-x.jsonl`
+ *   -> `.../projects/<projectId>/<parentSessionId>.jsonl`
+ */
+export function subagentParentTranscriptPath(subagentPath: string): string {
+  const subagentsDir = resolve(subagentPath, '..');
+  const parentSessionDir = resolve(subagentsDir, '..');
+  return `${parentSessionDir}.jsonl`;
+}
+
+/**
+ * Best-effort subagent run status. A completed subagent has a `tool_result` for
+ * its Task `toolUseId` in the parent transcript; a still-running one has only the
+ * `tool_use`. Falls back to 'completed' when we cannot prove it is running
+ * (missing toolUseId / unreadable parent) to avoid stale "running" badges.
+ */
+export async function deriveSubagentStatus(
+  subagentPath: string,
+  toolUseId: string | undefined,
+  parentReadCache: Map<string, string>,
+): Promise<'running' | 'completed'> {
+  if (!toolUseId) {
+    return 'completed';
+  }
+  const parentPath = subagentParentTranscriptPath(subagentPath);
+  let contents = parentReadCache.get(parentPath);
+  if (contents === undefined) {
+    try {
+      contents = await readFile(parentPath, 'utf8');
+    } catch {
+      contents = '';
+    }
+    parentReadCache.set(parentPath, contents);
+  }
+  if (!contents) {
+    return 'completed';
+  }
+  const hasResult = contents.includes(`"tool_use_id":"${toolUseId}"`)
+    || contents.includes(`"tool_use_id": "${toolUseId}"`);
+  return hasResult ? 'completed' : 'running';
+}
 
 async function listJsonlFiles(root: string): Promise<string[]> {
   let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
@@ -148,12 +253,18 @@ async function collectCandidates(options: AgentSessionImportRunOptions): Promise
     if (details.mtimeMs < cutoffMs || details.size > options.maxBytes) {
       continue;
     }
+    const subagent = item.provider === 'claude' && isSubagentPath(item.path);
+    const meta = subagent ? await readSubagentMeta(item.path) : {};
     candidates.push({
       provider: item.provider,
       path: item.path,
       size: BigInt(details.size),
       mtimeMs: BigInt(Math.floor(details.mtimeMs)),
       ...(item.provider === 'claude' ? { fallbackSessionId: item.path.replace(/\.jsonl$/, '').split('/').at(-1) } : {}),
+      ...(subagent ? { isSubagent: true } : {}),
+      ...(meta.agentType ? { subagentType: meta.agentType } : {}),
+      ...(meta.description ? { subagentDescription: meta.description } : {}),
+      ...(meta.toolUseId ? { subagentToolUseId: meta.toolUseId } : {}),
     });
   }
   return candidates
@@ -277,6 +388,9 @@ export async function runAgentSessionImportOnce(options: AgentSessionImportRunOp
   let remainingEvents = maxEvents;
   const candidates = await collectCandidates(options);
   const normalizedProjectPath = resolve(options.projectPath);
+  // Cache parent-transcript reads within a single run so N subagents sharing a
+  // parent trigger at most one read of that (potentially large) transcript.
+  const parentReadCache = new Map<string, string>();
   for (const candidate of candidates) {
     if (remainingEvents <= 0) {
       break;
@@ -308,21 +422,77 @@ export async function runAgentSessionImportOnce(options: AgentSessionImportRunOp
     if (!options.userId) {
       continue;
     }
+    // Already resolved as an ARIS-native transcript on a previous run: the live
+    // runtime owns these events, so importing them again would duplicate messages
+    // inside the native chat. Nothing to do.
+    if (imported.status === 'native') {
+      continue;
+    }
     const arisSessionId = await options.store.resolveProjectSessionIdByPath(normalizedProjectPath);
     if (!arisSessionId) {
       result.skipped += 1;
       continue;
     }
-    const { chatId } = imported.chatId
-      ? { chatId: imported.chatId }
-      : await options.store.ensureImportedAgentChat({
+    const isSubagent = candidate.isSubagent === true || parsed.isSubagent;
+
+    // Problem 2: a freshly-discovered top-level transcript whose provider session
+    // id already belongs to a native ARIS chat is an ARIS-originated session that
+    // came back through the file scan. Link the bookkeeping row to that chat and
+    // skip — never create a duplicate chat, never re-import its events.
+    if (!isSubagent && !imported.chatId && options.store.findOwningChat && options.store.markImportedAgentSessionNative) {
+      const owning = await options.store.findOwningChat(parsed.providerSessionId);
+      if (owning && !owning.isImported) {
+        await options.store.markImportedAgentSessionNative({
+          importId: imported.id,
+          arisSessionId,
+          chatId: owning.chatId,
+        });
+        result.skipped += 1;
+        continue;
+      }
+    }
+
+    // Problem 1: subagent (Task tool) transcripts are still imported, but into a
+    // hidden chat linked to their parent chat so they surface only in the subagent
+    // sidebar — never in the main chat list.
+    let subagentStatus: 'running' | 'completed' | null = null;
+    let parentChatId: string | null = null;
+    if (isSubagent) {
+      subagentStatus = await deriveSubagentStatus(candidate.path, candidate.subagentToolUseId, parentReadCache);
+      // parsed.providerSessionId for a subagent is the PARENT session id, so this
+      // resolves the chat the subagent belongs to (native or imported parent).
+      parentChatId = options.store.findOwningChat
+        ? (await options.store.findOwningChat(parsed.providerSessionId))?.chatId ?? null
+        : null;
+    }
+
+    const title = isSubagent && candidate.subagentDescription
+      ? normalizeImportedChatTitle(candidate.subagentDescription)
+      : buildImportedChatTitle(parsed.provider, parsed.messages);
+
+    const chatId = imported.chatId
+      ? imported.chatId
+      : (await options.store.ensureImportedAgentChat({
           importId: imported.id,
           arisSessionId,
           userId: options.userId,
-          title: buildImportedChatTitle(parsed.provider, parsed.messages),
-        });
+          title,
+          ...(isSubagent
+            ? { parentChatId, subagentType: candidate.subagentType ?? null, subagentStatus }
+            : {}),
+        })).chatId;
     if (!imported.chatId) {
       result.linkedChats += 1;
+    } else if (isSubagent && options.store.updateSubagentChatMeta) {
+      // Refresh status/parent linkage on an already-linked subagent chat (the
+      // parent chat may have been imported after the subagent; status may flip
+      // from running to completed).
+      await options.store.updateSubagentChatMeta({
+        chatId,
+        parentChatId,
+        subagentType: candidate.subagentType ?? null,
+        subagentStatus,
+      });
     }
     const selectedMessages = imported.chatId
       ? selectNewerMessages(parsed.messages, imported.newestCursorOffset, remainingEvents)

--- a/services/aris-backend/src/runtime/import/providerSessionImportParsers.ts
+++ b/services/aris-backend/src/runtime/import/providerSessionImportParsers.ts
@@ -17,6 +17,13 @@ export type ParsedProviderSessionLog = {
   oldestCursorOffset: bigint | null;
   newestCursorOffset: bigint | null;
   hasMoreBefore: boolean;
+  /**
+   * True when the transcript is a Claude Code subagent (Task tool) sidechain —
+   * every message-bearing record carried `isSidechain: true`. Subagent
+   * transcripts must not appear in the main chat list; they are surfaced only
+   * in the subagent sidebar. Always false for Codex (no sidechain concept).
+   */
+  isSubagent: boolean;
 };
 
 type ParseOptions = {
@@ -102,6 +109,7 @@ function finalizeParsedLog(input: {
   sourcePath: string;
   projectPath?: string;
   messages: ImportedProviderMessage[];
+  isSubagent?: boolean;
 }): ParsedProviderSessionLog {
   const providerSessionId = input.providerSessionId ?? input.sourcePath;
   const offsets = input.messages.map((message) => message.sourceOffset);
@@ -120,6 +128,7 @@ function finalizeParsedLog(input: {
     oldestCursorOffset,
     newestCursorOffset,
     hasMoreBefore: oldestCursorOffset !== null && oldestCursorOffset > 0n,
+    isSubagent: input.isSubagent ?? false,
   };
 }
 
@@ -175,6 +184,12 @@ export function parseClaudeSessionLog(contents: string, options: ParseOptions): 
   let providerSessionId = options.fallbackSessionId;
   let projectPath: string | undefined;
   const messages: ImportedProviderMessage[] = [];
+  // Track sidechain vs non-sidechain among message-bearing records so we can
+  // classify the whole transcript. A Claude Code subagent (Task tool) transcript
+  // is written to a separate `subagents/agent-*.jsonl` file where every record
+  // has `isSidechain: true`; a normal top-level session has none.
+  let sidechainMessages = 0;
+  let mainlineMessages = 0;
 
   for (const { line, offset } of splitJsonlWithOffsets(contents)) {
     const record = parseJsonLine(line);
@@ -199,6 +214,11 @@ export function parseClaudeSessionLog(contents: string, options: ParseOptions): 
     if (!text) {
       continue;
     }
+    if (record.isSidechain === true) {
+      sidechainMessages += 1;
+    } else {
+      mainlineMessages += 1;
+    }
     const sessionId = providerSessionId ?? options.sourcePath;
     messages.push({
       role,
@@ -215,6 +235,10 @@ export function parseClaudeSessionLog(contents: string, options: ParseOptions): 
     sourcePath: options.sourcePath,
     projectPath,
     messages,
+    // Pure-sidechain transcript => subagent. Mixed/none => treat as a normal
+    // session (the import worker also detects subagents by the `/subagents/`
+    // path segment, which is authoritative for the separate-file layout).
+    isSubagent: sidechainMessages > 0 && mainlineMessages === 0,
   });
 }
 

--- a/services/aris-backend/src/runtime/prismaStore.ts
+++ b/services/aris-backend/src/runtime/prismaStore.ts
@@ -51,6 +51,7 @@ type ImportedAgentSessionRecord = {
   oldestCursorOffset?: bigint | null;
   newestCursorOffset?: bigint | null;
   hasMoreBefore: boolean;
+  status?: string;
 };
 
 type DiscoverImportedAgentSessionInput = {
@@ -71,6 +72,9 @@ type EnsureImportedAgentChatInput = {
   userId: string;
   title: string;
   model?: string | null;
+  parentChatId?: string | null;
+  subagentType?: string | null;
+  subagentStatus?: string | null;
 };
 
 type AppendImportedAgentEventsInput = {
@@ -395,6 +399,77 @@ export class PrismaRuntimeStore {
     return fallback?.id ?? null;
   }
 
+  async findOwningChat(providerSessionId: string): Promise<{ chatId: string; isImported: boolean } | null> {
+    const trimmed = providerSessionId.trim();
+    if (!trimmed) {
+      return null;
+    }
+    // Fast path: a top-level chat whose threadId already points at this provider
+    // session (native chats — post-redesign — now persist threadId again; imported
+    // chats always do).
+    const byThread = await this.db.sessionChat.findFirst({
+      where: { threadId: trimmed, parentChatId: null },
+      orderBy: { lastActivityAt: 'desc' },
+      select: { id: true },
+    });
+    let chatId = byThread?.id ?? null;
+    if (!chatId) {
+      // Slow path: a single ARIS chat can rotate through several provider session
+      // ids across resume/continue, and older native chats never persisted
+      // threadId on the row — but the id is still recorded in each event's meta.
+      const event = await this.db.sessionChatEvent.findFirst({
+        where: { meta: { path: ['threadId'], equals: trimmed } },
+        orderBy: { createdAt: 'desc' },
+        select: { chatId: true },
+      });
+      if (event?.chatId) {
+        const chat = await this.db.sessionChat.findFirst({
+          where: { id: event.chatId, parentChatId: null },
+          select: { id: true },
+        });
+        chatId = chat?.id ?? null;
+      }
+    }
+    if (!chatId) {
+      return null;
+    }
+    const importedRow = await this.db.importedAgentSession.findFirst({
+      where: { chatId },
+      select: { id: true },
+    });
+    return { chatId, isImported: Boolean(importedRow) };
+  }
+
+  async markImportedAgentSessionNative(input: { importId: string; arisSessionId: string; chatId: string }): Promise<void> {
+    await this.db.importedAgentSession.update({
+      where: { id: input.importId },
+      data: {
+        arisSessionId: input.arisSessionId,
+        chatId: input.chatId,
+        status: 'native',
+        lastImportedAt: new Date(),
+      },
+    });
+  }
+
+  async updateSubagentChatMeta(input: {
+    chatId: string;
+    parentChatId?: string | null;
+    subagentType?: string | null;
+    subagentStatus?: string | null;
+  }): Promise<void> {
+    // Only ever set fields to non-null values so a transiently-unresolved parent
+    // (parent session imported after the subagent) never clears a good linkage.
+    await this.db.sessionChat.update({
+      where: { id: input.chatId },
+      data: {
+        ...(input.parentChatId ? { parentChatId: input.parentChatId } : {}),
+        ...(input.subagentType ? { subagentType: input.subagentType } : {}),
+        ...(input.subagentStatus ? { subagentStatus: input.subagentStatus } : {}),
+      },
+    });
+  }
+
   async ensureImportedAgentChat(input: EnsureImportedAgentChatInput): Promise<{ chatId: string }> {
     return this.runRuntimeWriteMutationWithRetry(async (tx) => {
       const imported = await tx.importedAgentSession.findUnique({
@@ -418,6 +493,9 @@ export class PrismaRuntimeStore {
           isPinned: false,
           isDefault: false,
           threadId: imported.providerSessionId,
+          parentChatId: input.parentChatId ?? null,
+          subagentType: input.subagentType ?? null,
+          subagentStatus: input.subagentStatus ?? null,
           model: input.model ?? null,
           latestPreview: '',
           latestEventIsUser: false,
@@ -958,10 +1036,20 @@ export class PrismaRuntimeStore {
           seq: nextSeq,
         },
       });
+      // Persist the provider session id onto the chat row. This linkage was
+      // dropped during the chat-surface redesign (the new ProjectChatSurface no
+      // longer PATCHes threadId), leaving native chats with threadId = null and
+      // letting the import worker re-create them as duplicate chats. Restoring it
+      // server-side covers every surface. A chat can rotate through several
+      // provider session ids (resume/continue), so we keep the latest.
+      const nextThreadId = typeof input.meta?.threadId === 'string' && input.meta.threadId.trim().length > 0
+        ? input.meta.threadId.trim()
+        : null;
       await tx.sessionChat.update({
         where: { id: chatId },
         data: {
           ...(lifecycleStatus === null && { latestPreview: input.text.slice(0, 280) }),
+          ...(nextThreadId ? { threadId: nextThreadId } : {}),
           latestEventId: created.id,
           latestEventAt: created.createdAt,
           latestEventIsUser: input.meta?.role === 'user',

--- a/services/aris-backend/src/store.ts
+++ b/services/aris-backend/src/store.ts
@@ -175,14 +175,30 @@ interface RuntimeStoreBackend {
     oldestCursorOffset?: bigint | null;
     newestCursorOffset?: bigint | null;
     hasMoreBefore: boolean;
+    status?: string;
   }>;
   resolveProjectSessionIdByPath?(projectPath: string): Promise<string | null>;
+  findOwningChat?(providerSessionId: string): Promise<{ chatId: string; isImported: boolean } | null>;
   ensureImportedAgentChat?(input: {
     importId: string;
     arisSessionId: string;
     userId: string;
     title: string;
+    parentChatId?: string | null;
+    subagentType?: string | null;
+    subagentStatus?: string | null;
   }): Promise<{ chatId: string }>;
+  markImportedAgentSessionNative?(input: {
+    importId: string;
+    arisSessionId: string;
+    chatId: string;
+  }): Promise<void>;
+  updateSubagentChatMeta?(input: {
+    chatId: string;
+    parentChatId?: string | null;
+    subagentType?: string | null;
+    subagentStatus?: string | null;
+  }): Promise<void>;
   appendImportedAgentEvents?(input: {
     importId: string;
     provider: ImportedAgentProvider;
@@ -754,9 +770,30 @@ export class RuntimeStore {
     throw new Error('IMPORTED_AGENT_SESSION_NOT_SUPPORTED');
   }
 
+  async findOwningChat(providerSessionId: string) {
+    if (typeof this.delegate.findOwningChat === 'function') {
+      return this.delegate.findOwningChat(providerSessionId);
+    }
+    return null;
+  }
+
   async ensureImportedAgentChat(input: Parameters<NonNullable<RuntimeStoreBackend['ensureImportedAgentChat']>>[0]) {
     if (typeof this.delegate.ensureImportedAgentChat === 'function') {
       return this.delegate.ensureImportedAgentChat(input);
+    }
+    throw new Error('IMPORTED_AGENT_SESSION_NOT_SUPPORTED');
+  }
+
+  async markImportedAgentSessionNative(input: Parameters<NonNullable<RuntimeStoreBackend['markImportedAgentSessionNative']>>[0]) {
+    if (typeof this.delegate.markImportedAgentSessionNative === 'function') {
+      return this.delegate.markImportedAgentSessionNative(input);
+    }
+    throw new Error('IMPORTED_AGENT_SESSION_NOT_SUPPORTED');
+  }
+
+  async updateSubagentChatMeta(input: Parameters<NonNullable<RuntimeStoreBackend['updateSubagentChatMeta']>>[0]) {
+    if (typeof this.delegate.updateSubagentChatMeta === 'function') {
+      return this.delegate.updateSubagentChatMeta(input);
     }
     throw new Error('IMPORTED_AGENT_SESSION_NOT_SUPPORTED');
   }

--- a/services/aris-backend/tests/agentSessionImportWorker.test.ts
+++ b/services/aris-backend/tests/agentSessionImportWorker.test.ts
@@ -166,6 +166,101 @@ describe('agent session import worker', () => {
     }));
   });
 
+  it('imports subagent transcripts into a hidden chat linked to the parent (not the chat list)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'aris-import-worker-'));
+    const projectDir = join(root, '.claude/projects/-home-ubuntu-project-ARIS');
+    const parentId = '22222222-2222-2222-2222-222222222222';
+    const subagentsDir = join(projectDir, parentId, 'subagents');
+    await mkdir(subagentsDir, { recursive: true });
+    // Subagent transcript: every record isSidechain, sessionId is the PARENT id.
+    await writeFile(join(subagentsDir, 'agent-explore1.jsonl'), [
+      '{"type":"user","isSidechain":true,"message":{"role":"user","content":"작업 지시"},"uuid":"su1","timestamp":"2026-07-07T00:00:01.000Z","cwd":"/home/ubuntu/project/ARIS","sessionId":"22222222-2222-2222-2222-222222222222"}',
+      '{"type":"assistant","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"작업 결과"}]},"uuid":"sa1","timestamp":"2026-07-07T00:00:02.000Z","cwd":"/home/ubuntu/project/ARIS","sessionId":"22222222-2222-2222-2222-222222222222"}',
+    ].join('\n'));
+    await writeFile(join(subagentsDir, 'agent-explore1.meta.json'), JSON.stringify({
+      agentType: 'Explore', description: '코드베이스 매핑', toolUseId: 'toolu_test123',
+    }));
+    // Parent transcript has the Task tool_use but NO tool_result => still running.
+    // No cwd => skipped as an import candidate, but still read for status.
+    await writeFile(join(projectDir, `${parentId}.jsonl`),
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_test123","name":"Task","input":{}}]},"uuid":"p1","timestamp":"2026-07-07T00:00:00.000Z"}');
+
+    const store = {
+      discoverImportedAgentSession: vi.fn().mockResolvedValue({ id: 'import-sub', chatId: null }),
+      resolveProjectSessionIdByPath: vi.fn().mockResolvedValue('project-session-1'),
+      findOwningChat: vi.fn().mockResolvedValue({ chatId: 'parent-chat-1', isImported: true }),
+      ensureImportedAgentChat: vi.fn().mockResolvedValue({ chatId: 'subagent-chat-1' }),
+      markImportedAgentSessionNative: vi.fn(),
+      updateSubagentChatMeta: vi.fn(),
+      appendImportedAgentEvents: vi.fn().mockResolvedValue([{ id: 'sev-1' }, { id: 'sev-2' }]),
+    };
+
+    const result = await runAgentSessionImportOnce({
+      store,
+      projectPath: '/home/ubuntu/project/ARIS',
+      userId: 'user-1',
+      codexHome: join(root, '.codex'),
+      claudeHome: join(root, '.claude'),
+      lookbackDays: 7,
+      maxFiles: 10,
+      maxBytes: 200_000,
+      tailTurns: 3,
+    });
+
+    expect(result.discovered).toBe(1);
+    expect(store.markImportedAgentSessionNative).not.toHaveBeenCalled();
+    expect(store.findOwningChat).toHaveBeenCalledWith('22222222-2222-2222-2222-222222222222');
+    expect(store.ensureImportedAgentChat).toHaveBeenCalledWith(expect.objectContaining({
+      parentChatId: 'parent-chat-1',
+      subagentType: 'Explore',
+      subagentStatus: 'running',
+      title: '코드베이스 매핑',
+    }));
+    expect(store.appendImportedAgentEvents).toHaveBeenCalledWith(expect.objectContaining({
+      chatId: 'subagent-chat-1',
+    }));
+  });
+
+  it('links ARIS-originated transcripts to the native chat instead of creating a duplicate', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'aris-import-worker-'));
+    const sessionDir = join(root, '.claude/projects/-home-ubuntu-project-ARIS');
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, '33333333-3333-3333-3333-333333333333.jsonl'), [
+      '{"type":"user","message":{"role":"user","content":"네이티브 요청"},"uuid":"nu1","timestamp":"2026-07-07T00:00:01.000Z","cwd":"/home/ubuntu/project/ARIS","sessionId":"33333333-3333-3333-3333-333333333333"}',
+      '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"네이티브 답변"}]},"uuid":"na1","timestamp":"2026-07-07T00:00:02.000Z","cwd":"/home/ubuntu/project/ARIS","sessionId":"33333333-3333-3333-3333-333333333333"}',
+    ].join('\n'));
+    const store = {
+      discoverImportedAgentSession: vi.fn().mockResolvedValue({ id: 'import-native', chatId: null }),
+      resolveProjectSessionIdByPath: vi.fn().mockResolvedValue('project-session-1'),
+      findOwningChat: vi.fn().mockResolvedValue({ chatId: 'native-chat-1', isImported: false }),
+      ensureImportedAgentChat: vi.fn(),
+      markImportedAgentSessionNative: vi.fn(),
+      updateSubagentChatMeta: vi.fn(),
+      appendImportedAgentEvents: vi.fn(),
+    };
+
+    const result = await runAgentSessionImportOnce({
+      store,
+      projectPath: '/home/ubuntu/project/ARIS',
+      userId: 'user-1',
+      codexHome: join(root, '.codex'),
+      claudeHome: join(root, '.claude'),
+      lookbackDays: 7,
+      maxFiles: 10,
+      maxBytes: 200_000,
+      tailTurns: 3,
+    });
+
+    expect(store.markImportedAgentSessionNative).toHaveBeenCalledWith({
+      importId: 'import-native',
+      arisSessionId: 'project-session-1',
+      chatId: 'native-chat-1',
+    });
+    expect(store.ensureImportedAgentChat).not.toHaveBeenCalled();
+    expect(store.appendImportedAgentEvents).not.toHaveBeenCalled();
+    expect(result.importedEvents).toBe(0);
+  });
+
   it('runs bounded backfill batches for imported chats with older transcript', async () => {
     const store = {
       discoverImportedAgentSession: vi.fn(),

--- a/services/aris-web/app/api/runtime/sessions/[sessionId]/chats/[chatId]/subagents/route.ts
+++ b/services/aris-web/app/api/runtime/sessions/[sessionId]/chats/[chatId]/subagents/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireApiUser } from '@/lib/auth/guard';
+import { listSubagentChats } from '@/lib/happy/chats';
+
+/**
+ * List the imported subagent (Task tool) transcripts that belong to a chat.
+ * These are hidden from the main chat list and surfaced only here, in the
+ * right-sidebar subagent panel.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string; chatId: string }> },
+) {
+  const auth = await requireApiUser(request);
+  if ('response' in auth) {
+    return auth.response;
+  }
+
+  try {
+    const { chatId } = await params;
+    const subagents = await listSubagentChats({
+      parentChatId: chatId,
+      userId: auth.user.id,
+    });
+    return NextResponse.json({ subagents });
+  } catch {
+    return NextResponse.json({ error: '서브에이전트 목록을 불러오지 못했습니다.' }, { status: 500 });
+  }
+}

--- a/services/aris-web/app/api/runtime/sessions/route.ts
+++ b/services/aris-web/app/api/runtime/sessions/route.ts
@@ -33,10 +33,10 @@ export async function GET(request: NextRequest) {
 
     // running 채팅 집계
     const runningCount = await prisma.chat.count({
-      where: { projectId: { in: runningSessionIds }, latestEventIsUser: false, latestEventId: { not: null }, userId },
+      where: { projectId: { in: runningSessionIds }, latestEventIsUser: false, latestEventId: { not: null }, userId, parentChatId: null, subagentStatus: null },
     });
     const runningSampleRows = await prisma.chat.findMany({
-      where: { projectId: { in: runningSessionIds }, latestEventIsUser: false, latestEventId: { not: null }, userId },
+      where: { projectId: { in: runningSessionIds }, latestEventIsUser: false, latestEventId: { not: null }, userId, parentChatId: null, subagentStatus: null },
       orderBy: { lastActivityAt: 'desc' },
       take: 3,
       select: { id: true, title: true, projectId: true, agent: true },
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest) {
 
     // completed 채팅 집계
     const completedNullCount = await prisma.chat.count({
-      where: { latestEventIsUser: false, latestEventId: { not: null }, userId, projectId: { notIn: runningSessionIds }, lastReadAt: null },
+      where: { latestEventIsUser: false, latestEventId: { not: null }, userId, projectId: { notIn: runningSessionIds }, lastReadAt: null, parentChatId: null, subagentStatus: null },
     });
     const completedNonNullResult = await prisma.$queryRaw<[{ count: bigint }]>`
       SELECT COUNT(*)::bigint as count
@@ -55,11 +55,13 @@ export async function GET(request: NextRequest) {
         AND "projectId" != ALL(${runningSessionIds}::text[])
         AND "lastReadAt" IS NOT NULL
         AND "lastActivityAt" > "lastReadAt"
+        AND "parentChatId" IS NULL
+        AND "subagentStatus" IS NULL
     `;
     const completedCount = completedNullCount + Number(completedNonNullResult[0]?.count ?? 0);
 
     const completedNullSample = await prisma.chat.findMany({
-      where: { latestEventIsUser: false, latestEventId: { not: null }, userId, projectId: { notIn: runningSessionIds }, lastReadAt: null },
+      where: { latestEventIsUser: false, latestEventId: { not: null }, userId, projectId: { notIn: runningSessionIds }, lastReadAt: null, parentChatId: null, subagentStatus: null },
       orderBy: { lastActivityAt: 'desc' }, take: 5,
       select: { id: true, title: true, projectId: true, agent: true, lastActivityAt: true },
     });
@@ -72,6 +74,8 @@ export async function GET(request: NextRequest) {
         AND "projectId" != ALL(${runningSessionIds}::text[])
         AND "lastReadAt" IS NOT NULL
         AND "lastActivityAt" > "lastReadAt"
+        AND "parentChatId" IS NULL
+        AND "subagentStatus" IS NULL
       ORDER BY "lastActivityAt" DESC
       LIMIT 5
     `;
@@ -81,12 +85,12 @@ export async function GET(request: NextRequest) {
 
     // 에이전트 분포
     const agentGroupBy = await prisma.chat.groupBy({
-      by: ['agent'], where: { userId }, _count: { id: true },
+      by: ['agent'], where: { userId, parentChatId: null, subagentStatus: null }, _count: { id: true },
     });
 
     // 세션별 채팅 에이전트 분포
     const perSessionGroupBy = await prisma.chat.groupBy({
-      by: ['projectId', 'agent'], where: { userId }, _count: { id: true },
+      by: ['projectId', 'agent'], where: { userId, parentChatId: null, subagentStatus: null }, _count: { id: true },
     });
     const sessionChatMeta = buildSessionChatMeta(perSessionGroupBy);
 

--- a/services/aris-web/app/api/runtime/sessions/stream/route.ts
+++ b/services/aris-web/app/api/runtime/sessions/stream/route.ts
@@ -60,15 +60,15 @@ export async function GET(request: NextRequest) {
           if (!cachedChatStats || now - chatStatsCachedAt > CHAT_STATS_TTL_MS) {
             const runningSessionIds = sessions.filter(s => s.status === 'running').map(s => s.id);
             const runningCount = await prisma.chat.count({
-              where: { projectId: { in: runningSessionIds }, latestEventIsUser: false, latestEventId: { not: null }, userId },
+              where: { projectId: { in: runningSessionIds }, latestEventIsUser: false, latestEventId: { not: null }, userId, parentChatId: null, subagentStatus: null },
             });
             const runningSampleRows = await prisma.chat.findMany({
-              where: { projectId: { in: runningSessionIds }, latestEventIsUser: false, latestEventId: { not: null }, userId },
+              where: { projectId: { in: runningSessionIds }, latestEventIsUser: false, latestEventId: { not: null }, userId, parentChatId: null, subagentStatus: null },
               orderBy: { lastActivityAt: 'desc' }, take: 3,
               select: { id: true, title: true, projectId: true, agent: true },
             });
             const completedNullCount = await prisma.chat.count({
-              where: { latestEventIsUser: false, latestEventId: { not: null }, userId, projectId: { notIn: runningSessionIds }, lastReadAt: null },
+              where: { latestEventIsUser: false, latestEventId: { not: null }, userId, projectId: { notIn: runningSessionIds }, lastReadAt: null, parentChatId: null, subagentStatus: null },
             });
             const completedNonNullResult = await prisma.$queryRaw<[{ count: bigint }]>`
               SELECT COUNT(*)::bigint as count FROM "Chat"
@@ -77,10 +77,11 @@ export async function GET(request: NextRequest) {
                 AND "latestEventId" IS NOT NULL
                 AND "projectId" != ALL(${runningSessionIds}::text[])
                 AND "lastReadAt" IS NOT NULL AND "lastActivityAt" > "lastReadAt"
+                AND "parentChatId" IS NULL AND "subagentStatus" IS NULL
             `;
             const completedCount = completedNullCount + Number(completedNonNullResult[0]?.count ?? 0);
             const completedNullSample = await prisma.chat.findMany({
-              where: { latestEventIsUser: false, latestEventId: { not: null }, userId, projectId: { notIn: runningSessionIds }, lastReadAt: null },
+              where: { latestEventIsUser: false, latestEventId: { not: null }, userId, projectId: { notIn: runningSessionIds }, lastReadAt: null, parentChatId: null, subagentStatus: null },
               orderBy: { lastActivityAt: 'desc' }, take: 5,
               select: { id: true, title: true, projectId: true, agent: true, lastActivityAt: true },
             });
@@ -90,13 +91,14 @@ export async function GET(request: NextRequest) {
                 AND "latestEventId" IS NOT NULL
                 AND "projectId" != ALL(${runningSessionIds}::text[])
                 AND "lastReadAt" IS NOT NULL AND "lastActivityAt" > "lastReadAt"
+                AND "parentChatId" IS NULL AND "subagentStatus" IS NULL
               ORDER BY "lastActivityAt" DESC LIMIT 5
             `;
             const completedSample = [...completedNullSample, ...completedNonNullSample]
               .sort((a, b) => new Date(b.lastActivityAt).getTime() - new Date(a.lastActivityAt).getTime())
               .slice(0, 5);
-            const agentGroupBy = await prisma.chat.groupBy({ by: ['agent'], where: { userId }, _count: { id: true } });
-            const perSessionGroupBy = await prisma.chat.groupBy({ by: ['projectId', 'agent'], where: { userId }, _count: { id: true } });
+            const agentGroupBy = await prisma.chat.groupBy({ by: ['agent'], where: { userId, parentChatId: null, subagentStatus: null }, _count: { id: true } });
+            const perSessionGroupBy = await prisma.chat.groupBy({ by: ['projectId', 'agent'], where: { userId, parentChatId: null, subagentStatus: null }, _count: { id: true } });
             const sessionChatMeta = buildSessionChatMeta(perSessionGroupBy);
             const sessionNameById = new Map(sessions.map(s => {
               const ws = workspaceMap.get(s.id);

--- a/services/aris-web/app/styles/project-chat.css
+++ b/services/aris-web/app/styles/project-chat.css
@@ -2973,6 +2973,95 @@ html[data-theme='dark'] .pc-proto .pc-action-stack {
   flex-shrink: 0;
 }
 
+.pc-proto .subagent-empty {
+  padding: var(--sp-3) var(--sp-4);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+}
+
+.pc-proto .subagent-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-2);
+  min-width: 0;
+  padding: var(--sp-3) var(--sp-4);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.pc-proto .subagent-row__dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  margin-top: 5px;
+  border-radius: var(--r-full);
+  background: var(--text-tertiary);
+}
+
+.pc-proto .subagent-row[data-status="running"] .subagent-row__dot {
+  background: var(--warning-fg);
+  box-shadow: 0 0 0 3px var(--warning-bg);
+}
+
+.pc-proto .subagent-row[data-status="completed"] .subagent-row__dot {
+  background: var(--success-fg);
+}
+
+.pc-proto .subagent-row__body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.pc-proto .subagent-row__main {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.pc-proto .subagent-row__type {
+  flex: 0 0 auto;
+  padding: 1px var(--sp-2);
+  border-radius: var(--r-full);
+  background: var(--surface-sunken);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.pc-proto .subagent-row__title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pc-proto .subagent-row__preview {
+  margin-top: 2px;
+  overflow: hidden;
+  color: var(--text-tertiary);
+  font-size: var(--text-2xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pc-proto .subagent-row__status {
+  flex: 0 0 auto;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.pc-proto .subagent-row[data-status="running"] .subagent-row__status {
+  color: var(--warning-fg);
+}
+
+.pc-proto .subagent-row[data-status="completed"] .subagent-row__status {
+  color: var(--success-fg);
+}
+
 .pc-proto .chist {
   display: flex;
   flex-direction: column;

--- a/services/aris-web/components/project-chat/ProjectChatSurface.tsx
+++ b/services/aris-web/components/project-chat/ProjectChatSurface.tsx
@@ -19,6 +19,7 @@ import {
   AlertTriangle,
   ArrowDown,
   AtSign,
+  Bot,
   Check,
   ChevronLeft,
   ChevronRight,
@@ -47,6 +48,7 @@ import {
 } from 'lucide-react';
 import { ProviderLogo, type ProviderLogoProvider } from '@/components/ui/ProviderLogo';
 import { WorkspaceFileEditor } from '@/components/files/WorkspaceFileEditor';
+import { SubagentPanel } from '@/components/project-chat/SubagentPanel';
 import { isTerminalRunStatus, readUiEventRunStatus } from '@/lib/happy/chatRuntime';
 import { hydratePersistedPermissions, mergeRenderablePermissions } from '@/lib/happy/permissions';
 import { withAppBasePath } from '@/lib/routing/appPath';
@@ -113,7 +115,7 @@ import { DensityMenuList } from './cmd-display/DensityMenuList';
 // Local type aliases (duplicated from HomePageClient.tsx; cleanup out of scope)
 // ---------------------------------------------------------------------------
 type ComposerMode = 'agent' | 'plan' | 'terminal';
-type WorkspaceTab = 'run' | 'files' | 'git' | 'terminal' | 'context';
+type WorkspaceTab = 'run' | 'files' | 'git' | 'terminal' | 'context' | 'subagents';
 type PreviewState = 'closed' | 'open' | 'dock';
 type ModelProvider = ProviderLogoProvider;
 type ReasoningEffort = 'Low' | 'Medium' | 'High' | 'XHigh' | 'Max';
@@ -3161,6 +3163,7 @@ export function ProjectChatSurface({
               <button type="button" className="ws__tab" data-tab="git" aria-pressed={workspaceTab === 'git'} onClick={() => activateWorkspaceTab('git')}><GitActionMark size={12} />Git</button>
               <button type="button" className="ws__tab" data-tab="terminal" aria-pressed={workspaceTab === 'terminal'} onClick={() => activateWorkspaceTab('terminal')}><Terminal size={12} />Terminal</button>
               <button type="button" className="ws__tab" data-tab="context" aria-pressed={workspaceTab === 'context'} onClick={() => activateWorkspaceTab('context')}><PanelsTopLeft size={12} />Context</button>
+              <button type="button" className="ws__tab" data-tab="subagents" aria-pressed={workspaceTab === 'subagents'} onClick={() => activateWorkspaceTab('subagents')}><Bot size={12} />Subagents</button>
             </div>
             <div className="ws__status">
               <div className="ws__status-left">
@@ -3279,6 +3282,9 @@ export function ProjectChatSurface({
                     </button>
                   ))}
                 </div>
+              </div>
+              <div className={`ws__pane${workspaceTab === 'subagents' ? ' ws__pane--active' : ''}`} data-pane="subagents">
+                <SubagentPanel sessionId={session.id} chatId={activeChat?.id ?? null} active={workspaceTab === 'subagents'} />
               </div>
             </div>
           </aside>
@@ -3587,6 +3593,7 @@ export function ProjectChatSurface({
             <button type="button" className="ws__tab" data-tab="git" aria-pressed={workspaceTab === 'git'} onClick={() => activateWorkspaceTab('git')}><GitActionMark size={12} />Git</button>
             <button type="button" className="ws__tab" data-tab="terminal" aria-pressed={workspaceTab === 'terminal'} onClick={() => activateWorkspaceTab('terminal')}><Terminal size={12} />Terminal</button>
             <button type="button" className="ws__tab" data-tab="context" aria-pressed={workspaceTab === 'context'} onClick={() => activateWorkspaceTab('context')}><PanelsTopLeft size={12} />Context</button>
+              <button type="button" className="ws__tab" data-tab="subagents" aria-pressed={workspaceTab === 'subagents'} onClick={() => activateWorkspaceTab('subagents')}><Bot size={12} />Subagents</button>
           </div>
           <div className="ws__status">
             <div className="ws__status-left">
@@ -3846,6 +3853,9 @@ export function ProjectChatSurface({
                   </button>
                 ))}
               </div>
+            </div>
+            <div className={`ws__pane${workspaceTab === 'subagents' ? ' ws__pane--active' : ''}`} data-pane="subagents">
+              <SubagentPanel sessionId={session.id} chatId={activeChat?.id ?? null} active={workspaceTab === 'subagents'} />
             </div>
           </div>
           <div className="ws__footer">

--- a/services/aris-web/components/project-chat/SubagentPanel.tsx
+++ b/services/aris-web/components/project-chat/SubagentPanel.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SessionChat } from '@/lib/happy/types';
+
+type SubagentPanelProps = {
+  sessionId: string;
+  chatId: string | null;
+  active: boolean;
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  running: '실행 중',
+  completed: '완료',
+};
+
+function normalizeStatus(value: string | null | undefined): 'running' | 'completed' | 'unknown' {
+  return value === 'running' || value === 'completed' ? value : 'unknown';
+}
+
+function statusLabel(value: string | null | undefined): string {
+  return value && STATUS_LABELS[value] ? STATUS_LABELS[value] : value || '알 수 없음';
+}
+
+/**
+ * Right-sidebar panel listing the imported subagent (Task tool) transcripts that
+ * belong to the active chat. Subagent transcripts are intentionally hidden from
+ * the main chat list; this is the only place they surface. Polls while visible so
+ * the run status (running/completed) stays roughly live.
+ */
+export function SubagentPanel({ sessionId, chatId, active }: SubagentPanelProps) {
+  const [subagents, setSubagents] = useState<SessionChat[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const reqRef = useRef(0);
+
+  const load = useCallback(async () => {
+    if (!chatId) {
+      setSubagents([]);
+      return;
+    }
+    const reqId = reqRef.current + 1;
+    reqRef.current = reqId;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/runtime/sessions/${encodeURIComponent(sessionId)}/chats/${encodeURIComponent(chatId)}/subagents`,
+        { cache: 'no-store' },
+      );
+      const body = (await res.json().catch(() => ({}))) as { subagents?: SessionChat[]; error?: string };
+      if (reqId !== reqRef.current) {
+        return;
+      }
+      if (!res.ok) {
+        setError(body.error ?? '서브에이전트를 불러오지 못했습니다.');
+        return;
+      }
+      setSubagents(Array.isArray(body.subagents) ? body.subagents : []);
+    } catch (err) {
+      if (reqId !== reqRef.current) {
+        return;
+      }
+      setError(err instanceof Error ? err.message : '서브에이전트를 불러오지 못했습니다.');
+    } finally {
+      if (reqId === reqRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [sessionId, chatId]);
+
+  useEffect(() => {
+    if (!active || !chatId) {
+      return;
+    }
+    void load();
+    const timer = setInterval(() => { void load(); }, 5000);
+    return () => clearInterval(timer);
+  }, [active, chatId, load]);
+
+  if (!chatId) {
+    return (
+      <div className="ctx-group">
+        <div className="subagent-empty">채팅을 선택하면 서브에이전트가 표시됩니다.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ctx-group">
+      <div className="ctx-group__head">
+        <span className="ctx-group__title">Subagents</span>
+        <span className="ctx-group__count">{subagents.length}</span>
+      </div>
+      {error ? <div className="subagent-empty">{error}</div> : null}
+      {!error && subagents.length === 0 ? (
+        <div className="subagent-empty">{loading ? '불러오는 중…' : '이 채팅에는 서브에이전트가 없습니다.'}</div>
+      ) : null}
+      {subagents.map((sub) => {
+        const status = normalizeStatus(sub.subagentStatus);
+        return (
+          <div key={sub.id} className="subagent-row" data-status={status}>
+            <span aria-hidden className="subagent-row__dot" />
+            <div className="subagent-row__body">
+              <div className="subagent-row__main">
+                {sub.subagentType ? (
+                  <span className="subagent-row__type">{sub.subagentType}</span>
+                ) : null}
+                <span className="subagent-row__title" title={sub.title}>
+                  {sub.title}
+                </span>
+              </div>
+              {sub.latestPreview ? (
+                <div className="subagent-row__preview">
+                  {sub.latestPreview}
+                </div>
+              ) : null}
+            </div>
+            <span className="subagent-row__status">
+              {statusLabel(sub.subagentStatus)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/services/aris-web/lib/happy/chats.ts
+++ b/services/aris-web/lib/happy/chats.ts
@@ -14,6 +14,9 @@ function toSessionChat(record: {
   isPinned: boolean;
   isDefault: boolean;
   threadId: string | null;
+  parentChatId?: string | null;
+  subagentType?: string | null;
+  subagentStatus?: string | null;
   latestPreview: string;
   latestEventId: string | null;
   latestEventAt: Date | null;
@@ -36,6 +39,9 @@ function toSessionChat(record: {
     isPinned: record.isPinned,
     isDefault: record.isDefault,
     threadId: record.threadId,
+    parentChatId: record.parentChatId ?? null,
+    subagentType: record.subagentType ?? null,
+    subagentStatus: record.subagentStatus ?? null,
     latestPreview: record.latestPreview,
     latestEventId: record.latestEventId,
     latestEventAt: record.latestEventAt ? record.latestEventAt.toISOString() : null,
@@ -142,6 +148,10 @@ export async function listSessionChats(input: {
       where: {
         projectId: input.sessionId,
         userId: input.userId,
+        // Ignore imported subagent chats so a project that only contains
+        // subagent transcripts still gets a real default chat.
+        parentChatId: null,
+        subagentStatus: null,
       },
       select: { id: true },
     });
@@ -162,6 +172,11 @@ export async function listSessionChats(input: {
     where: {
       projectId: input.sessionId,
       userId: input.userId,
+      // Subagent (Task tool) transcripts are imported but must never appear in
+      // the main chat list — they are surfaced only in the subagent sidebar.
+      // A subagent chat is marked by a non-null parentChatId and/or subagentStatus.
+      parentChatId: null,
+      subagentStatus: null,
     },
     orderBy: [
       { isPinned: 'desc' },
@@ -172,6 +187,27 @@ export async function listSessionChats(input: {
   });
 
   return sortChats(chats.map(toSessionChat));
+}
+
+/**
+ * List the subagent (Task tool) transcripts that belong to a given parent chat,
+ * for the right-sidebar subagent panel. Ordered most-recent first.
+ */
+export async function listSubagentChats(input: {
+  parentChatId: string;
+  userId: string;
+}): Promise<SessionChat[]> {
+  const chats = await prisma.chat.findMany({
+    where: {
+      parentChatId: input.parentChatId,
+      userId: input.userId,
+    },
+    orderBy: [
+      { lastActivityAt: 'desc' },
+      { createdAt: 'desc' },
+    ],
+  });
+  return chats.map(toSessionChat);
 }
 
 export async function createSessionChat(input: {

--- a/services/aris-web/lib/happy/homeSessions.ts
+++ b/services/aris-web/lib/happy/homeSessions.ts
@@ -49,11 +49,13 @@ export async function enrichSessionsWithRecentChats(
   const [perSessionGroupBy, recentChatGroups] = await Promise.all([
     prisma.chat.groupBy({
       by: ['projectId', 'agent'],
-      where: { userId, projectId: { in: sessionIds } },
+      // Exclude imported subagent transcripts from per-project chat counts.
+      where: { userId, projectId: { in: sessionIds }, parentChatId: null, subagentStatus: null },
       _count: { id: true },
     }),
     Promise.all(sessionIds.map((sessionId) => prisma.chat.findMany({
-      where: { userId, projectId: sessionId },
+      // Subagent transcripts must not surface as recent chats on the home screen.
+      where: { userId, projectId: sessionId, parentChatId: null, subagentStatus: null },
       orderBy: [{ lastActivityAt: 'desc' }, { createdAt: 'desc' }],
       take: Math.max(0, Math.floor(recentPerSession)),
     }))),

--- a/services/aris-web/lib/happy/types.ts
+++ b/services/aris-web/lib/happy/types.ts
@@ -39,6 +39,9 @@ export type SessionChat = {
   isPinned: boolean;
   isDefault: boolean;
   threadId: string | null;
+  parentChatId?: string | null;
+  subagentType?: string | null;
+  subagentStatus?: string | null;
   latestPreview?: string;
   latestEventId?: string | null;
   latestEventAt?: string | null;

--- a/services/aris-web/prisma/migrations/20260707120000_add_chat_subagent_fields/migration.sql
+++ b/services/aris-web/prisma/migrations/20260707120000_add_chat_subagent_fields/migration.sql
@@ -1,0 +1,10 @@
+-- Subagent linkage + status for imported agent sessions.
+-- parentChatId: when set, this Chat is a subagent transcript belonging to another chat
+--   and MUST be excluded from the main chat list (surfaced only in the subagent sidebar).
+-- subagentType/subagentStatus: metadata shown in the subagent sidebar.
+ALTER TABLE "Chat"
+ADD COLUMN "parentChatId" TEXT,
+ADD COLUMN "subagentType" TEXT,
+ADD COLUMN "subagentStatus" TEXT;
+
+CREATE INDEX "Chat_parentChatId_idx" ON "Chat"("parentChatId");

--- a/services/aris-web/prisma/schema.prisma
+++ b/services/aris-web/prisma/schema.prisma
@@ -109,6 +109,9 @@ model Chat {
   isPinned       Boolean  @default(false)
   isDefault      Boolean  @default(false)
   threadId       String?
+  parentChatId   String?
+  subagentType   String?
+  subagentStatus String?
   model          String?
   geminiMode     String?
   modelReasoningEffort String?
@@ -129,6 +132,7 @@ model Chat {
 
   @@index([projectId, userId, isPinned, lastActivityAt])
   @@index([userId, updatedAt])
+  @@index([parentChatId])
 }
 
 model SessionRun {


### PR DESCRIPTION
## 변경 요약

- Claude/Codex import 중 `subagents/agent-*.jsonl` 전사를 일반 채팅으로 노출하지 않도록 `parentChatId`, `subagentType`, `subagentStatus`를 추가했습니다.
- 서브에이전트 채팅은 import는 유지하되 메인 채팅 목록에서는 제외하고, 프로젝트 채팅 우측 패널의 Subagents 탭에서 조회하도록 연결했습니다.
- ARIS에서 생성한 네이티브 채팅이 Claude/Codex 로그로 다시 import되어 중복 채팅으로 보이는 문제를 `Chat.threadId` 및 `SessionChatEvent.meta.threadId` 기준으로 판별하도록 보강했습니다.
- 기존 잘못 import된 row를 점검하고 보정할 수 있는 `reconcile:agent-imports` 스크립트를 추가했습니다. 기본은 dry-run이며, 실제 반영은 `--apply`가 있을 때만 수행합니다.

## Claude 세션에서 확인한 작업 맥락

- 원래 이슈는 두 가지였습니다.
  - 서브에이전트 세션이 일반 채팅 목록에 섞여 노출됨.
  - ARIS 네이티브 채팅이 에이전트 로그 import 과정에서 다시 들어와 중복 채팅으로 보임.
- Claude Code subagent transcript는 부모 세션 하위 `subagents/agent-*.jsonl`에 있고, 레코드에 `isSidechain: true`가 포함되는 것으로 확인했습니다.
- redesigned chat surface에서 native chat의 `threadId` persistence가 빠져 dedup 기준이 깨지는 것도 함께 확인했습니다.

## 검증

- `npm --prefix services/aris-backend run typecheck`
- `npm --prefix services/aris-backend test -- agentSessionImportWorker.test.ts`
- `npm --prefix services/aris-backend test`
- `./node_modules/.bin/tsc --noEmit` in `services/aris-web`
- `npm --prefix services/aris-web run lint` (기존 warning만 있고 error 없음)
- `git diff --check`
- `npm --prefix services/aris-backend run reconcile:agent-imports` dry-run 확인

## 배포/운영 메모

- 이 PR은 production 배포하지 않았습니다.
- `reconcile:agent-imports --apply`는 DB schema migration 적용 이후에만 실행해야 합니다.
- 현재 production DB에는 새 Chat subagent 컬럼이 없어서 dry-run이 migration 미적용 상태를 정상적으로 보고합니다.
