### PR TITLE
fix(import): 숨긴 native duplicate를 부모 후보에서 제외

### DIFF
--- a/services/aris-backend/scripts/reconcile-agent-session-imports.ts
+++ b/services/aris-backend/scripts/reconcile-agent-session-imports.ts
@@ -15,6 +15,13 @@ type OwnerChat = {
   importedSourcePath?: string | null;
 };
 
+type SubagentChatState = {
+  parentChatId?: string | null;
+  subagentType?: string | null;
+  subagentStatus?: string | null;
+  title?: string | null;
+};
+
 type Action = {
   kind: 'link-subagent' | 'mark-native-duplicate';
   importId: string;
@@ -67,7 +74,7 @@ async function readClaudeProviderSessionId(sourcePath: string): Promise<string |
 
 async function ownerFromChat(chatId: string): Promise<OwnerChat | null> {
   const chat = await db.sessionChat.findFirst({
-    where: { id: chatId, parentChatId: null },
+    where: { id: chatId, parentChatId: null, subagentStatus: null },
     select: { id: true, sessionId: true },
   });
   if (!chat) {
@@ -99,6 +106,7 @@ async function findOwnerChat(providerSessionId: string, options: {
     where: {
       threadId: trimmed,
       parentChatId: null,
+      subagentStatus: null,
       ...(options.excludeChatId ? { id: { not: options.excludeChatId } } : {}),
     },
     orderBy: { lastActivityAt: 'desc' },
@@ -170,6 +178,27 @@ async function reconcileSubagents(actions: Action[]): Promise<void> {
     }
     const meta = await readSubagentMeta(row.sourcePath);
     const status = await deriveSubagentStatus(row.sourcePath, meta.toolUseId, parentReadCache);
+    const current = row.chatId
+      ? await db.sessionChat.findUnique({
+          where: { id: row.chatId },
+          select: {
+            parentChatId: true,
+            subagentType: true,
+            subagentStatus: true,
+            title: true,
+          },
+        })
+      : null;
+    const nextTitle = meta.description ? meta.description.trim().slice(0, 120) : null;
+    const expected: SubagentChatState = {
+      parentChatId: owner.id,
+      subagentType: meta.agentType ?? null,
+      subagentStatus: status,
+      ...(nextTitle ? { title: nextTitle } : {}),
+    };
+    if (current && isSubagentChatCurrent(current, expected)) {
+      continue;
+    }
     actions.push({
       kind: 'link-subagent',
       importId: row.id,
@@ -182,10 +211,10 @@ async function reconcileSubagents(actions: Action[]): Promise<void> {
       await db.sessionChat.update({
         where: { id: row.chatId ?? '' },
         data: {
-          parentChatId: owner.id,
-          subagentType: meta.agentType ?? null,
-          subagentStatus: status,
-          ...(meta.description ? { title: meta.description.trim().slice(0, 120) } : {}),
+          parentChatId: expected.parentChatId,
+          subagentType: expected.subagentType,
+          subagentStatus: expected.subagentStatus,
+          ...(expected.title ? { title: expected.title } : {}),
         },
       });
       await db.importedAgentSession.update({
@@ -198,6 +227,22 @@ async function reconcileSubagents(actions: Action[]): Promise<void> {
       });
     }
   }
+}
+
+function isSubagentChatCurrent(current: SubagentChatState, expected: SubagentChatState): boolean {
+  if (current.parentChatId !== expected.parentChatId) {
+    return false;
+  }
+  if ((current.subagentType ?? null) !== (expected.subagentType ?? null)) {
+    return false;
+  }
+  if ((current.subagentStatus ?? null) !== (expected.subagentStatus ?? null)) {
+    return false;
+  }
+  if (expected.title && current.title !== expected.title) {
+    return false;
+  }
+  return true;
 }
 
 async function reconcileNativeDuplicates(actions: Action[]): Promise<void> {

--- a/services/aris-backend/src/runtime/prismaStore.ts
+++ b/services/aris-backend/src/runtime/prismaStore.ts
@@ -408,7 +408,7 @@ export class PrismaRuntimeStore {
     // session (native chats — post-redesign — now persist threadId again; imported
     // chats always do).
     const byThread = await this.db.sessionChat.findFirst({
-      where: { threadId: trimmed, parentChatId: null },
+      where: { threadId: trimmed, parentChatId: null, subagentStatus: null },
       orderBy: { lastActivityAt: 'desc' },
       select: { id: true },
     });
@@ -424,7 +424,7 @@ export class PrismaRuntimeStore {
       });
       if (event?.chatId) {
         const chat = await this.db.sessionChat.findFirst({
-          where: { id: event.chatId, parentChatId: null },
+          where: { id: event.chatId, parentChatId: null, subagentStatus: null },
           select: { id: true },
         });
         chatId = chat?.id ?? null;

--- a/services/aris-backend/tests/agentSessionImportStore.test.ts
+++ b/services/aris-backend/tests/agentSessionImportStore.test.ts
@@ -32,6 +32,39 @@ describe('PrismaRuntimeStore imported agent sessions', () => {
     }));
   });
 
+  it('does not treat hidden native duplicates as owning chats', async () => {
+    const sessionChat = {
+      findFirst: vi.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null),
+    };
+    const sessionChatEvent = {
+      findFirst: vi.fn().mockResolvedValue({ chatId: 'duplicate-chat-1' }),
+    };
+    const importedAgentSession = {
+      findFirst: vi.fn(),
+    };
+    const store = buildStoreWithMockDb({ sessionChat, sessionChatEvent, importedAgentSession });
+
+    await expect(store.findOwningChat('provider-session-1')).resolves.toBeNull();
+
+    expect(sessionChat.findFirst).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      where: {
+        threadId: 'provider-session-1',
+        parentChatId: null,
+        subagentStatus: null,
+      },
+    }));
+    expect(sessionChat.findFirst).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      where: {
+        id: 'duplicate-chat-1',
+        parentChatId: null,
+        subagentStatus: null,
+      },
+    }));
+    expect(importedAgentSession.findFirst).not.toHaveBeenCalled();
+  });
+
   it('creates a chat with provider thread id and links the import ledger', async () => {
     const importedAgentSession = {
       findUnique: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## 변경 요약

- `findOwningChat`이 `native_duplicate`로 숨긴 Chat을 부모 후보로 다시 선택하지 않도록 `subagentStatus: null` 조건을 추가했습니다.
- reconcile 스크립트도 같은 기준으로 부모 후보를 고르고, 이미 목표 상태인 subagent row는 action으로 출력하지 않도록 idempotency를 보강했습니다.
- 숨긴 duplicate가 event meta 경로를 통해 다시 owner로 잡히지 않는 회귀 테스트를 추가했습니다.

## 배경

PR #373 배포 후 reconcile `--apply`를 실행했는데, 이후 dry-run에서 subagent 부모가 `native_duplicate` row로 다시 잡히는 케이스가 확인됐습니다. 원인은 duplicate row를 숨긴 뒤 imported ledger가 native chat으로 옮겨지면서, 숨긴 duplicate row가 imported row 없는 top-level chat처럼 보인 점입니다.

## 검증

- `npm --prefix services/aris-backend test -- agentSessionImportStore.test.ts agentSessionImportWorker.test.ts`
- `npm --prefix services/aris-backend run typecheck`
- `npm --prefix services/aris-backend test`
- `git diff --check`
- hotfix 스크립트로 production DB dry-run 확인: 잔여 action 1건은 실제 잘못 연결된 subagent parent 보정 대상임을 읽기 전용 조회로 확인
