### PR TITLE
fix(web): 하단 내비 숨김을 CSS 오프셋 대신 언마운트로 — iOS Safari 하단 띠 제거

### DIFF
--- a/services/aris-web/app/styles/bottom-nav.css
+++ b/services/aris-web/app/styles/bottom-nav.css
@@ -21,18 +21,33 @@
   box-shadow:
     inset 0 0 0 1px var(--bottom-nav-inset-border),
     var(--bottom-nav-shadow);
-  transition: bottom 0.28s ease, opacity 0.2s ease;
-  will-change: bottom, opacity;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   transform-style: preserve-3d;
   overflow: hidden;
+  /* 숨김/표시는 React mount/unmount로 처리한다 (BottomNav.tsx 참고).
+     기존처럼 뷰포트 아래로 offset해 숨기면 offscreen fixed + backdrop-filter
+     레이어가 iOS Safari 툴바 축소 시 하단에 죽은 띠를 남긴다.
+     아래 애니메이션은 재마운트 시 슬라이드-인 연출용. */
+  animation: bottom-nav-in 0.22s ease;
 }
 
-.bottom-nav-hidden {
-  bottom: calc(-62px - 1.75rem - var(--safe-area-inset-bottom));
-  opacity: 0;
-  pointer-events: none;
+@keyframes bottom-nav-in {
+  from {
+    transform: translateX(-50%) translateY(12px);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateX(-50%) translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bottom-nav {
+    animation: none;
+  }
 }
 
 .bottom-nav-indicator {

--- a/services/aris-web/components/layout/BottomNav.tsx
+++ b/services/aris-web/components/layout/BottomNav.tsx
@@ -160,8 +160,17 @@ export function BottomNav({ activeTab, onTabChange }: BottomNavProps) {
     { id: 'files', label: 'Files', icon: FolderTree },
   ];
 
+  // 숨김 상태에서는 DOM에서 완전히 제거한다. CSS로 뷰포트 아래에 숨겨두면
+  // (offscreen fixed + backdrop-filter 컴포지팅 레이어) iOS Safari가 하단 툴바를
+  // 접을 때 그 자리에 죽은 띠를 남겨 콘텐츠 영역을 잘라먹는다.
+  // 스크롤 감지 훅은 계속 살아 있으므로 위로 스크롤하면 다시 마운트된다.
+  // 재등장 애니메이션은 .bottom-nav의 CSS mount 애니메이션이 담당한다.
+  if (hidden) {
+    return null;
+  }
+
   return (
-    <nav className={`bottom-nav${hidden ? ' bottom-nav-hidden' : ''}`} ref={navRef}>
+    <nav className="bottom-nav" ref={navRef}>
       <span
         className="bottom-nav-indicator"
         aria-hidden="true"


### PR DESCRIPTION
## 요약
iOS Safari에서 스크롤로 하단 툴바가 접히는 즉시 하단에 죽은 띠가 생겨 콘텐츠 영역을 잘라먹는 문제를 수정합니다. 사용자가 기억한 과거 해결책("숨김 시 하단 내비를 아예 렌더링하지 않기")을 검토·적용한 것입니다.

## 원인 분석
- 하단 내비(BottomNav)는 아래 방향 스크롤에서 자동 숨김되는데, 기존 방식은 DOM에 남긴 채 `bottom` 음수 오프셋으로 **뷰포트 아래에 주차**시키는 CSS 숨김이었습니다.
- 이 요소는 `position: fixed` + `backdrop-filter: blur(24px)` + `will-change` 조합이라 숨겨진 뒤에도 **컴포지팅 레이어가 하단 영역에 살아 있고**, 하단 내비를 숨기는 스크롤 제스처가 곧 Safari 툴바를 접는 제스처라서 툴바 축소 시점과 정확히 겹칩니다. iOS Safari가 툴바를 접으며 뷰포트를 확장할 때 이 offscreen 레이어 자리에 죽은 띠를 남기는 렌더링 아티팩트입니다.
- 증상 특성과 모두 부합: 툴바 숨김 "즉시" 발생(같은 제스처), "지속"(레이어가 계속 주차 상태), "모든 화면 공통"(BottomNav는 채팅 화면 제외 전 탭에 렌더링), 콘텐츠 영역 잘림(페이지가 그 영역을 못 그림).
- 커밋 이력이 방증: `f62acee`(불안정해서 scroll-hide 제거) → `3156c4e`(재도입) → `9f604f3`(transform→bottom으로 클리핑 회피) → `6d377de`(backface-visibility 레이어 핵 추가) — 전부 이 요소의 iOS 렌더링 아티팩트와 싸운 기록입니다.

## 변경
- `BottomNav.tsx`: `hidden`이면 `null` 반환 (컴포넌트는 마운트 유지 → 스크롤 훅이 계속 살아 있어 위로 스크롤 시 재마운트됨)
- `bottom-nav.css`: 죽은 `.bottom-nav-hidden` 규칙과 `bottom`/`opacity` 트랜지션 제거, 재마운트 슬라이드-인은 CSS mount 애니메이션으로 대체 (`prefers-reduced-motion` 대응 포함)

## 검증
- `git diff --check`, `tsc --noEmit` 통과
- `vitest` — `designSystemV1Implementation`, `projectListSurface`, `mobileScrollAutoHide` 51개 테스트 전부 통과
- ⚠️ 아티팩트 자체는 iOS 실기기에서만 재현되므로 배포 후 실기기 확인 필요

## 관련
- PR #384 (theme-color 메타): 하단 바 영역의 **색**을 앱 테마와 맞추는 별개 개선 — 이 PR과 무관하게 유효하지만 이번 증상의 원인은 아님
- PR #382 (html/body `--app-vh`): 배포됨, 같은 계열 정리지만 이번 증상의 원인은 아니었음

worktree: `.worktrees/fix-bottom-nav-unmount` (머지 후 제거 예정)
배포 여부: production 배포 안 함 (지시 시 진행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mAt6tLGZ4BCuVt1T1RrJe
