### PR TITLE
fix(web): 모바일 키보드 오픈 시 컴포저가 화면 위로 밀리는 경합 조건 해소

### DIFF
--- a/services/aris-web/app/layout.tsx
+++ b/services/aris-web/app/layout.tsx
@@ -115,6 +115,10 @@ export const viewport: Viewport = {
   maximumScale: 1,
   userScalable: false,
   viewportFit: 'cover',
+  // Android/Chrome: 키보드가 열릴 때 레이아웃 뷰포트 자체를 줄여서(visual
+  // viewport가 아니라) 100dvh 등 CSS 단위가 자연스럽게 따라가게 한다.
+  // iOS Safari는 이 속성을 지원하지 않아 무시되므로 부작용이 없다.
+  interactiveWidget: 'resizes-content',
 };
 
 export default function RootLayout({

--- a/services/aris-web/app/styles/ia-shell.css
+++ b/services/aris-web/app/styles/ia-shell.css
@@ -859,39 +859,46 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
   min-height: 0;
 }
 
-/* Mobile + on-screen keyboard open: fit the whole chat screen to the VISIBLE
-   viewport so the composer pins directly above the keyboard instead of forcing a
-   page scroll. ViewportHeightSync intentionally locks --app-vh to the pre-keyboard
-   height (to avoid reflow on the legacy surface), so the redesigned chat surface
-   must switch to --visual-viewport-height, which does shrink with the keyboard.
-   Without this, the document stays full height while only the reduced area is
-   visible, and the browser scrolls the focused composer up to the top.
+/* 모바일 키보드가 열려 있는 동안만 채팅 화면을 실제 보이는 뷰포트에 고정한다.
+   (평상시에는 잠그지 않는다 — layout.css가 모바일에서 .app-shell-ia--chat-screen을
+   의도적으로 overflow:visible/height:auto로 두는데, 이는 iOS Safari 주소창이
+   스크롤에 반응해 자동 숨김되는 UX를 위한 것이다. 그 동작을 깨지 않도록 이 잠금은
+   키보드가 열려 있는 좁은 구간에만 적용한다.)
 
-   Critically this must also cover html/body themselves: reset.css sets
-   `overflow-x: hidden` on them without an explicit overflow-y, and per the CSS
-   Overflow spec a `visible` overflow-y paired with a non-visible overflow-x is
-   computed as `auto` — so html/body are actually vertically scrollable. Since
-   both use `min-height: var(--app-vh, 100dvh)` and --app-vh stays frozen at the
-   pre-keyboard height while the keyboard is open, body's own box stays as tall
-   as the old viewport while only its content shrinks to fit the new, smaller
-   visible area — leaving genuine scrollable overflow below the shrunk content.
-   The browser's native "scroll focused input into view" then scrolls that
-   overflow away, which is what actually drags the composer up past the top of
-   the visible viewport. Pinning html/body to the live visual viewport height
-   with overflow hidden removes that scrollable overflow entirely. */
-@media (max-width: 960px) {
+   data-keyboard-open은 ViewportHeightSync가 계산하며, 이제 포커스 시점에
+   낙관적으로(실제 리사이즈를 기다리지 않고) 먼저 true가 된다 — 그 이유는
+   아래에 있다.
+
+   reset.css가 html/body에 overflow-x만 지정해 overflow-y가 스펙상 auto로
+   계산되고, min-height는 키보드가 열린 동안 이전 높이에 고정되는 --app-vh를
+   따른다. 그래서 키보드가 열리면 body 박스는 이전 높이에 머무는데 실제 보이는
+   영역은 줄어들어 스크롤 가능한 여백이 생기고, 네이티브 "포커스 요소를 화면에
+   보이도록 스크롤"이 그 여백을 없애려 페이지를 끌어올린다 — 이게 컴포저가
+   화면 위로 밀려 올라가는 현상의 정체다.
+
+   이 CSS 잠금 자체는 이미 정확하지만(실측으로 검증됨), 실기기에서 여전히
+   재현된 이유는 타이밍 경합으로 보인다: --visual-viewport-height 기반
+   data-keyboard-open은 visualViewport의 resize 이벤트(키보드 애니메이션이
+   시작된 "이후"에만 발생)를 기다려야 true가 되는데, iOS의 네이티브 스크롤은
+   포커스 시점에 훨씬 더 즉각적으로 실행될 수 있다. ViewportHeightSync는 이제
+   포커스 이벤트에서 실제 인셋을 측정하기 전에 곧바로 낙관적으로 잠가서 이
+   경합 자체를 없앤다(components/layout/ViewportHeightSync.tsx 참고). */
+@media (max-width: 767px) {
   html[data-keyboard-open='true'],
   html[data-keyboard-open='true'] body {
+    position: fixed;
+    inset: 0;
+    top: var(--visual-viewport-offset-top, 0px);
     height: var(--visual-viewport-height, 100dvh);
-    min-height: var(--visual-viewport-height, 100dvh);
-    overflow-y: hidden;
+    min-height: 0;
+    overflow: hidden;
   }
 
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen,
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen .aris-ia-shell,
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main {
     height: var(--visual-viewport-height, 100dvh);
-    min-height: var(--visual-viewport-height, 100dvh);
+    min-height: 0;
     overflow: hidden;
   }
 
@@ -899,11 +906,18 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
      더 이상 그 높이를 빼지 않는다. */
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main-scroll--project-chat-detail .pc-proto {
     height: 100%;
-    min-height: var(--visual-viewport-height, 100dvh);
+    min-height: 0;
   }
 
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main-scroll--project-chat-detail .pc-proto .shell {
     height: var(--visual-viewport-height, 100dvh);
+  }
+
+  /* 컴포저 auto-grow 상한도 얼어붙은 --app-vh가 아니라 실제 보이는 높이를
+     기준으로 삼아, 키보드가 열린 좁은 화면에서 입력창이 과도하게 커지지
+     않게 한다. */
+  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .pc-proto .cmp__input {
+    max-height: min(200px, calc(var(--visual-viewport-height, 100dvh) * 0.3));
   }
 }
 

--- a/services/aris-web/app/styles/ui-responsive.css
+++ b/services/aris-web/app/styles/ui-responsive.css
@@ -469,7 +469,10 @@
     padding-top: 0;
   }
 
-  /* 입력 길이에 따른 auto-grow: 상한은 뷰포트의 30% (키보드 오픈 시 함께 줄어듦) */
+  /* 입력 길이에 따른 auto-grow: 상한은 뷰포트의 30%.
+     --app-vh는 키보드가 열린 동안 이전 높이로 고정되므로 실제로는 따라 줄지
+     않는다 — 키보드 중 축소는 ia-shell.css의 data-keyboard-open 규칙이
+     --visual-viewport-height로 override한다. */
   .pc-proto .cmp__input {
     padding: 11px 14px;
     min-height: 44px;

--- a/services/aris-web/components/layout/ViewportHeightSync.tsx
+++ b/services/aris-web/components/layout/ViewportHeightSync.tsx
@@ -10,6 +10,13 @@ const KEYBOARD_INSET_THRESHOLD_DEFAULT_PX = 120;
 // 입력 요소가 포커스 상태일 때는 키보드일 가능성이 높으므로 임계값을 낮춰
 // 작은 가상 키보드/부분 키보드/키보드 애니메이션 중간 상태에서도 inset이 적용되도록 한다.
 const KEYBOARD_INSET_THRESHOLD_FOCUSED_PX = 60;
+// 포커스 시점에 곧바로 data-keyboard-open을 낙관적으로 켜 두는 기간(ms).
+// visualViewport의 resize 이벤트는 키보드 애니메이션이 "시작된 이후"에만
+// 도착하는데, iOS/Android의 네이티브 "포커스 요소를 화면에 보이도록 스크롤"은
+// 포커스 시점에 훨씬 즉각적으로 실행될 수 있다. resize를 기다렸다가 잠그면
+// 그 경합에서 항상 늦으므로, 포커스 이벤트 자체에서 곧장 잠근다. 실제 인셋
+// 측정(재sync 스케줄과 동일하게 100/300/600ms)이 이 창 안에서 이어받는다.
+const OPTIMISTIC_KEYBOARD_LOCK_MS = 700;
 
 const isTextInputElement = (element: Element | null): boolean => {
   if (!element) return false;
@@ -30,6 +37,7 @@ export function ViewportHeightSync() {
     const root = document.documentElement;
     let lastNoKeyboardHeight = window.visualViewport?.height ?? window.innerHeight;
     let lastInnerWidth = window.innerWidth;
+    let optimisticKeyboardOpenUntil = 0;
     let previousMetrics: {
       appViewportHeight: number;
       height: number;
@@ -70,7 +78,8 @@ export function ViewportHeightSync() {
       const threshold = focusedTextInput
         ? KEYBOARD_INSET_THRESHOLD_FOCUSED_PX
         : KEYBOARD_INSET_THRESHOLD_DEFAULT_PX;
-      const keyboardOpen = bottomInset > threshold;
+      const withinOptimisticWindow = performance.now() < optimisticKeyboardOpenUntil;
+      const keyboardOpen = bottomInset > threshold || withinOptimisticWindow;
       const keyboardInset = keyboardOpen ? bottomInset : 0;
       const visualViewportBottomInset = keyboardOpen ? 0 : bottomInset;
 
@@ -115,6 +124,7 @@ export function ViewportHeightSync() {
           keyboardOpen,
           threshold,
           focusedTextInput,
+          withinOptimisticWindow,
         },
       });
       if (metricsChanged) {
@@ -146,6 +156,10 @@ export function ViewportHeightSync() {
       if (!isTextInputElement(event.target as Element | null)) {
         return;
       }
+      // 실제 visualViewport resize를 기다리지 않고 포커스 시점에 곧바로
+      // 낙관적으로 잠근다 — 네이티브 스크롤과의 경합에서 이겨야 하므로,
+      // 아직 키보드 인셋을 측정하지 못했더라도 먼저 잠그고 본다.
+      optimisticKeyboardOpenUntil = performance.now() + OPTIMISTIC_KEYBOARD_LOCK_MS;
       clearFocusResyncTimeouts();
       updateViewportHeight('document:focusin');
       [100, 300, 600].forEach((delay) => {
@@ -159,6 +173,9 @@ export function ViewportHeightSync() {
       if (!isTextInputElement(event.target as Element | null)) {
         return;
       }
+      // 낙관적 잠금을 즉시 해제한다 — 실제로 키보드가 열려 있었다면 곧이어
+      // 실행되는 updateViewportHeight가 측정값으로 다시 true를 확인해 준다.
+      optimisticKeyboardOpenUntil = 0;
       clearFocusResyncTimeouts();
       // 키보드가 닫히는 애니메이션도 한 번에 끝나지 않을 수 있어 같은 패턴으로 재sync.
       updateViewportHeight('document:focusout');

--- a/services/aris-web/tests/e2e/chat-chrome-collapse-debug.spec.ts
+++ b/services/aris-web/tests/e2e/chat-chrome-collapse-debug.spec.ts
@@ -356,17 +356,39 @@ test('컴포저 포커스 후 키보드가 열려도 body에 스크롤 가능한
   await openProjectChatScreen(page, projectId!);
   await removeDevOverlays(page);
 
+  // 포커스 전: 평상시 page-scroll 모델이 유지되어야 한다(iOS 주소창 자동 숨김 UX 보존).
+  const beforeFocus = await page.evaluate(() => ({
+    keyboardOpen: document.documentElement.dataset.keyboardOpen,
+    bodyPosition: getComputedStyle(document.body).position,
+  }));
+  expect(beforeFocus.keyboardOpen).toBe('false');
+  expect(beforeFocus.bodyPosition).toBe('static');
+
   const composerInput = page.locator('[data-project-chat-screen] .cmp-wrap .cmp__input');
   await composerInput.click();
-  await page.waitForTimeout(100);
 
-  // 실제 모바일 키보드가 열리는 것을 흉내낸다: visualViewport.height를 여러
-  // 단계로 줄여가며 resize 이벤트를 발생시킨다(ViewportHeightSync가 구독).
-  for (const height of [664, 560, 460, 400, 380, 380]) {
-    await page.evaluate((h) => {
+  // 리사이즈 이벤트를 단 하나도 보내지 않은 채 곧바로 확인한다: 실기기에서
+  // iOS의 네이티브 "포커스 요소 스크롤"은 visualViewport.resize보다 먼저 실행될
+  // 수 있으므로, 우리 쪽 잠금도 resize를 기다리지 않고 포커스만으로 즉시 걸려야
+  // 그 경합에서 이길 수 있다(ViewportHeightSync의 낙관적 잠금 참고).
+  const immediatelyAfterFocus = await page.evaluate(() => document.documentElement.dataset.keyboardOpen);
+  expect(immediatelyAfterFocus).toBe('true');
+
+  // 실제 모바일 키보드가 열리는 것을 흉내낸다: visualViewport.height/offsetTop을
+  // 여러 단계로 바꿔가며 resize 이벤트를 발생시킨다(ViewportHeightSync가 구독).
+  // offsetTop도 함께 변화시켜, 키보드 애니메이션 중 주소창 상태 변화로
+  // visualViewport의 top이 밀리는 경우까지 보정되는지 확인한다.
+  for (const { height, offsetTop } of [
+    { height: 664, offsetTop: 0 },
+    { height: 460, offsetTop: 20 },
+    { height: 380, offsetTop: 34 },
+    { height: 380, offsetTop: 34 },
+  ]) {
+    await page.evaluate(({ h, o }) => {
       Object.defineProperty(window.visualViewport, 'height', { get: () => h, configurable: true });
+      Object.defineProperty(window.visualViewport, 'offsetTop', { get: () => o, configurable: true });
       window.visualViewport!.dispatchEvent(new Event('resize'));
-    }, height);
+    }, { h: height, o: offsetTop });
     await page.waitForTimeout(50);
   }
   await page.waitForTimeout(900);
@@ -374,10 +396,17 @@ test('컴포저 포커스 후 키보드가 열려도 body에 스크롤 가능한
   const state = await page.evaluate(() => ({
     keyboardOpen: document.documentElement.dataset.keyboardOpen,
     bodyScrollHeight: document.body.scrollHeight,
+    bodyPosition: getComputedStyle(document.body).position,
+    bodyTop: getComputedStyle(document.body).top,
     visualViewportHeight: window.visualViewport?.height,
+    visualViewportOffsetTop: window.visualViewport?.offsetTop ?? 0,
     scrollY: window.scrollY,
   }));
   expect(state.keyboardOpen).toBe('true');
+  expect(state.bodyPosition).toBe('fixed');
+  // visualViewport의 top이 밀린 만큼 body도 함께 보정되어야, 고정 레이아웃과
+  // 실제 보이는 영역의 기준점이 어긋나지 않는다.
+  expect(state.bodyTop).toBe(`${state.visualViewportOffsetTop}px`);
   // body의 실제 스크롤 가능 높이가 라이브 visualViewport 높이를 초과하면 안 된다
   // (초과분이 곧 브라우저의 네이티브 "포커스 요소 스크롤"이 컴포저를 화면 밖으로
   // 끌고 가는 여지였다).
@@ -390,6 +419,21 @@ test('컴포저 포커스 후 키보드가 열려도 body에 스크롤 가능한
   });
   // 컴포저가 화면 맨 위로 끌려가지 않고, 축소된 뷰포트 안에서 하단 근처에 남아있어야 한다
   expect(cmpRect.top).toBeGreaterThan(50);
-  expect(cmpRect.bottom).toBeLessThanOrEqual((state.visualViewportHeight ?? 0) + 1);
+  expect(cmpRect.bottom).toBeLessThanOrEqual((state.visualViewportHeight ?? 0) + state.visualViewportOffsetTop + 1);
   await page.screenshot({ path: 'test-results/chat-keyboard-open-no-overflow.png' });
+
+  // blur 후에는 낙관적 잠금과 실측 상태 모두 해제되어 평상시 모델로 복귀해야 한다.
+  await composerInput.evaluate((node) => (node as HTMLElement).blur());
+  await page.evaluate(() => {
+    Object.defineProperty(window.visualViewport, 'height', { get: () => 844, configurable: true });
+    Object.defineProperty(window.visualViewport, 'offsetTop', { get: () => 0, configurable: true });
+    window.visualViewport!.dispatchEvent(new Event('resize'));
+  });
+  await page.waitForTimeout(900);
+  const afterBlur = await page.evaluate(() => ({
+    keyboardOpen: document.documentElement.dataset.keyboardOpen,
+    bodyPosition: getComputedStyle(document.body).position,
+  }));
+  expect(afterBlur.keyboardOpen).toBe('false');
+  expect(afterBlur.bodyPosition).toBe('static');
 });

--- a/services/aris-web/tests/helpers/readAppStyles.ts
+++ b/services/aris-web/tests/helpers/readAppStyles.ts
@@ -5,6 +5,9 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const stylesDir = resolve(__dirname, '../../app/styles');
 
+// app/globals.css의 실제 @import 순서와 일치시킨다 — 순서가 다르면 동률
+// specificity에서 실제 프로덕션 캐스케이드와 다른 승자가 선택되어 테스트가
+// 거짓 양성을 낼 수 있다(layout.css가 빠져 있던 것이 실제 사례).
 const appStyleFiles = [
   'ui.css',
   'ia-shell.css',
@@ -13,6 +16,7 @@ const appStyleFiles = [
   'project-chat.css',
   'files.css',
   'ui-responsive.css',
+  'layout.css',
 ];
 
 export function readAppStyles() {

--- a/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
+++ b/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { readCssWithImports } from './helpers/readAppStyles';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const iaShellCss = readCssWithImports(resolve(__dirname, '../app/styles/ia-shell.css'));
+const layoutCss = readCssWithImports(resolve(__dirname, '../app/styles/layout.css'));
+const viewportHeightSync = readFileSync(
+  resolve(__dirname, '../components/layout/ViewportHeightSync.tsx'),
+  'utf8',
+);
+
+describe('mobile keyboard composer lock', () => {
+  it('pins html/body to the live visual viewport (with offsetTop) only while the keyboard is open', () => {
+    expect(iaShellCss).toMatch(
+      /html\[data-keyboard-open='true'\],\s*\n\s*html\[data-keyboard-open='true'\] body\s*\{[^}]*position:\s*fixed;/,
+    );
+    expect(iaShellCss).toContain('top: var(--visual-viewport-offset-top, 0px);');
+    expect(iaShellCss).toContain('height: var(--visual-viewport-height, 100dvh);');
+  });
+
+  it('does not lock html/body unconditionally on mobile — layout.css deliberately keeps the chat screen page-scrollable so iOS auto-hides its toolbar', () => {
+    // 이 규칙을 지우면 키보드 버그는 막히지만 iOS Safari 주소창 자동 숨김 UX가
+    // 깨진다(layout.css 상단 주석 참고). data-keyboard-open으로 좁혀 적용해야 한다.
+    expect(layoutCss).toMatch(
+      /@media \(max-width: 960px\) \{[\s\S]*?\.app-shell-chat-screen,\s*\n\s*\.app-shell-ia--chat-screen\s*\{[^}]*overflow:\s*visible;/,
+    );
+
+    // ia-shell.css가 --visual-viewport-height로 .app-shell-ia--chat-screen의
+    // height를 override하는 곳은 전부 data-keyboard-open 게이트 안에 있어야 한다
+    // (게이트 없이 상시 적용하면 위 layout.css의 의도된 동작을 깨뜨린다).
+    const gatedOccurrences = iaShellCss.match(/html\[data-keyboard-open='true'\][^{]*\.app-shell-ia--chat-screen[^{]*\{\s*\n\s*height:\s*var\(--visual-viewport-height/g) ?? [];
+    const ungatedOccurrences = iaShellCss.match(/(?:^|\n)\.app-shell-ia--chat-screen\s*\{\s*\n\s*height:\s*var\(--visual-viewport-height/g) ?? [];
+    expect(gatedOccurrences.length).toBeGreaterThan(0);
+    expect(ungatedOccurrences.length).toBe(0);
+  });
+
+  it('locks the composer auto-grow cap to the live viewport while the keyboard is open', () => {
+    expect(iaShellCss).toContain(
+      "max-height: min(200px, calc(var(--visual-viewport-height, 100dvh) * 0.3));",
+    );
+  });
+
+  it('flips data-keyboard-open optimistically on focus instead of waiting for a visualViewport resize', () => {
+    // 실기기에서 iOS의 네이티브 "포커스 요소 스크롤"이 우리 쪽 resize 기반 감지보다
+    // 먼저 실행되는 경합이 있었다. resize를 기다리지 않고 포커스 시점에 곧바로
+    // 잠가서 그 경합 자체를 없앤다.
+    expect(viewportHeightSync).toContain('OPTIMISTIC_KEYBOARD_LOCK_MS');
+    expect(viewportHeightSync).toContain('optimisticKeyboardOpenUntil = performance.now() + OPTIMISTIC_KEYBOARD_LOCK_MS');
+    expect(viewportHeightSync).toContain('const keyboardOpen = bottomInset > threshold || withinOptimisticWindow;');
+    // blur는 낙관적 잠금을 즉시 풀어야 한다 — 실제로 열려 있었다면 이어지는
+    // 측정이 다시 true를 확인해 준다.
+    expect(viewportHeightSync).toMatch(/handleDocumentFocusOut[\s\S]*?optimisticKeyboardOpenUntil = 0;/);
+  });
+});


### PR DESCRIPTION
## 배경

PR #386(모바일 채팅 헤더 병합)에서 "컴포저 터치 시 뷰포트가 확장되고 컴포저가 화면 맨 위로 밀리는" 버그를 수정했다고 보고했으나, 프로덕션 배포 후에도 실기기에서 동일하게 재현된다는 신고가 들어왔다. 이 PR은 "땜질이 아니라 근본 원인"을 다시 조사해 찾은 실제 원인을 고친다.

## 무엇이 진짜 원인이었나

이전 수정(`html[data-keyboard-open='true']` 기반 body 잠금)의 **CSS 자체는 틀리지 않았다.** 문제는 그 CSS를 발동시키는 조건이 너무 늦게 켜졌다는 타이밍 경합이었다.

- `data-keyboard-open`은 `ViewportHeightSync`가 `visualViewport`의 `resize` 이벤트를 받아야 계산된다.
- 그런데 `resize` 이벤트는 키보드 애니메이션이 **시작된 이후**에만 발생한다.
- 반면 iOS/Android의 네이티브 "포커스된 입력 요소를 화면에 보이도록 스크롤"은 포커스 시점에 훨씬 더 즉각적으로 실행될 수 있다.
- 즉 우리 쪽 잠금은 항상 이 경합에서 늦게 도착했다 — resize를 기다리는 동안 네이티브 스크롤이 이미 페이지를 끌어올린 뒤였다.

Chromium 기반 Playwright로는 이 경합 자체를 재현할 수 없었다(진짜 OS 키보드가 없어 네이티브 스크롤 히스틱이 발동하지 않음) — 그래서 지난 수정의 e2e 테스트는 통과했지만 실기기에서는 뚫렸다.

추가로 두 가지를 더 확인했다:
1. `--visual-viewport-offset-top`이 `ViewportHeightSync`에서 계산만 되고 CSS 어디에서도 소비되지 않고 있었다 — 키보드 애니메이션 중 주소창 상태가 바뀌며 visualViewport의 top이 밀리는 경우를 보정하지 못하는 gap.
2. `layout.css`가 모바일에서 `.app-shell-ia--chat-screen`을 **의도적으로** `overflow: visible`로 둔다는 걸 뒤늦게 발견했다 — iOS Safari 주소창이 스크롤에 반응해 자동 숨김되는 UX를 위해서다(파일 상단 주석에 명시). 이 파일이 vitest의 `readAppStyles` 헬퍼 목록에 빠져 있어서, 기존 CSS 단언 테스트들이 실제 프로덕션 캐스케이드의 일부를 보지 못한 채 통과하고 있었다.

## 수정 내용

### 1. `ViewportHeightSync.tsx` — 포커스 시점 낙관적 잠금
텍스트 입력에 포커스가 잡히는 즉시(리사이즈를 기다리지 않고) `data-keyboard-open`을 낙관적으로 켠다. 700ms 창 안에서 실제 인셋 측정(기존 100/300/600ms 재sync 스케줄)이 이어받아 확정하고, blur 시 즉시 해제한다. 이렇게 하면 우리 쪽 잠금이 네이티브 스크롤과 **같은 이벤트(포커스)** 를 트리거로 삼게 되어 경합에서 늦을 이유가 없어진다.

### 2. `ia-shell.css` — offsetTop 보정 + 컴포저 auto-grow 상한
기존 `data-keyboard-open` 잠금 블록에 `top: var(--visual-viewport-offset-top, 0px)`를 추가했다. 컴포저 textarea의 auto-grow 상한(`max-height`)도 키보드가 열린 동안 얼어붙는 `--app-vh` 대신 `--visual-viewport-height`를 쓰도록 전환했다.

**중요**: 이 잠금은 여전히 `data-keyboard-open` 상태에서만 적용된다. `layout.css`가 지켜온 "평상시엔 page-scroll 모델 유지(iOS 주소창 자동 숨김)" 동작은 건드리지 않았다.

### 3. `readAppStyles.ts` — 테스트 헬퍼가 실제 캐스케이드를 보도록 수정
`layout.css`를 실제 `globals.css`의 `@import` 순서에 맞춰 추가. 이 파일이 빠져 있던 것 자체가 이번 조사에서 발견한 회귀 위험이었다.

### 4. 테스트
- `tests/mobileKeyboardComposerLock.test.ts` (신규): CSS 게이팅 관계(잠금은 조건부, layout.css의 의도된 동작은 보존)와 `ViewportHeightSync`의 낙관적 잠금 로직 존재를 회귀 방지.
- `tests/e2e/chat-chrome-collapse-debug.spec.ts`: 포커스 "직후"(resize 이벤트 0개 상태에서) `data-keyboard-open`이 이미 `true`인지 확인하는 단언 추가, `offsetTop` 보정 검증 추가, blur 후 평상시 모델로 복귀하는지 확인 추가.

## 검증

- `tsc --noEmit` ✅ · `next lint` 신규 경고 0 ✅ (기존 5개 무관 경고만 존재)
- vitest 전체 **122개 파일 / 613개 테스트 통과** (신규 파일 1개, 4개 테스트 추가)
- 로그인 없이 격리된 Playwright 스크립트로 낙관적 잠금의 핵심 타이밍만 별도 검증: **resize 이벤트를 단 하나도 보내지 않은 상태에서 포커스만으로 `data-keyboard-open`이 즉시 `true`로 전환됨을 확인** — 이전 버전은 resize를 기다려야 했던 부분이 이번 수정으로 제거됐다.

### 한계 — 솔직히 밝혀둔다
리서치 결과(WebKit 표준 트래커, Apple 개발자 포럼 등) 이 종류의 iOS 키보드-뷰포트 문제는 **CSS/JS만으로 100% 보장되는 표준화된 해법이 없다**. iOS 26에서도 관련 회귀가 보고되고 있다. 이번 수정은 우리 쪽 감지-대응 로직이 네이티브 스크롤과의 경합에서 늦는 구조적 원인을 제거해 발생 확률을 크게 낮추는 것이지, 모든 iOS 버전/기기 조합에서 100% 재현 불가를 보장하지는 못한다. 실기기(특히 iOS Safari) 재확인을 권장한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbeRFoKWdoefKCvECrNfkt
