### PR TITLE
fix(web): iOS Safari 하단 바 축소 시 검은 띠 — theme-color 메타 동기화

### DIFF
--- a/services/aris-web/app/layout.tsx
+++ b/services/aris-web/app/layout.tsx
@@ -8,6 +8,18 @@ const appBasePath = normalizeAppBasePath(process.env.NEXT_PUBLIC_ARIS_WEB_ASSET_
 
 const themeBootScript = `
 (() => {
+  const syncThemeColorMeta = (resolved) => {
+    // iOS Safari 15+는 하단 바가 축소될 때 그 영역을 theme-color 메타로 칠한다.
+    // 메타가 없으면 시스템 다크 모드에서 Safari 기본 다크 크롬색(검정)이 쓰여
+    // 라이트 테마 페이지 아래에 검은 띠가 남는다. 색상은 tokens.css의 --canvas와 동기 유지.
+    let meta = document.querySelector('meta[name="theme-color"]');
+    if (!meta) {
+      meta = document.createElement('meta');
+      meta.setAttribute('name', 'theme-color');
+      document.head.appendChild(meta);
+    }
+    meta.setAttribute('content', resolved === 'dark' ? '#08090c' : '#F7F8FA');
+  };
   try {
     const key = 'aris-theme';
     const stored = localStorage.getItem(key);
@@ -17,8 +29,10 @@ const themeBootScript = `
     const root = document.documentElement;
     root.dataset.theme = resolved;
     root.dataset.themeMode = mode;
+    syncThemeColorMeta(resolved);
   } catch {
     document.documentElement.dataset.theme = 'light';
+    syncThemeColorMeta('light');
   }
 })();
 `;

--- a/services/aris-web/lib/theme/clientTheme.ts
+++ b/services/aris-web/lib/theme/clientTheme.ts
@@ -27,12 +27,30 @@ export function resolveTheme(mode: ThemeMode): ResolvedTheme {
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
+// iOS Safari 15+는 하단 바가 축소될 때 그 영역을 theme-color 메타로 칠하므로
+// 런타임 테마 전환 시에도 메타를 함께 갱신해야 한다.
+// 최초 페인트 전 적용은 app/layout.tsx의 themeBootScript가 같은 로직으로 수행한다.
+// 색상은 tokens.css의 --canvas와 동기 유지.
+export function syncThemeColorMeta(resolved: ResolvedTheme): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  let meta = document.querySelector('meta[name="theme-color"]');
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.setAttribute('name', 'theme-color');
+    document.head.appendChild(meta);
+  }
+  meta.setAttribute('content', resolved === 'dark' ? '#08090c' : '#F7F8FA');
+}
+
 export function applyTheme(mode: ThemeMode): ResolvedTheme {
   const resolved = resolveTheme(mode);
   if (typeof document !== 'undefined') {
     const root = document.documentElement;
     root.dataset.theme = resolved;
     root.dataset.themeMode = mode;
+    syncThemeColorMeta(resolved);
   }
   writeLocalStorage(THEME_STORAGE_KEY, mode);
   return resolved;


### PR DESCRIPTION
## 요약
iOS Safari에서 하단 툴바가 자동 숨김되는 즉시 그 자리에 검은 띠가 지속적으로 남는 문제(모든 화면 공통)를 수정합니다. 사용자 스크린샷 기준: 시스템 다크 모드 기기에서 라이트 테마 페이지 하단에 검은 띠.

## 원인
- iOS Safari 15+는 하단 바가 축소될 때 그 영역을 페이지의 `theme-color` 메타 색으로 칠합니다. 이 앱에는 `theme-color` 메타가 없어서, 시스템 다크 모드에서 Safari 기본 다크 크롬색(검정)이 사용됐습니다.
- 이 영역은 페이지 뷰포트 밖의 **브라우저 크롬**이라 CSS 높이/배경 규칙으로는 접근 불가 — "모든 화면 공통"인 이유입니다.
- 참고: PR #382(html/body `--app-vh` 동기화)는 별개 계층의 정리였고 이 증상의 원인이 아니었습니다. 이번 변경이 스크린샷의 실제 증상을 겨냥합니다.

## 변경
- `app/layout.tsx` `themeBootScript`: 첫 페인트 전에 resolved 테마 기준으로 `theme-color` 메타 생성/갱신
- `lib/theme/clientTheme.ts` `applyTheme`: 런타임 테마 전환 시에도 동일하게 메타 갱신 (`syncThemeColorMeta` export)
- `prefers-color-scheme` media 속성 방식이 아닌 resolved 테마 기준인 이유: 사용자가 시스템과 무관하게 라이트/다크를 강제할 수 있기 때문 (스크린샷 상황이 정확히 "시스템 다크 + 앱 라이트")
- 색상은 `tokens.css`의 `--canvas`와 동일 (라이트 `#F7F8FA`, 다크 `#08090c`)

## 검증
- `git diff --check`, `tsc --noEmit` 통과
- `layout.tsx`에서 부트 스크립트를 그대로 추출해 Playwright(WebKit)에서 시스템 테마 × 저장된 테마 4가지 조합 실행 — resolved 테마와 메타 색이 모두 기대값과 일치 (보고된 케이스 "시스템 다크 + 앱 라이트" → `#F7F8FA` 포함), 메타 중복 생성 없음
- ⚠️ Safari 크롬 칠하기 동작 자체는 실기기에서만 확인 가능하므로 배포 후 아이폰에서 최종 확인 필요

worktree: `.worktrees/fix-safari-theme-color` (머지 후 제거 예정)
배포 여부: production 배포 안 함 (지시 시 진행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mAt6tLGZ4BCuVt1T1RrJe
