### PR TITLE
fix(web): iOS Safari 하단 툴바 자동 숨김 시 배경색 미채움 버그 수정

### DIFF
--- a/services/aris-web/app/styles/project-chat/shell.css
+++ b/services/aris-web/app/styles/project-chat/shell.css
@@ -1,6 +1,6 @@
 .pc-proto {
   position: relative;
-  min-height: calc(100vh - 238px);
+  min-height: calc(var(--app-vh, 100dvh) - 238px);
   border: 0;
   background: var(--canvas);
   overflow: hidden;

--- a/services/aris-web/app/styles/project-chat/timeline-composer.css
+++ b/services/aris-web/app/styles/project-chat/timeline-composer.css
@@ -3,7 +3,7 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) 420px;
   grid-template-areas: "main workspace";
-  height: calc(100vh - 238px);
+  height: calc(var(--app-vh, 100dvh) - 238px);
   min-height: 620px;
   background: var(--canvas);
 }

--- a/services/aris-web/app/styles/reset.css
+++ b/services/aris-web/app/styles/reset.css
@@ -16,8 +16,11 @@ html {
 
 html, body {
   width: 100%;
-  min-height: 100%;
-  min-height: -webkit-fill-available;
+  /* app-shell 등 나머지 전체 화면 컨테이너와 동일하게 --app-vh(ViewportHeightSync가
+     visualViewport 기준으로 갱신)에 맞춘다. 이전의 정적 100%/-webkit-fill-available는
+     iOS Safari 하단 툴바가 자동 숨김되며 visualViewport가 커질 때 갱신되지 않아,
+     실제 UI보다 짧게 고정된 layout viewport 높이 아래로 캔버스 배경색이 노출됐다. */
+  min-height: var(--app-vh, 100dvh);
   background-color: var(--bg);
   color: var(--text);
   font-size: var(--text-body, 14px);
@@ -29,7 +32,7 @@ html, body {
 }
 
 body {
-  min-height: 100%;
+  min-height: var(--app-vh, 100dvh);
 }
 
 a {


### PR DESCRIPTION
## 요약
- iOS Safari에서 하단 툴바(주소창/탭바)가 스크롤로 자동 숨김되면, 화면 하단에 앱 UI 색이 아닌 캔버스 배경색이 채워지지 않은 것처럼 보이는 문제를 수정합니다.

## 원인
- `html, body`는 `min-height: 100%` / `-webkit-fill-available`라는 정적 값을 사용했고, 앱의 나머지 전체 화면 컨테이너(`app-shell`, `aris-ia-shell`, `pc-proto` 등)는 모두 `ViewportHeightSync`가 `visualViewport` 기준으로 실시간 갱신하는 `--app-vh` 커스텀 프로퍼티를 사용했습니다.
- iOS Safari의 layout viewport(`window.innerHeight`)는 툴바 상태와 무관하게 항상 "툴바가 숨겨졌을 때" 기준의 큰 고정값입니다. 반면 `visualViewport.height`(→ `--app-vh`)는 툴바가 보일 때 더 작은 값으로 실시간 변합니다.
- 그 결과 `html`의 박스는 항상 큰 고정 높이로 렌더링되지만, 그 안의 앱 UI는 더 작은 `--app-vh`에 맞춰 렌더링되어 두 박스 사이에 `html`의 캔버스 배경색만 칠해진 틈이 생겼습니다. 이 틈은 평소엔 화면 밖(툴바 뒤)에 가려져 있다가, 툴바가 자동 숨김되는 순간 노출됩니다.
- 실제 `reset.css`/`layout.css`/`ia-shell.css` 캐스케이드를 그대로 로드하고 `visualViewport`를 모킹한 Playwright(WebKit) 재현으로 확인했습니다: 수정 전 `html`의 렌더링 높이는 762px(`--app-vh`, 앱 UI 전체와 동일)가 아닌 844px(고정 layout viewport)로 측정되어 82px 불일치가 실측으로 확인됐습니다. 수정 후에는 `html`/`body`/`app-shell`/`aris-ia-shell`/`m-sb`/`m-body` 모두 762px로 정확히 일치합니다.
- 부가로, `project-chat/shell.css`와 `timeline-composer.css`에 남아있던 정적 `100vh` 규칙도 같은 방식으로 고쳤습니다. `ProjectChatSurface`가 `.m-main-scroll--project-chat-detail` 안에 렌더링될 때는 더 구체적인 `--app-vh` 규칙에 항상 덮어써지지만, `.proj-pane` 탭 레이아웃 안에 직접 렌더링되는 두 번째 경로에서는 이 정적 규칙이 그대로 적용되어 동일한 버그 패턴을 만듭니다.

## 변경
- `services/aris-web/app/styles/reset.css`: `html, body`의 `min-height`을 `var(--app-vh, 100dvh)`로 통일
- `services/aris-web/app/styles/project-chat/shell.css`, `timeline-composer.css`: 남아있던 `100vh` 계산식을 `var(--app-vh, 100dvh)`로 교체

## 검증
- `git diff --check`: 통과
- `tsc --noEmit`: 통과 (CSS-only 변경이라 타입 오류 없음 확인 목적)
- Playwright(WebKit) 정적 CSS 재현 스크립트로 수정 전/후 `html`/`body`/`app-shell`/`aris-ia-shell` 등의 렌더링 높이를 실측 비교 — 수정 전 82px 불일치 확인, 수정 후 전부 일치 확인
- ⚠️ 실제 iOS Safari 기기에서의 최종 시각 확인은 하지 못했습니다. 이 저장소의 dev 서버 기동에 필요한 `DEPLOY_ENV_FILE=/home/ubuntu/.config/aris/prod.env` 사용이 이번 작업(순수 CSS 조사) 범위에 비해 과도하다고 자동 차단되어, 로그인이 필요한 실기 e2e(`tests/e2e/mobile-overflow.spec.ts` 패턴)는 돌리지 못했습니다. 실제 아이폰 Safari에서 채팅 화면을 열고 스크롤해 하단 툴바를 자동 숨김시켜 봐 주시면 감사하겠습니다.

worktree: `.worktrees/fix-ios-safari-viewport-bg` (머지 후 제거 예정)
배포 여부: production 배포 안 함

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019mAt6tLGZ4BCuVt1T1RrJe