### PR TITLE
fix(web): 모바일 채팅 셸 높이 테스트 단언을 --app-vh 기준으로 갱신

### DIFF
--- a/services/aris-web/tests/chatMobileScrollOwnership.test.ts
+++ b/services/aris-web/tests/chatMobileScrollOwnership.test.ts
@@ -25,7 +25,7 @@ describe('chat mobile scroll ownership', () => {
     const timeline = readCssBlock(projectChatCss, '.pc-proto .tl');
 
     expect(proto).toContain('overflow: hidden;');
-    expect(shell).toContain('height: calc(100vh - 238px);');
+    expect(shell).toContain('height: calc(var(--app-vh, 100dvh) - 238px);');
     expect(main).toContain('min-height: 0;');
     expect(timeline).toContain('overflow-y: auto;');
     expect(timeline).not.toContain('overflow: visible;');


### PR DESCRIPTION
## 변경 요약

`c5370b6`("sync html/body min-height to --app-vh for iOS Safari toolbar gap")가 `.pc-proto .shell`의 height를 `calc(100vh - 238px)`에서 `calc(var(--app-vh, 100dvh) - 238px)`로 의도적으로 변경했지만, `tests/chatMobileScrollOwnership.test.ts`의 리터럴 문자열 단언은 갱신되지 않아 main이 vitest 기준 1개 테스트 red 상태였습니다.

PR #375(모바일 채팅 크롬 자동 숨김 + 컴포저) 병합 전 전체 검증 과정에서 발견했습니다. 해당 PR과는 무관한 기존 결함이며, `d47f90c`(PR #375 병합 직전 main)에서도 동일하게 재현되는 것을 확인했습니다.

## 검증
- `tsc --noEmit` ✅
- vitest 전체(aris-web) 121개 파일 / 609개 테스트 통과 (수정 전 120/608 + 1 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbeRFoKWdoefKCvECrNfkt