### PR TITLE
fix(web): 모바일 채팅 헤더 1줄 병합 + 스크롤/키보드 오픈 버그 수정

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -19,18 +19,15 @@ import {
   Home,
   MessageSquareText,
   Monitor,
-  Moon,
-  MoreHorizontal,
   PanelsTopLeft,
   Plus,
   Search,
   Send,
   Sparkles,
-  Settings,
-  Sun,
   Wifi,
   X,
 } from 'lucide-react';
+import { AppChromeMenu } from '@/components/layout/AppChromeMenu';
 import { BottomNav, TabType } from '@/components/layout/BottomNav';
 import { SidebarFooterMenu } from '@/components/layout/SidebarFooterMenu';
 import { SidebarResizer } from '@/components/layout/SidebarResizer';
@@ -126,12 +123,6 @@ const CMD_CONSOLE_SCRIPT: Array<[string, CmdConsoleOutput[]]> = [
   ['aris memory write --type project "ia-v3"', [
     { kind: 'out', text: 'signature: ghost-button + console + spotlight' },
   ]],
-];
-
-const THEME_OPTIONS = [
-  { mode: 'system' as const, label: '시스템', Icon: Monitor },
-  { mode: 'light' as const, label: '라이트', Icon: Sun },
-  { mode: 'dark' as const, label: '다크', Icon: Moon },
 ];
 
 const FALLBACK_FILES: FileItem[] = [
@@ -842,8 +833,6 @@ function Topbar({
   onThemeChange: (mode: ThemeMode) => void;
   onOpenSettings: () => void;
 }) {
-  const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
   const activeProjects = sessions.filter((session) => session.status === 'running' || session.status === 'error').length;
   const copy: Record<TabType, { title: string; crumb: string }> = {
     home: { title: 'Home', crumb: 'workspace overview' },
@@ -851,39 +840,6 @@ function Topbar({
     project: { title: 'Projects', crumb: `${activeProjects} active · project chats in sidebar` },
     files: { title: 'Files', crumb: 'project filesystem' },
     settings: { title: 'Settings', crumb: 'preferences & configuration' },
-  };
-
-  useEffect(() => {
-    if (!menuOpen) {
-      return;
-    }
-    const closeOnOutsidePointer = (event: MouseEvent) => {
-      if (menuRef.current?.contains(event.target as Node)) {
-        return;
-      }
-      setMenuOpen(false);
-    };
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setMenuOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', closeOnOutsidePointer);
-    document.addEventListener('keydown', closeOnEscape);
-    return () => {
-      document.removeEventListener('mousedown', closeOnOutsidePointer);
-      document.removeEventListener('keydown', closeOnEscape);
-    };
-  }, [menuOpen]);
-
-  const changeThemeMode = (next: ThemeMode) => {
-    onThemeChange(next);
-    setMenuOpen(false);
-  };
-
-  const handleOpenSettings = () => {
-    setMenuOpen(false);
-    onOpenSettings();
   };
 
   return (
@@ -914,56 +870,7 @@ function Topbar({
         )}
       </div>
       <div className="m-top__right">
-        <div className="m-context-menu" ref={menuRef}>
-          <button
-            type="button"
-            className="m-context-menu__button"
-            aria-label="상단 헤더 메뉴"
-            aria-haspopup="menu"
-            aria-expanded={menuOpen}
-            onClick={() => setMenuOpen((open) => !open)}
-          >
-            <MoreHorizontal size={16} />
-          </button>
-          {menuOpen && (
-            <div className="m-context-menu__panel" role="menu" aria-label="상단 헤더 메뉴">
-              <div className="m-context-menu__section">
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="m-context-menu__item"
-                  onClick={handleOpenSettings}
-                >
-                  <Settings size={13} aria-hidden="true" />
-                  <span>설정</span>
-                </button>
-              </div>
-              <div className="m-context-menu__section">
-                <div className="m-context-menu__label">테마</div>
-                <div className="m-theme-toggle" role="group" aria-label="테마 선택">
-                  {THEME_OPTIONS.map(({ mode, label, Icon }) => {
-                    const active = themeMode === mode;
-                    return (
-                      <button
-                        key={mode}
-                        type="button"
-                        role="menuitemradio"
-                        className={`m-theme-toggle__item${active ? ' m-theme-toggle__item--active' : ''}`}
-                        aria-checked={active}
-                        aria-label={`${label} 테마`}
-                        title={`${label} 테마`}
-                        onClick={() => changeThemeMode(mode)}
-                      >
-                        <Icon size={13} />
-                        <span className="m-theme-toggle__label">{label}</span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
+        <AppChromeMenu themeMode={themeMode} onThemeChange={onThemeChange} onOpenSettings={onOpenSettings} />
       </div>
     </header>
   );
@@ -1516,22 +1423,30 @@ function ProjectDetailSurface({
   index,
   isOperator,
   onBackToProjects,
+  onLogoHome,
+  onOpenSettings,
   onProjectChatOpen,
   onProjectViewChange,
+  onThemeChange,
   projectView,
   selectedChatId,
   session,
   surfaceMode,
+  themeMode,
 }: {
   index: number;
   isOperator: boolean;
   onBackToProjects: () => void;
+  onLogoHome: () => void;
+  onOpenSettings: () => void;
   onProjectChatOpen: (chatId: string) => void;
   onProjectViewChange: (view: ProjectView) => void;
+  onThemeChange: (mode: ThemeMode) => void;
   projectView: ProjectView;
   selectedChatId: string | null;
   session: SessionSummary;
   surfaceMode: ProjectChatSurfaceMode;
+  themeMode: ThemeMode;
 }) {
   const projectName = displayProjectName(session);
   const projectPath = displayProjectPath(session);
@@ -1590,12 +1505,16 @@ function ProjectDetailSurface({
           modelLabel={modelLabel}
           onBackToChatList={() => onProjectViewChange('chats')}
           onChatOpen={onProjectChatOpen}
+          onLogoHome={onLogoHome}
+          onOpenSettings={onOpenSettings}
+          onThemeChange={onThemeChange}
           projectName={projectName}
           projectPath={projectPath}
           recentPreview={recentPreview}
           selectedChatId={selectedChatId}
           session={session}
           surfaceMode={surfaceMode}
+          themeMode={themeMode}
           tokenLabel={tokenLabel}
         />
       </div>
@@ -1881,25 +1800,33 @@ function ProjectPlaceholderPanel({
 function ProjectSurface({
   isOperator,
   onBackToProjects,
+  onLogoHome,
+  onOpenSettings,
   onProjectChatOpen,
   onProjectOpen,
   onProjectViewChange,
+  onThemeChange,
   projectView,
   selectedChatId,
   selectedProjectId,
   sessions,
   surfaceMode,
+  themeMode,
 }: {
   isOperator: boolean;
   onBackToProjects: () => void;
+  onLogoHome: () => void;
+  onOpenSettings: () => void;
   onProjectChatOpen: (sessionId: string, chatId: string) => void;
   onProjectOpen: (sessionId: string, view?: ProjectView) => void;
   onProjectViewChange: (view: ProjectView) => void;
+  onThemeChange: (mode: ThemeMode) => void;
   projectView: ProjectView;
   selectedChatId: string | null;
   selectedProjectId: string | null;
   sessions: SessionSummary[];
   surfaceMode: ProjectChatSurfaceMode;
+  themeMode: ThemeMode;
 }) {
   const [query, setQuery] = useState('');
   const [activeFilter, setActiveFilter] = useState('All');
@@ -1927,11 +1854,15 @@ function ProjectSurface({
         index={selectedIndex}
         isOperator={isOperator}
         onBackToProjects={onBackToProjects}
+        onLogoHome={onLogoHome}
+        onOpenSettings={onOpenSettings}
         onProjectChatOpen={(chatId) => onProjectChatOpen(selectedProject.id, chatId)}
         onProjectViewChange={onProjectViewChange}
+        onThemeChange={onThemeChange}
         projectView={projectView}
         selectedChatId={selectedChatId}
         surfaceMode={surfaceMode}
+        themeMode={themeMode}
       />
     );
   }
@@ -2348,14 +2279,18 @@ export default function HomePageWrapper({
         <ProjectSurface
           isOperator={user.role === 'operator'}
           onBackToProjects={handleBackToProjects}
+          onLogoHome={() => handleTabChange('home')}
+          onOpenSettings={() => handleTabChange('settings')}
           onProjectChatOpen={handleProjectChatOpen}
           onProjectOpen={handleProjectOpen}
           onProjectViewChange={handleProjectViewChange}
+          onThemeChange={changeThemeMode}
           projectView={selectedProjectView}
           selectedChatId={selectedProjectChatId}
           selectedProjectId={selectedProjectId}
           sessions={sessions}
           surfaceMode={projectSurfaceMode}
+          themeMode={themeMode}
         />
       );
     }

--- a/services/aris-web/app/styles/ia-shell.css
+++ b/services/aris-web/app/styles/ia-shell.css
@@ -865,8 +865,28 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
    height (to avoid reflow on the legacy surface), so the redesigned chat surface
    must switch to --visual-viewport-height, which does shrink with the keyboard.
    Without this, the document stays full height while only the reduced area is
-   visible, and the browser scrolls the focused composer up to the top. */
+   visible, and the browser scrolls the focused composer up to the top.
+
+   Critically this must also cover html/body themselves: reset.css sets
+   `overflow-x: hidden` on them without an explicit overflow-y, and per the CSS
+   Overflow spec a `visible` overflow-y paired with a non-visible overflow-x is
+   computed as `auto` — so html/body are actually vertically scrollable. Since
+   both use `min-height: var(--app-vh, 100dvh)` and --app-vh stays frozen at the
+   pre-keyboard height while the keyboard is open, body's own box stays as tall
+   as the old viewport while only its content shrinks to fit the new, smaller
+   visible area — leaving genuine scrollable overflow below the shrunk content.
+   The browser's native "scroll focused input into view" then scrolls that
+   overflow away, which is what actually drags the composer up past the top of
+   the visible viewport. Pinning html/body to the live visual viewport height
+   with overflow hidden removes that scrollable overflow entirely. */
 @media (max-width: 960px) {
+  html[data-keyboard-open='true'],
+  html[data-keyboard-open='true'] body {
+    height: var(--visual-viewport-height, 100dvh);
+    min-height: var(--visual-viewport-height, 100dvh);
+    overflow-y: hidden;
+  }
+
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen,
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen .aris-ia-shell,
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main {
@@ -875,13 +895,15 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
     overflow: hidden;
   }
 
+  /* 모바일 채팅 화면은 상단 앱 탑바를 렌더링하지 않으므로(단일 헤더로 병합됨)
+     더 이상 그 높이를 빼지 않는다. */
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main-scroll--project-chat-detail .pc-proto {
     height: 100%;
-    min-height: calc(var(--visual-viewport-height, 100dvh) - 48px);
+    min-height: var(--visual-viewport-height, 100dvh);
   }
 
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main-scroll--project-chat-detail .pc-proto .shell {
-    height: calc(var(--visual-viewport-height, 100dvh) - 48px);
+    height: var(--visual-viewport-height, 100dvh);
   }
 }
 

--- a/services/aris-web/app/styles/project-chat/history-preview.css
+++ b/services/aris-web/app/styles/project-chat/history-preview.css
@@ -994,3 +994,10 @@ html[data-theme='dark'] .pc-proto .chturn[data-open="true"] {
 .pc-proto .cmd-mini-pop__meta {
   font-size: 10.5px; color: var(--text-tertiary); font-family: var(--font-mono);
 }
+
+/* 모바일 채팅 헤더 병합 메뉴: 밀도 섹션과 앱 크롬(홈/설정/테마) 섹션 사이 구분선 */
+.pc-proto .ch-context-menu__section--divider {
+  margin-top: 4px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-subtle);
+}

--- a/services/aris-web/app/styles/ui-responsive.css
+++ b/services/aris-web/app/styles/ui-responsive.css
@@ -87,15 +87,14 @@
     animation: none;
   }
 
-  .app-shell-ia--chat-screen .m-top,
-  .pc-proto .ch,
-  .pc-proto .shell,
+  .pc-proto .shell__main > .tl,
   .pc-proto .cmp-pill__add,
   .pc-proto .cmp-pill__body {
     transition: none;
   }
 
   .pc-proto .cmp-pill,
+  .pc-proto .shell__main > .ch,
   .pc-proto[data-composer="expanded"] .shell__main > .cmp-wrap .cmp {
     animation: none;
   }
@@ -311,20 +310,26 @@
     padding: var(--sp-8);
   }
 
-  .pc-proto {
-    min-height: calc(var(--app-vh, 100dvh) - 48px);
+  /* 모바일 채팅 화면은 앱 탑바(.m-top)를 렌더링하지 않으므로(아래 참고)
+     더 이상 그 높이를 빼지 않는다. ia-shell.css의 더 구체적인
+     `.m-main-scroll--project-chat-detail .pc-proto` 규칙을 이겨야 하므로
+     동일한 선택자 체인으로 작성한다(파일 로드 순서상 이 파일이 나중이라
+     동률일 때 이 규칙이 이긴다). */
+  .m-main-scroll--project-chat-detail .pc-proto {
+    min-height: var(--app-vh, 100dvh);
   }
 
   .pc-parallel {
-    height: calc(var(--app-vh, 100dvh) - 48px);
+    height: var(--app-vh, 100dvh);
     min-height: 0;
   }
 
-  .pc-proto .shell {
-    /* 부모 min-height 기준의 % 해석에 기대지 않도록 명시 높이를 사용한다 */
-    height: calc(var(--app-vh, 100dvh) - 48px);
+  .m-main-scroll--project-chat-detail .pc-proto .shell {
+    /* 부모 min-height 기준의 % 해석에 기대지 않도록 명시 높이를 사용한다.
+       헤더 표시/숨김에 따라 흔들리지 않도록 상수로 고정한다(스크롤 시
+       공간 확보는 .tl의 padding-top 쪽에서 처리한다). */
+    height: var(--app-vh, 100dvh);
     min-height: 0;
-    transition: height 200ms var(--ease-smooth);
   }
 
   .pc-proto .ch {
@@ -430,37 +435,38 @@
     min-width: 0;
   }
 
-  /* 스크롤 다운 시 상단 크롬(채팅 헤더 + 앱 탑바) 자동 숨김 */
-  .pc-proto .ch {
-    transition: margin-top 200ms var(--ease-smooth), opacity 160ms var(--ease-smooth);
-  }
-
-  .pc-proto[data-chrome="hidden"] .ch {
-    margin-top: -53px;
-    opacity: 0;
-    pointer-events: none;
-  }
-
+  /* 모바일 채팅 화면은 앱 탑바(.m-top)와 채팅 헤더(.ch)를 한 줄로 병합한다.
+     탑바는 항상 렌더링하지 않고(스크롤과 무관, 상시), 탑바의 홈 이동/설정/
+     테마 기능은 .ch의 "More chat actions" 메뉴로 옮겨 기능 손실 없이 통합했다
+     (ProjectChatSurface의 AppChromeMenuItems 참고). */
   .app-shell-ia--chat-screen .m-top {
-    transition: margin-top 200ms var(--ease-smooth), opacity 160ms var(--ease-smooth);
+    display: none;
   }
 
-  /* :has() 미지원 브라우저에서는 탑바 숨김과 화면 확장을 함께 포기해
-     레이아웃 높이가 어긋나지 않게 한 쌍으로 게이트한다. */
-  @supports selector(:has(*)) {
-    .app-shell-ia--chat-screen:has(.pc-proto[data-chrome="hidden"]) .m-top {
-      margin-top: -49px;
-      opacity: 0;
-      pointer-events: none;
-    }
+  /* 스크롤 다운 시 채팅 헤더 자동 숨김. 헤더는 타임라인 위 오버레이로 띄워
+     (.shell__main 기준 position:absolute) 숨김/표시가 .shell__main이나 .tl의
+     박스 크기 자체를 흔들지 않게 한다 — 이전에는 .ch가 flex 흐름 안에서
+     margin-top으로 축소되며 형제인 .tl의 높이/화면 위치를 함께 바꿔
+     스크롤이 흔들리는 것처럼 보였다. 헤더가 실제로 차지하던 공간은 .tl의
+     padding-top으로만 표현하고, data-chrome 토글에 따라 그 값만 애니메이션한다.
+     헤더는 React 쪽에서 스크롤-숨김 시 아예 언마운트되어(true unmount) DOM에도
+     남지 않는다. */
+  .pc-proto .shell__main > .ch {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 22;
+    animation: pc-ch-fade-in 160ms var(--ease-smooth);
+  }
 
-    .pc-proto[data-chrome="hidden"] {
-      min-height: var(--app-vh, 100dvh);
-    }
+  .pc-proto .shell__main > .tl {
+    padding-top: var(--pc-header-height, 52px);
+    transition: padding-top 200ms var(--ease-smooth);
+  }
 
-    .pc-proto[data-chrome="hidden"] .shell {
-      height: var(--app-vh, 100dvh);
-    }
+  .pc-proto[data-chrome="hidden"] .shell__main > .tl {
+    padding-top: 0;
   }
 
   /* 입력 길이에 따른 auto-grow: 상한은 뷰포트의 30% (키보드 오픈 시 함께 줄어듦) */
@@ -660,5 +666,11 @@
 @keyframes pc-cmp-pill-spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes pc-ch-fade-in {
+  from {
+    opacity: 0;
   }
 }

--- a/services/aris-web/components/layout/AppChromeMenu.tsx
+++ b/services/aris-web/components/layout/AppChromeMenu.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Home, Monitor, Moon, MoreHorizontal, Settings, Sun } from 'lucide-react';
+import type { ThemeMode } from '@/lib/theme/clientTheme';
+
+const THEME_OPTIONS = [
+  { mode: 'system' as const, label: '시스템', Icon: Monitor },
+  { mode: 'light' as const, label: '라이트', Icon: Sun },
+  { mode: 'dark' as const, label: '다크', Icon: Moon },
+];
+
+/** 홈 이동(선택)/설정/테마 전환 항목. 독립 트리거를 가진 메뉴와 기존 메뉴에 얹는 용도 모두에서 쓴다. */
+export function AppChromeMenuItems({
+  onLogoHome,
+  onOpenSettings,
+  onSelect,
+  onThemeChange,
+  themeMode,
+}: {
+  onLogoHome?: () => void;
+  onOpenSettings: () => void;
+  onSelect: () => void;
+  onThemeChange: (mode: ThemeMode) => void;
+  themeMode: ThemeMode;
+}) {
+  return (
+    <>
+      {onLogoHome && (
+        <div className="m-context-menu__section">
+          <button
+            type="button"
+            role="menuitem"
+            className="m-context-menu__item"
+            onClick={() => { onSelect(); onLogoHome(); }}
+          >
+            <Home size={13} aria-hidden="true" />
+            <span>홈으로 이동</span>
+          </button>
+        </div>
+      )}
+      <div className="m-context-menu__section">
+        <button
+          type="button"
+          role="menuitem"
+          className="m-context-menu__item"
+          onClick={() => { onSelect(); onOpenSettings(); }}
+        >
+          <Settings size={13} aria-hidden="true" />
+          <span>설정</span>
+        </button>
+      </div>
+      <div className="m-context-menu__section">
+        <div className="m-context-menu__label">테마</div>
+        <div className="m-theme-toggle" role="group" aria-label="테마 선택">
+          {THEME_OPTIONS.map(({ mode, label, Icon }) => {
+            const active = themeMode === mode;
+            return (
+              <button
+                key={mode}
+                type="button"
+                role="menuitemradio"
+                className={`m-theme-toggle__item${active ? ' m-theme-toggle__item--active' : ''}`}
+                aria-checked={active}
+                aria-label={`${label} 테마`}
+                title={`${label} 테마`}
+                onClick={() => { onThemeChange(mode); onSelect(); }}
+              >
+                <Icon size={13} />
+                <span className="m-theme-toggle__label">{label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}
+
+/** 자체 트리거 버튼 + 드롭다운을 가진 독립형 앱 크롬 메뉴 (Topbar용). */
+export function AppChromeMenu({
+  onOpenSettings,
+  onThemeChange,
+  themeMode,
+}: {
+  onOpenSettings: () => void;
+  onThemeChange: (mode: ThemeMode) => void;
+  themeMode: ThemeMode;
+}) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const closeOnOutsidePointer = (event: MouseEvent) => {
+      if (menuRef.current?.contains(event.target as Node)) {
+        return;
+      }
+      setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', closeOnOutsidePointer);
+    document.addEventListener('keydown', closeOnEscape);
+    return () => {
+      document.removeEventListener('mousedown', closeOnOutsidePointer);
+      document.removeEventListener('keydown', closeOnEscape);
+    };
+  }, [open]);
+
+  return (
+    <div className="m-context-menu" ref={menuRef}>
+      <button
+        type="button"
+        className="m-context-menu__button"
+        aria-label="상단 헤더 메뉴"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <MoreHorizontal size={16} />
+      </button>
+      {open && (
+        <div className="m-context-menu__panel" role="menu" aria-label="상단 헤더 메뉴">
+          <AppChromeMenuItems
+            onOpenSettings={onOpenSettings}
+            onSelect={() => setOpen(false)}
+            onThemeChange={onThemeChange}
+            themeMode={themeMode}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/services/aris-web/components/project-chat/ProjectChatSurface.tsx
+++ b/services/aris-web/components/project-chat/ProjectChatSurface.tsx
@@ -102,6 +102,8 @@ import {
 import { GitActionMark } from '@/components/project-chat/helpers/actionMarks';
 import { useComposerAutoGrow } from '@/components/project-chat/helpers/useComposerAutoGrow';
 import { useMobileChatChrome } from '@/components/project-chat/helpers/useMobileChatChrome';
+import { AppChromeMenuItems } from '@/components/layout/AppChromeMenu';
+import type { ThemeMode } from '@/lib/theme/clientTheme';
 import { useProjectSkills } from '@/components/project-chat/helpers/useProjectSkills';
 import { useRecentSkills } from '@/components/project-chat/helpers/useRecentSkills';
 import { useSlashAutocomplete } from '@/components/project-chat/helpers/useSlashAutocomplete';
@@ -1183,12 +1185,16 @@ export function ProjectChatSurface({
   modelLabel,
   onBackToChatList,
   onChatOpen,
+  onLogoHome,
+  onOpenSettings,
+  onThemeChange,
   projectName,
   projectPath,
   recentPreview,
   selectedChatId,
   session,
   surfaceMode = 'full',
+  themeMode,
   tokenLabel,
 }: {
   fileCount: number;
@@ -1196,12 +1202,16 @@ export function ProjectChatSurface({
   modelLabel: string;
   onBackToChatList: () => void;
   onChatOpen: (chatId: string) => void;
+  onLogoHome?: () => void;
+  onOpenSettings?: () => void;
+  onThemeChange?: (mode: ThemeMode) => void;
   projectName: string;
   projectPath: string;
   recentPreview: string;
   selectedChatId: string | null;
   session: SessionSummary;
   surfaceMode?: ProjectChatSurfaceMode;
+  themeMode?: ThemeMode;
   tokenLabel: string;
 }) {
   const projectId = session.id;
@@ -1345,6 +1355,27 @@ export function ProjectChatSurface({
   const prototypeRef = useRef<HTMLDivElement | null>(null);
   const composerWrapRef = useRef<HTMLElement | null>(null);
   const composerInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const chatHeaderObserverRef = useRef<ResizeObserver | null>(null);
+  // 스크롤 시 헤더를 아예 언마운트하므로(true unmount) 일반 ref로는 옵저버를
+  // 붙일 시점을 놓친다. 콜백 ref로 마운트/언마운트마다 직접 연결·해제한다.
+  const setChatHeaderNode = useCallback((node: HTMLElement | null) => {
+    chatHeaderObserverRef.current?.disconnect();
+    chatHeaderObserverRef.current = null;
+    if (!node) {
+      return;
+    }
+    const syncHeaderHeight = () => {
+      const height = Math.ceil(node.getBoundingClientRect().height);
+      prototypeRef.current?.style.setProperty('--pc-header-height', `${height}px`);
+    };
+    syncHeaderHeight();
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+    const observer = new ResizeObserver(syncHeaderHeight);
+    observer.observe(node);
+    chatHeaderObserverRef.current = observer;
+  }, []);
   const isComposerInputFocused = useCallback(
     () => Boolean(composerInputRef.current) && document.activeElement === composerInputRef.current,
     [],
@@ -1354,6 +1385,7 @@ export function ProjectChatSurface({
     handleTimelineChromeScroll,
     isChromeHidden,
     isComposerCollapsed,
+    isMobileViewport,
     suppressChromeScroll,
   } = useMobileChatChrome({ isComposerInputFocused });
   useComposerAutoGrow(composerInputRef, prompt, !isComposerCollapsed);
@@ -2954,7 +2986,8 @@ export function ProjectChatSurface({
       <>
       <div className="shell">
         <main className="shell__main">
-          <header className="ch">
+          {!isChromeHidden && (
+          <header ref={setChatHeaderNode} className="ch">
             <button type="button" className="ch__menu ch__menu--visible" onClick={onBackToChatList} aria-label="Back to chats">
               <ChevronLeft size={18} />
             </button>
@@ -3006,11 +3039,25 @@ export function ProjectChatSurface({
                       <div className="ch-context-menu__label">액션 카드 밀도</div>
                       <DensityMenuList onSelect={() => setContextMenuOpen(false)} />
                     </div>
+                    {/* 모바일은 상단 앱 탑바를 렌더링하지 않으므로(1줄 헤더),
+                        홈 이동·설정·테마를 이 메뉴로 옮겨 기능 손실 없이 통합한다. */}
+                    {isMobileViewport && onOpenSettings && onThemeChange && (
+                      <div className="ch-context-menu__section ch-context-menu__section--divider">
+                        <AppChromeMenuItems
+                          onLogoHome={onLogoHome}
+                          onOpenSettings={onOpenSettings}
+                          onSelect={() => setContextMenuOpen(false)}
+                          onThemeChange={onThemeChange}
+                          themeMode={themeMode ?? 'system'}
+                        />
+                      </div>
+                    )}
                   </div>
                 )}
               </div>
             </div>
           </header>
+          )}
 
           <div className="tl" ref={timelineRef} onScroll={handleTimelineScroll}>
             <div className="tl__container">

--- a/services/aris-web/tests/designSystemV1Implementation.test.ts
+++ b/services/aris-web/tests/designSystemV1Implementation.test.ts
@@ -7,6 +7,7 @@ import { readAppStyles } from './helpers/readAppStyles';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const tokensCss = readFileSync(resolve(__dirname, '../app/styles/tokens.css'), 'utf8');
 const homeClient = readFileSync(resolve(__dirname, '../app/HomePageClient.tsx'), 'utf8');
+const appChromeMenu = readFileSync(resolve(__dirname, '../components/layout/AppChromeMenu.tsx'), 'utf8');
 const uiCss = readAppStyles();
 const header = readFileSync(resolve(__dirname, '../components/layout/Header.tsx'), 'utf8');
 const bottomNav = readFileSync(resolve(__dirname, '../components/layout/BottomNav.tsx'), 'utf8');
@@ -45,8 +46,6 @@ describe('ARIS design-system-v1 implementation', () => {
       'className="m-sb"',
       'className="m-top"',
       'className="m-top__right"',
-      'className="m-context-menu"',
-      'className="m-theme-toggle"',
       'className="home-orb"',
       'className="home-strip"',
       'home-proj__chats${className',
@@ -59,6 +58,12 @@ describe('ARIS design-system-v1 implementation', () => {
       'className="files-preview"',
     ].forEach((classFragment) => {
       expect(homeClient).toContain(classFragment);
+    });
+
+    // 테마/설정 메뉴는 채팅 헤더와 공유하기 위해 AppChromeMenu로 추출됐다
+    // (모바일 채팅 화면은 단일 헤더로 병합되어 앱 탑바를 별도로 렌더링하지 않는다).
+    ['className="m-context-menu"', 'className="m-theme-toggle"'].forEach((classFragment) => {
+      expect(appChromeMenu).toContain(classFragment);
     });
 
     [
@@ -89,13 +94,15 @@ describe('ARIS design-system-v1 implementation', () => {
   it('keeps the IA v2 topbar theme control wired to system, light, and dark modes', () => {
     expect(homeClient).toContain('readThemeMode');
     expect(homeClient).toContain('applyTheme');
-    expect(homeClient).toContain("'system' as const");
-    expect(homeClient).toContain("'light' as const");
-    expect(homeClient).toContain("'dark' as const");
-    expect(homeClient).toContain('시스템');
-    expect(homeClient).toContain('라이트');
-    expect(homeClient).toContain('다크');
-    expect(homeClient).toContain("aria-label=\"테마 선택\"");
+    // 실제 시스템/라이트/다크 옵션 목록은 AppChromeMenu(Topbar와 채팅 헤더가
+    // 공유하는 메뉴 컴포넌트)에 있다.
+    expect(appChromeMenu).toContain("'system' as const");
+    expect(appChromeMenu).toContain("'light' as const");
+    expect(appChromeMenu).toContain("'dark' as const");
+    expect(appChromeMenu).toContain('시스템');
+    expect(appChromeMenu).toContain('라이트');
+    expect(appChromeMenu).toContain('다크');
+    expect(appChromeMenu).toContain("aria-label=\"테마 선택\"");
     expect(homeClient).not.toContain('More actions');
   });
 

--- a/services/aris-web/tests/e2e/chat-chrome-collapse-debug.spec.ts
+++ b/services/aris-web/tests/e2e/chat-chrome-collapse-debug.spec.ts
@@ -125,15 +125,37 @@ test('스크롤 시 상단 크롬 숨김/복원과 컴포저 pill 축소·확장
   const timeline = page.locator('[data-project-chat-screen] .tl');
   const composerInput = page.locator('[data-project-chat-screen] .cmp-wrap .cmp__input');
 
-  // 초기 상태: 크롬 표시 + 컴포저 확장
+  // 초기 상태: 크롬 표시 + 컴포저 확장. 앱 탑바는 모바일 채팅 화면에서 항상
+  // 렌더링되지 않고(1줄 헤더 병합), 채팅 헤더(.ch)가 유일한 헤더다.
   await expect(chatScreen).toHaveAttribute('data-chrome', 'visible');
   await expect(chatScreen).toHaveAttribute('data-composer', 'expanded');
-  await expect(topbar).toBeVisible();
+  await expect(topbar).toBeHidden();
+  await expect(chatHeader).toHaveCount(1);
+  await expect(chatHeader).toBeVisible();
 
+  // 앱 탑바가 사라진 대신, 홈 이동/설정/테마가 채팅 헤더의 More 메뉴로
+  // 기능 손실 없이 통합되어 있어야 한다.
+  await removeDevOverlays(page);
+  await page.locator('[data-project-chat-screen] .ch__action[aria-label="More chat actions"]').click();
+  await expect(page.locator('.ch-context-menu')).toBeVisible();
+  const mergedMenuItems = page.locator('.ch-context-menu .m-context-menu__item');
+  await expect(mergedMenuItems).toContainText(['홈으로 이동', '설정']);
+  await expect(page.locator('.ch-context-menu .m-theme-toggle__item')).toHaveCount(3);
+  await page.screenshot({ path: 'test-results/chat-single-header-menu.png' });
+  await page.locator('[data-project-chat-screen] .ch__action[aria-label="More chat actions"]').click();
+  await expect(page.locator('.ch-context-menu')).toHaveCount(0);
+
+  // 타임라인 박스 자체(top/height)는 헤더 표시 여부와 무관하게 항상 고정이어야
+  // 한다 — 헤더는 오버레이이고 확보 공간은 padding-top으로만 표현되므로,
+  // 스크롤 중 .tl의 화면상 위치가 흔들리지 않는다(= 스크롤이 움직이는 버그 없음).
+  const fixedTimelineTop = await timeline.evaluate((node) => Math.round(node.getBoundingClientRect().top));
   const initialTimelineHeight = await timeline.evaluate((node) => node.clientHeight);
   // 컴포저는 오버레이라서 확보 공간은 타임라인 하단 패딩(--pc-composer-height 연동)으로 측정
   const expandedTimelinePadding = await timeline.evaluate(
     (node) => Number.parseFloat(window.getComputedStyle(node).paddingBottom),
+  );
+  const expandedTimelinePaddingTop = await timeline.evaluate(
+    (node) => Number.parseFloat(window.getComputedStyle(node).paddingTop),
   );
 
   // 스크롤 가능하도록 스페이서 주입 후 최상단 근처로 이동
@@ -157,31 +179,36 @@ test('스크롤 시 상단 크롬 숨김/복원과 컴포저 pill 축소·확장
   await timelineScrollBy(page, 200);
   await expect(chatScreen).toHaveAttribute('data-chrome', 'hidden');
   await expect(chatScreen).toHaveAttribute('data-composer', 'collapsed');
-  // opacity는 트랜지션 속성이라 headless 환경에서 중간값에 머물 수 있으므로
-  // 즉시 적용되는 pointer-events로 숨김 상태를 판정한다.
-  await expect
-    .poll(() => topbar.evaluate((node) => window.getComputedStyle(node).pointerEvents))
-    .toBe('none');
-  await expect
-    .poll(() => chatHeader.evaluate((node) => window.getComputedStyle(node).pointerEvents))
-    .toBe('none');
+  // 헤더는 숨김 시 화면 밖으로 옮기는 게 아니라 아예 언마운트된다(true unmount).
+  await expect(chatHeader).toHaveCount(0);
 
-  // pill이 나타나고, 타임라인이 실제로 세로 공간을 얻었는지 확인
+  // pill이 나타나고, 타임라인이 실제로 세로 공간을 얻었는지 확인.
+  // 타임라인의 박스 자체(top/height)는 그대로이고 padding만 줄어야 한다 —
+  // 헤더/컴포저 표시 여부가 .tl의 화면상 위치를 흔들면 안 된다.
   await expect(page.locator('[data-project-chat-screen] .cmp-pill')).toBeVisible();
   await page.waitForTimeout(400);
   const collapsedTimelinePadding = await timeline.evaluate(
     (node) => Number.parseFloat(window.getComputedStyle(node).paddingBottom),
   );
-  const hiddenTimelineHeight = await timeline.evaluate((node) => node.clientHeight);
+  const collapsedTimelinePaddingTop = await timeline.evaluate(
+    (node) => Number.parseFloat(window.getComputedStyle(node).paddingTop),
+  );
+  const collapsedTimelineTop = await timeline.evaluate((node) => Math.round(node.getBoundingClientRect().top));
+  const collapsedTimelineHeight = await timeline.evaluate((node) => node.clientHeight);
   expect(collapsedTimelinePadding).toBeLessThan(expandedTimelinePadding - 40);
-  expect(hiddenTimelineHeight).toBeGreaterThan(initialTimelineHeight + 80);
+  expect(collapsedTimelinePaddingTop).toBeLessThan(expandedTimelinePaddingTop - 20);
+  expect(collapsedTimelineTop).toBe(fixedTimelineTop);
+  expect(collapsedTimelineHeight).toBe(initialTimelineHeight);
   await removeDevOverlays(page);
   await page.screenshot({ path: 'test-results/chat-chrome-collapsed.png' });
 
-  // 위로 스크롤 → 크롬 복원, 컴포저는 축소 유지
+  // 위로 스크롤 → 크롬 복원(헤더 재마운트), 컴포저는 축소 유지
   await timelineScrollBy(page, -120);
   await expect(chatScreen).toHaveAttribute('data-chrome', 'visible');
   await expect(chatScreen).toHaveAttribute('data-composer', 'collapsed');
+  await expect(chatHeader).toHaveCount(1);
+  await expect(chatHeader).toBeVisible();
+  expect(await timeline.evaluate((node) => Math.round(node.getBoundingClientRect().top))).toBe(fixedTimelineTop);
 
   // pill 본문 터치 → 확장 + 입력 포커스
   await removeDevOverlays(page);
@@ -318,4 +345,51 @@ test('스크롤 시 상단 크롬 숨김/복원과 컴포저 pill 축소·확장
   await composerInput.fill('/zzz-not-a-skill');
   await page.waitForTimeout(300);
   await expect(page.locator('[data-project-chat-screen] .cmp-slash')).toHaveCount(0);
+});
+
+test('컴포저 포커스 후 키보드가 열려도 body에 스크롤 가능한 여백이 생기지 않는다', async ({ page }) => {
+  const projectId = process.env.CHAT_CHROME_PROJECT_ID;
+  test.skip(!projectId, 'CHAT_CHROME_PROJECT_ID is required');
+
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await login(page);
+  await openProjectChatScreen(page, projectId!);
+  await removeDevOverlays(page);
+
+  const composerInput = page.locator('[data-project-chat-screen] .cmp-wrap .cmp__input');
+  await composerInput.click();
+  await page.waitForTimeout(100);
+
+  // 실제 모바일 키보드가 열리는 것을 흉내낸다: visualViewport.height를 여러
+  // 단계로 줄여가며 resize 이벤트를 발생시킨다(ViewportHeightSync가 구독).
+  for (const height of [664, 560, 460, 400, 380, 380]) {
+    await page.evaluate((h) => {
+      Object.defineProperty(window.visualViewport, 'height', { get: () => h, configurable: true });
+      window.visualViewport!.dispatchEvent(new Event('resize'));
+    }, height);
+    await page.waitForTimeout(50);
+  }
+  await page.waitForTimeout(900);
+
+  const state = await page.evaluate(() => ({
+    keyboardOpen: document.documentElement.dataset.keyboardOpen,
+    bodyScrollHeight: document.body.scrollHeight,
+    visualViewportHeight: window.visualViewport?.height,
+    scrollY: window.scrollY,
+  }));
+  expect(state.keyboardOpen).toBe('true');
+  // body의 실제 스크롤 가능 높이가 라이브 visualViewport 높이를 초과하면 안 된다
+  // (초과분이 곧 브라우저의 네이티브 "포커스 요소 스크롤"이 컴포저를 화면 밖으로
+  // 끌고 가는 여지였다).
+  expect(state.bodyScrollHeight).toBeLessThanOrEqual((state.visualViewportHeight ?? 0) + 1);
+  expect(state.scrollY).toBe(0);
+
+  const cmpRect = await page.locator('[data-project-chat-screen] .cmp-wrap .cmp').evaluate((node) => {
+    const r = node.getBoundingClientRect();
+    return { top: Math.round(r.top), bottom: Math.round(r.bottom) };
+  });
+  // 컴포저가 화면 맨 위로 끌려가지 않고, 축소된 뷰포트 안에서 하단 근처에 남아있어야 한다
+  expect(cmpRect.top).toBeGreaterThan(50);
+  expect(cmpRect.bottom).toBeLessThanOrEqual((state.visualViewportHeight ?? 0) + 1);
+  await page.screenshot({ path: 'test-results/chat-keyboard-open-no-overflow.png' });
 });

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -13,6 +13,7 @@ const projectRunStatusChip = readFileSync(resolve(__dirname, '../components/proj
 const projectChatEventsHelper = readFileSync(resolve(__dirname, '../components/project-chat/helpers/projectChatEvents.ts'), 'utf8');
 const actionMarksHelper = readFileSync(resolve(__dirname, '../components/project-chat/helpers/actionMarks.tsx'), 'utf8');
 const commandTokensHelper = readFileSync(resolve(__dirname, '../components/project-chat/helpers/commandTokens.tsx'), 'utf8');
+const appChromeMenuSource = readFileSync(resolve(__dirname, '../components/layout/AppChromeMenu.tsx'), 'utf8');
 const uiCss = readAppStyles();
 const terminalRoute = readFileSync(resolve(__dirname, '../app/api/runtime/sessions/[sessionId]/terminal/route.ts'), 'utf8');
 
@@ -45,21 +46,21 @@ describe('project list surface', () => {
     const topbarStart = homeClient.indexOf('function Topbar({');
     const homeOrbStart = homeClient.indexOf('function HomeOrb()');
     const topbarSource = homeClient.slice(topbarStart, homeOrbStart);
-    const menuStart = topbarSource.indexOf('className="m-context-menu"');
-    const menuEnd = topbarSource.indexOf('</header>', menuStart);
-    const menuSource = topbarSource.slice(menuStart, menuEnd);
 
-    expect(menuSource).toContain('className="m-context-menu"');
-    expect(menuSource).toContain('className="m-context-menu__button"');
-    expect(menuSource).toContain('aria-label="상단 헤더 메뉴"');
-    expect(menuSource).toContain('aria-haspopup="menu"');
+    // Topbar는 설정/테마 메뉴 자체를 그리지 않고 AppChromeMenu(채팅 헤더와
+    // 공유하는 컴포넌트)에 위임한다 — 로직 중복 없이 두 헤더가 같은 메뉴를 쓴다.
     expect(topbarSource).toContain('onOpenSettings: () => void;');
-    expect(topbarSource).toContain('const handleOpenSettings = () => {');
-    expect(menuSource).toContain('className="m-context-menu__item"');
-    expect(menuSource).toContain('설정');
-    expect(menuSource).toContain('className="m-theme-toggle"');
-    expect(menuSource).toContain('aria-label="테마 선택"');
+    expect(topbarSource).toContain('<AppChromeMenu');
     expect(topbarSource).not.toContain('New project');
+
+    expect(appChromeMenuSource).toContain('className="m-context-menu"');
+    expect(appChromeMenuSource).toContain('className="m-context-menu__button"');
+    expect(appChromeMenuSource).toContain('aria-label="상단 헤더 메뉴"');
+    expect(appChromeMenuSource).toContain('aria-haspopup="menu"');
+    expect(appChromeMenuSource).toContain('className="m-context-menu__item"');
+    expect(appChromeMenuSource).toContain('설정');
+    expect(appChromeMenuSource).toContain('className="m-theme-toggle"');
+    expect(appChromeMenuSource).toContain('aria-label="테마 선택"');
     expect(uiCss).toContain('.m-context-menu__panel');
   });
 
@@ -693,9 +694,17 @@ describe('project list surface', () => {
     expect(homeClient).toContain("className={`app-shell app-shell-ia${shouldShowBottomNav ? '' : ' app-shell-ia--chat-screen'}${projectSurfaceMode === 'panel' ? ' app-shell-ia--project-panel' : ''}`}");
     expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.app-shell-ia--chat-screen\s*\{[^}]*padding-bottom:\s*0;/s);
     expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.app-shell-ia--chat-screen \.aris-ia-shell\s*\{[^}]*min-height:\s*var\(--app-vh,\s*100dvh\);/s);
-    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.pc-proto\s*\{[^}]*min-height:\s*calc\(var\(--app-vh,\s*100dvh\) - 48px\);/s);
-    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.pc-proto \.shell\s*\{[^}]*height:\s*calc\(var\(--app-vh,\s*100dvh\) - 48px\);[^}]*min-height:\s*0;/s);
-    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.pc-proto\[data-chrome="hidden"\] \.shell\s*\{[^}]*height:\s*var\(--app-vh,\s*100dvh\);/s);
+    // 모바일 채팅 화면은 앱 탑바를 항상 렌더링하지 않으므로(1줄 헤더 병합)
+    // .pc-proto/.shell 높이 계산에서 더 이상 그 48px을 빼지 않는다.
+    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.m-main-scroll--project-chat-detail \.pc-proto\s*\{[^}]*min-height:\s*var\(--app-vh,\s*100dvh\);/s);
+    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.m-main-scroll--project-chat-detail \.pc-proto \.shell\s*\{[^}]*height:\s*var\(--app-vh,\s*100dvh\);[^}]*min-height:\s*0;/s);
+    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.app-shell-ia--chat-screen \.m-top\s*\{[^}]*display:\s*none;/s);
+    // 채팅 헤더는 스크롤 숨김 시 이동시키지 않고 언마운트되며(React 쪽), 표시
+    // 중에는 타임라인 위 오버레이라 .tl/.shell__main의 박스 크기를 흔들지 않는다.
+    // 헤더가 차지하던 공간은 .tl의 padding-top으로만 표현되고 그 값만 토글된다.
+    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.pc-proto \.shell__main > \.ch\s*\{[^}]*position:\s*absolute;/s);
+    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.pc-proto \.shell__main > \.tl\s*\{[^}]*padding-top:\s*var\(--pc-header-height,\s*52px\);/s);
+    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.pc-proto\[data-chrome="hidden"\] \.shell__main > \.tl\s*\{[^}]*padding-top:\s*0;/s);
     expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.pc-proto \.tl\s*\{[^}]*min-height:\s*0;/s);
     expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.pc-proto \.cmp__top\s*\{[^}]*flex-direction:\s*row;[^}]*overflow-x:\s*auto;/s);
     expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.pc-proto \.cmp__toolbar\s*\{[^}]*flex-direction:\s*row;/s);


### PR DESCRIPTION
## 변경 요약

모바일 채팅 화면에서 보고된 4가지 문제를 수정합니다.

### 1. 상단 헤더 2줄 → 1줄 병합
모바일 채팅 화면에서 앱 탑바(`.m-top`)를 더 이상 렌더링하지 않습니다(스크롤과 무관하게 항상). 탑바가 갖고 있던 홈 이동/설정/테마 기능은 신규 공유 컴포넌트 `AppChromeMenu`로 추출해 채팅 헤더(`.ch`)의 기존 "More chat actions"(⋯) 드롭다운에 통합했습니다 — **기능 손실 없이** 헤더가 1줄(52px)로 줄어듭니다. `Topbar`도 같은 컴포넌트를 재사용하도록 리팩터링했고, 데스크톱은 변경 없이 기존 2줄 레이아웃을 유지합니다(모바일에만 스코프).

### 2. 헤더 등장 시 화면이 움직이는 버그
`.ch`를 flex 흐름에서 빼내 타임라인 위 절대 위치 오버레이로 승격했습니다. 기존에는 헤더가 `margin-top`으로 축소되며 형제인 `.shell`/`.tl`의 박스 크기와 화면상 위치를 함께 흔들어 스크롤이 움직이는 것처럼 보였습니다. 이제 헤더 표시/숨김은 `.tl`의 `padding-top`만 토글하고, `.tl` 자신의 박스(top/height)는 항상 고정입니다.

### 3. 헤더 숨김 시 미표시가 아니라 완전 제거
스크롤로 숨겨진 헤더를 화면 밖으로 옮기는 대신 React 조건부 렌더링으로 실제 DOM에서 제거합니다(true unmount). 헤더 높이는 콜백 ref + `ResizeObserver`로 측정해 `--pc-header-height`로 노출하고, `.tl`의 `padding-top`이 그 값을 참조합니다.

### 4. 컴포저 터치 시 뷰포트가 확장되고 컴포저가 맨 위로 밀리는 버그
**근본 원인** (Playwright로 실측 확인): `reset.css`의 `html/body`는 `overflow-x: hidden`만 지정해 CSS 스펙상 `overflow-y`가 `auto`로 계산되고, `min-height`는 `--app-vh`(키보드 오픈 중 이전 높이로 고정됨)를 따릅니다. 키보드가 열리면 body 박스는 예전 높이(예 844px)에 그대로 머무는데 실제 보이는 뷰포트는 축소되어(예 380px) 최대 284px의 스크롤 가능한 여백이 생기고, 브라우저의 네이티브 "포커스 요소 스크롤"이 이 여백을 없애려 페이지를 끌어올리며 컴포저가 화면 위로 밀려났습니다.

수정: 키보드 오픈 시(`data-keyboard-open`) `html/body`도 `--visual-viewport-height`로 고정하고 `overflow-y: hidden`을 추가해 그 여백 자체를 제거했습니다.

## 검증 방법
CLAUDE.md 지침에 따라 코드 추정 대신 Playwright로 실제 런타임 상태(`scrollHeight`, `--app-vh`, `getBoundingClientRect` 등)를 측정해 각 근본 원인을 먼저 확인한 뒤 수정했습니다.
- Playwright + 모의 `visualViewport` 축소로 body 여백(844 vs 380) 확인 → 수정 후 정확히 일치(380=380) 확인
- `.tl` 박스의 `top`이 스크롤 전체 구간에서 불변임을 실측(이전엔 헤더/셸 리사이즈로 흔들렸을 값)
- 헤더 `chInDom` true→false→true 전환(true unmount + 재마운트) 확인

## 검증 결과
- `tsc --noEmit` ✅ (양 서비스) · `next lint` 신규 경고 0 ✅ · `git diff --check` ✅
- aris-web vitest 전체 121개 파일 / 609개 테스트 통과 (헤더 구조 변경에 맞춰 stale 단언 3건 갱신)
- Playwright e2e `chat-chrome-collapse-debug.spec.ts` — mobile-chromium/mobile-webkit 양쪽 모두 기존 테스트 + 신규 헤더 단언 + 신규 키보드-오픈 테스트까지 통과
- 데스크톱(1440×900) 수동 확인: 2줄 헤더 그대로, `.ch`는 `position: static` 유지 — 모바일 전용 변경임을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbeRFoKWdoefKCvECrNfkt
