### PR TITLE
fix(web): 모바일 키보드 컴포저를 네이티브 스크롤과 협력하는 방식으로 재설계

### DIFF
--- a/services/aris-web/app/styles/ia-shell.css
+++ b/services/aris-web/app/styles/ia-shell.css
@@ -859,63 +859,35 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
   min-height: 0;
 }
 
-/* 모바일 키보드가 열려 있는 동안만 채팅 화면을 실제 보이는 뷰포트에 고정한다.
-   (평상시에는 잠그지 않는다 — layout.css가 모바일에서 .app-shell-ia--chat-screen을
-   의도적으로 overflow:visible/height:auto로 두는데, 이는 iOS Safari 주소창이
-   스크롤에 반응해 자동 숨김되는 UX를 위한 것이다. 그 동작을 깨지 않도록 이 잠금은
-   키보드가 열려 있는 좁은 구간에만 적용한다.)
+/* 모바일 키보드 대응: 네이티브 스크롤과 "싸우지" 않고 "협력"한다.
+   (ChatGPT 웹 모바일의 실제 구현을 조사해 확인한 전략 — html/body는 position을
+   절대 바꾸지 않고, 포커스된 입력을 화면에 보이도록 끌어올리는 브라우저
+   네이티브 동작을 그대로 둔다.)
 
-   data-keyboard-open은 ViewportHeightSync가 계산하며, 이제 포커스 시점에
-   낙관적으로(실제 리사이즈를 기다리지 않고) 먼저 true가 된다 — 그 이유는
-   아래에 있다.
+   이전 시도는 data-keyboard-open일 때 html/body를 position:fixed로 강제
+   잠갔다. CSS 자체는 정확했지만 position:static → fixed 전환은 스펙상
+   transition이 불가능한 이산적(discrete) 값 변경이라, 네이티브 스크롤이
+   컴포저를 끌어올린 "직후" 이 잠금이 뒤늦게 걸리며 순간이동(스냅)하는
+   것으로 보였다 — "화면 맨 위로 과도하게 올라갔다가 정상 위치로 순간이동".
 
-   reset.css가 html/body에 overflow-x만 지정해 overflow-y가 스펙상 auto로
-   계산되고, min-height는 키보드가 열린 동안 이전 높이에 고정되는 --app-vh를
-   따른다. 그래서 키보드가 열리면 body 박스는 이전 높이에 머무는데 실제 보이는
-   영역은 줄어들어 스크롤 가능한 여백이 생기고, 네이티브 "포커스 요소를 화면에
-   보이도록 스크롤"이 그 여백을 없애려 페이지를 끌어올린다 — 이게 컴포저가
-   화면 위로 밀려 올라가는 현상의 정체다.
+   근본 수정은 reset.css에서 overflow-x: hidden을 overflow-x: clip으로
+   바꾼 것이다: CSS Overflow 스펙상 overflow-x가 non-visible이고 overflow-y가
+   미지정이면 overflow-y가 auto로 자동 승격되는데(hidden은 이 승격을
+   트리거), 이게 키보드가 열린 동안 body에 실제보다 훨씬 큰 스크롤 가능
+   여백을 만든 진짜 원인이었다. clip은 이 승격을 트리거하지 않으므로,
+   네이티브 스크롤이 필요한 만큼(키보드 높이만큼)만 자연스럽게 문서를
+   끌어올리고 — 이게 ChatGPT/Claude 같은 서비스가 "매끄럽게" 느껴지는 이유다:
+   그들도 이 문제를 막지 않고, 막을 필요가 없도록 구조 자체를 정직하게
+   유지한다.
 
-   이 CSS 잠금 자체는 이미 정확하지만(실측으로 검증됨), 실기기에서 여전히
-   재현된 이유는 타이밍 경합으로 보인다: --visual-viewport-height 기반
-   data-keyboard-open은 visualViewport의 resize 이벤트(키보드 애니메이션이
-   시작된 "이후"에만 발생)를 기다려야 true가 되는데, iOS의 네이티브 스크롤은
-   포커스 시점에 훨씬 더 즉각적으로 실행될 수 있다. ViewportHeightSync는 이제
-   포커스 이벤트에서 실제 인셋을 측정하기 전에 곧바로 낙관적으로 잠가서 이
-   경합 자체를 없앤다(components/layout/ViewportHeightSync.tsx 참고). */
+   .cmp__input의 auto-grow 상한만 남겨둔다 — position/scroll과 무관하게
+   입력창 자체가 과도하게 커지지 않도록 하는 순수 시각적 제약이라 여기엔
+   영향이 없다. */
 @media (max-width: 767px) {
-  html[data-keyboard-open='true'],
-  html[data-keyboard-open='true'] body {
-    position: fixed;
-    inset: 0;
-    top: var(--visual-viewport-offset-top, 0px);
-    height: var(--visual-viewport-height, 100dvh);
-    min-height: 0;
-    overflow: hidden;
+  .pc-proto .cmp__input {
+    transition: max-height 150ms var(--ease-smooth, ease);
   }
 
-  html[data-keyboard-open='true'] .app-shell-ia--chat-screen,
-  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .aris-ia-shell,
-  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main {
-    height: var(--visual-viewport-height, 100dvh);
-    min-height: 0;
-    overflow: hidden;
-  }
-
-  /* 모바일 채팅 화면은 상단 앱 탑바를 렌더링하지 않으므로(단일 헤더로 병합됨)
-     더 이상 그 높이를 빼지 않는다. */
-  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main-scroll--project-chat-detail .pc-proto {
-    height: 100%;
-    min-height: 0;
-  }
-
-  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main-scroll--project-chat-detail .pc-proto .shell {
-    height: var(--visual-viewport-height, 100dvh);
-  }
-
-  /* 컴포저 auto-grow 상한도 얼어붙은 --app-vh가 아니라 실제 보이는 높이를
-     기준으로 삼아, 키보드가 열린 좁은 화면에서 입력창이 과도하게 커지지
-     않게 한다. */
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen .pc-proto .cmp__input {
     max-height: min(200px, calc(var(--visual-viewport-height, 100dvh) * 0.3));
   }

--- a/services/aris-web/app/styles/reset.css
+++ b/services/aris-web/app/styles/reset.css
@@ -28,7 +28,13 @@ html, body {
   letter-spacing: var(--ls-normal, normal);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
-  overflow-x: hidden;
+  /* hidden이 아니라 clip: CSS Overflow 스펙상 overflow-x가 visible이 아니고
+     overflow-y가 미지정이면 overflow-y가 auto로 자동 승격되는데, hidden은 이
+     승격을 트리거하지만 clip은 트리거하지 않는다(가로 스크롤 차단 목적은
+     동일). 이 승격이 모바일 채팅 화면에서 키보드가 열릴 때 body에 실제로는
+     필요 없는 스크롤 가능 여백을 만들어, 네이티브 "포커스 요소 스크롤"이
+     컴포저를 화면 밖으로 과도하게 끌고 가는 원인이었다. */
+  overflow-x: clip;
 }
 
 body {

--- a/services/aris-web/tests/e2e/chat-chrome-collapse-debug.spec.ts
+++ b/services/aris-web/tests/e2e/chat-chrome-collapse-debug.spec.ts
@@ -347,7 +347,7 @@ test('스크롤 시 상단 크롬 숨김/복원과 컴포저 pill 축소·확장
   await expect(page.locator('[data-project-chat-screen] .cmp-slash')).toHaveCount(0);
 });
 
-test('컴포저 포커스 후 키보드가 열려도 body에 스크롤 가능한 여백이 생기지 않는다', async ({ page }) => {
+test('컴포저 포커스 후 키보드가 열려도 html/body의 position은 절대 바뀌지 않는다 (네이티브 스크롤과 협력)', async ({ page }) => {
   const projectId = process.env.CHAT_CHROME_PROJECT_ID;
   test.skip(!projectId, 'CHAT_CHROME_PROJECT_ID is required');
 
@@ -356,28 +356,27 @@ test('컴포저 포커스 후 키보드가 열려도 body에 스크롤 가능한
   await openProjectChatScreen(page, projectId!);
   await removeDevOverlays(page);
 
-  // 포커스 전: 평상시 page-scroll 모델이 유지되어야 한다(iOS 주소창 자동 숨김 UX 보존).
+  // ChatGPT 웹 모바일 실측으로 확인한 전략: html/body의 position은 키보드
+  // 상태와 무관하게 항상 static이어야 한다. position:static → fixed 전환은
+  // 스펙상 transition이 불가능해, 이전엔 네이티브 스크롤이 컴포저를 끌어올린
+  // "직후" 잠금이 뒤늦게 걸리며 순간이동(스냅)하는 것으로 보였다.
   const beforeFocus = await page.evaluate(() => ({
     keyboardOpen: document.documentElement.dataset.keyboardOpen,
     bodyPosition: getComputedStyle(document.body).position,
+    bodyOverflowY: getComputedStyle(document.body).overflowY,
   }));
   expect(beforeFocus.keyboardOpen).toBe('false');
   expect(beforeFocus.bodyPosition).toBe('static');
+  // overflow-x: clip(hidden 아님)이므로 overflow-y가 auto로 자동 승격되지 않아야 한다.
+  expect(beforeFocus.bodyOverflowY).not.toBe('auto');
 
   const composerInput = page.locator('[data-project-chat-screen] .cmp-wrap .cmp__input');
   await composerInput.click();
-
-  // 리사이즈 이벤트를 단 하나도 보내지 않은 채 곧바로 확인한다: 실기기에서
-  // iOS의 네이티브 "포커스 요소 스크롤"은 visualViewport.resize보다 먼저 실행될
-  // 수 있으므로, 우리 쪽 잠금도 resize를 기다리지 않고 포커스만으로 즉시 걸려야
-  // 그 경합에서 이길 수 있다(ViewportHeightSync의 낙관적 잠금 참고).
   const immediatelyAfterFocus = await page.evaluate(() => document.documentElement.dataset.keyboardOpen);
   expect(immediatelyAfterFocus).toBe('true');
 
   // 실제 모바일 키보드가 열리는 것을 흉내낸다: visualViewport.height/offsetTop을
   // 여러 단계로 바꿔가며 resize 이벤트를 발생시킨다(ViewportHeightSync가 구독).
-  // offsetTop도 함께 변화시켜, 키보드 애니메이션 중 주소창 상태 변화로
-  // visualViewport의 top이 밀리는 경우까지 보정되는지 확인한다.
   for (const { height, offsetTop } of [
     { height: 664, offsetTop: 0 },
     { height: 460, offsetTop: 20 },
@@ -395,31 +394,22 @@ test('컴포저 포커스 후 키보드가 열려도 body에 스크롤 가능한
 
   const state = await page.evaluate(() => ({
     keyboardOpen: document.documentElement.dataset.keyboardOpen,
-    bodyScrollHeight: document.body.scrollHeight,
     bodyPosition: getComputedStyle(document.body).position,
-    bodyTop: getComputedStyle(document.body).top,
+    bodyOverflowY: getComputedStyle(document.body).overflowY,
+    htmlPosition: getComputedStyle(document.documentElement).position,
     visualViewportHeight: window.visualViewport?.height,
-    visualViewportOffsetTop: window.visualViewport?.offsetTop ?? 0,
-    scrollY: window.scrollY,
   }));
   expect(state.keyboardOpen).toBe('true');
-  expect(state.bodyPosition).toBe('fixed');
-  // visualViewport의 top이 밀린 만큼 body도 함께 보정되어야, 고정 레이아웃과
-  // 실제 보이는 영역의 기준점이 어긋나지 않는다.
-  expect(state.bodyTop).toBe(`${state.visualViewportOffsetTop}px`);
-  // body의 실제 스크롤 가능 높이가 라이브 visualViewport 높이를 초과하면 안 된다
-  // (초과분이 곧 브라우저의 네이티브 "포커스 요소 스크롤"이 컴포저를 화면 밖으로
-  // 끌고 가는 여지였다).
-  expect(state.bodyScrollHeight).toBeLessThanOrEqual((state.visualViewportHeight ?? 0) + 1);
-  expect(state.scrollY).toBe(0);
+  // 키보드가 열려도 position은 절대 바뀌지 않는다 — 이게 이번 재설계의 핵심.
+  expect(state.bodyPosition).toBe('static');
+  expect(state.htmlPosition).toBe('static');
+  expect(state.bodyOverflowY).not.toBe('auto');
 
-  const cmpRect = await page.locator('[data-project-chat-screen] .cmp-wrap .cmp').evaluate((node) => {
-    const r = node.getBoundingClientRect();
-    return { top: Math.round(r.top), bottom: Math.round(r.bottom) };
-  });
-  // 컴포저가 화면 맨 위로 끌려가지 않고, 축소된 뷰포트 안에서 하단 근처에 남아있어야 한다
-  expect(cmpRect.top).toBeGreaterThan(50);
-  expect(cmpRect.bottom).toBeLessThanOrEqual((state.visualViewportHeight ?? 0) + state.visualViewportOffsetTop + 1);
+  // 컴포저 auto-grow 상한이 실제 보이는 높이 기준으로 줄어드는지 확인한다
+  // (position/scroll과 무관한 순수 시각 제약이라 여기선 안전하게 반응해야 한다).
+  const cmpInputMaxHeight = await composerInput.evaluate((node) => getComputedStyle(node).maxHeight);
+  expect(Number.parseFloat(cmpInputMaxHeight)).toBeLessThanOrEqual(Math.round((state.visualViewportHeight ?? 0) * 0.3) + 1);
+
   await page.screenshot({ path: 'test-results/chat-keyboard-open-no-overflow.png' });
 
   // blur 후에는 낙관적 잠금과 실측 상태 모두 해제되어 평상시 모델로 복귀해야 한다.

--- a/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
+++ b/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
@@ -6,52 +6,58 @@ import { readCssWithImports } from './helpers/readAppStyles';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const iaShellCss = readCssWithImports(resolve(__dirname, '../app/styles/ia-shell.css'));
+const resetCss = readCssWithImports(resolve(__dirname, '../app/styles/reset.css'));
 const layoutCss = readCssWithImports(resolve(__dirname, '../app/styles/layout.css'));
 const viewportHeightSync = readFileSync(
   resolve(__dirname, '../components/layout/ViewportHeightSync.tsx'),
   'utf8',
 );
 
-describe('mobile keyboard composer lock', () => {
-  it('pins html/body to the live visual viewport (with offsetTop) only while the keyboard is open', () => {
-    expect(iaShellCss).toMatch(
-      /html\[data-keyboard-open='true'\],\s*\n\s*html\[data-keyboard-open='true'\] body\s*\{[^}]*position:\s*fixed;/,
-    );
-    expect(iaShellCss).toContain('top: var(--visual-viewport-offset-top, 0px);');
-    expect(iaShellCss).toContain('height: var(--visual-viewport-height, 100dvh);');
+describe('mobile keyboard composer — cooperates with native scroll instead of fighting it', () => {
+  it('never locks html/body position on mobile keyboard open — position:static -> fixed cannot be transitioned and caused a visible snap', () => {
+    // ChatGPT 웹 모바일 실측 결과와 동일한 전략: html/body의 position은 절대
+    // 바꾸지 않는다. 이전엔 data-keyboard-open일 때 position:fixed로 강제
+    // 잠갔는데, position 전환은 스펙상 transition이 불가능해 네이티브 스크롤
+    // 직후 "순간이동"으로 보였다.
+    // 실제 CSS 규칙 블록(주석 제외)에서 data-keyboard-open 선택자와
+    // position:fixed 선언이 같은 규칙 안에 함께 있으면 안 된다.
+    const withoutComments = iaShellCss.replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(withoutComments).not.toMatch(/html\[data-keyboard-open='true'\][^{]*\{[^}]*position:\s*fixed/);
   });
 
-  it('does not lock html/body unconditionally on mobile — layout.css deliberately keeps the chat screen page-scrollable so iOS auto-hides its toolbar', () => {
-    // 이 규칙을 지우면 키보드 버그는 막히지만 iOS Safari 주소창 자동 숨김 UX가
-    // 깨진다(layout.css 상단 주석 참고). data-keyboard-open으로 좁혀 적용해야 한다.
+  it("uses overflow-x: clip (not hidden) on html/body so overflow-y is never auto-promoted", () => {
+    // CSS Overflow 스펙: overflow-x가 non-visible이고 overflow-y가 미지정이면
+    // overflow-y가 auto로 자동 승격된다. hidden은 이 승격을 트리거하지만
+    // clip은 트리거하지 않는다 — 이게 키보드가 열린 동안 body에 불필요한
+    // 스크롤 여백이 생기던 진짜 원인이었다.
+    expect(resetCss).toMatch(/html,\s*body\s*\{[^}]*overflow-x:\s*clip;/s);
+    expect(resetCss).not.toMatch(/html,\s*body\s*\{[^}]*overflow-x:\s*hidden;/s);
+  });
+
+  it('still preserves the intentional page-scroll model on mobile (iOS toolbar auto-hide)', () => {
+    // layout.css가 모바일에서 .app-shell-ia--chat-screen을 의도적으로
+    // overflow:visible/height:auto로 두는 것은 이번 재설계와 방향이 같다 —
+    // 둘 다 "막지 않고 네이티브 스크롤에 맡긴다"는 동일한 철학이다.
     expect(layoutCss).toMatch(
       /@media \(max-width: 960px\) \{[\s\S]*?\.app-shell-chat-screen,\s*\n\s*\.app-shell-ia--chat-screen\s*\{[^}]*overflow:\s*visible;/,
     );
-
-    // ia-shell.css가 --visual-viewport-height로 .app-shell-ia--chat-screen의
-    // height를 override하는 곳은 전부 data-keyboard-open 게이트 안에 있어야 한다
-    // (게이트 없이 상시 적용하면 위 layout.css의 의도된 동작을 깨뜨린다).
-    const gatedOccurrences = iaShellCss.match(/html\[data-keyboard-open='true'\][^{]*\.app-shell-ia--chat-screen[^{]*\{\s*\n\s*height:\s*var\(--visual-viewport-height/g) ?? [];
-    const ungatedOccurrences = iaShellCss.match(/(?:^|\n)\.app-shell-ia--chat-screen\s*\{\s*\n\s*height:\s*var\(--visual-viewport-height/g) ?? [];
-    expect(gatedOccurrences.length).toBeGreaterThan(0);
-    expect(ungatedOccurrences.length).toBe(0);
   });
 
-  it('locks the composer auto-grow cap to the live viewport while the keyboard is open', () => {
+  it('keeps the composer auto-grow cap tied to the live viewport, with a transition so it never snaps', () => {
+    // position/scroll과 무관한 순수 시각적 제약이라 네이티브 스크롤과
+    // 경합하지 않는다. transition을 둬서 그 자체도 부드럽게 바뀐다.
+    expect(iaShellCss).toContain('transition: max-height 150ms var(--ease-smooth, ease);');
     expect(iaShellCss).toContain(
       "max-height: min(200px, calc(var(--visual-viewport-height, 100dvh) * 0.3));",
     );
   });
 
   it('flips data-keyboard-open optimistically on focus instead of waiting for a visualViewport resize', () => {
-    // 실기기에서 iOS의 네이티브 "포커스 요소 스크롤"이 우리 쪽 resize 기반 감지보다
-    // 먼저 실행되는 경합이 있었다. resize를 기다리지 않고 포커스 시점에 곧바로
-    // 잠가서 그 경합 자체를 없앤다.
+    // position 잠금에는 더 이상 쓰이지 않지만, 컴포저 auto-grow 상한이
+    // 최대한 빨리 정확한 값을 참조하도록 이 메커니즘은 유지한다.
     expect(viewportHeightSync).toContain('OPTIMISTIC_KEYBOARD_LOCK_MS');
     expect(viewportHeightSync).toContain('optimisticKeyboardOpenUntil = performance.now() + OPTIMISTIC_KEYBOARD_LOCK_MS');
     expect(viewportHeightSync).toContain('const keyboardOpen = bottomInset > threshold || withinOptimisticWindow;');
-    // blur는 낙관적 잠금을 즉시 풀어야 한다 — 실제로 열려 있었다면 이어지는
-    // 측정이 다시 true를 확인해 준다.
     expect(viewportHeightSync).toMatch(/handleDocumentFocusOut[\s\S]*?optimisticKeyboardOpenUntil = 0;/);
   });
 });


### PR DESCRIPTION
## 배경

PR #387(포커스 시점 낙관적 잠금)을 배포한 뒤에도 "컴포저 터치 시 키보드가 열리며 화면 맨 위로 과도하게 올라갔다가 → 정상 위치로 순간이동해서 돌아온다"는 신고를 받았다. ChatGPT/Claude 같은 매끄러운 경험이 아니라는 지적에 따라, ChatGPT 웹 모바일의 실제 구현을 조사하고 우리 구현과의 근본적인 아키텍처 차이를 찾아 재설계했다.

## ChatGPT 실제 구현 (공개 게스트 채팅에서 직접 추출)

로그인 없이 접근 가능한 `chatgpt.com`의 게스트 채팅에서 실제 컴퓨티드 스타일과 번들 JS/CSS를 직접 추출해 확인했다:

```css
/* body 기본 크기 — 네이티브 CSS 단위만, JS 계산값 없음 */
body { min-height: 100dvb; overflow-x: clip; }  /* overflow-y 미지정 */

/* 키보드 대응 — iOS 전용, position은 절대 안 건드림 */
@supports (-webkit-touch-callout: none) {
  [data-visual-keyboard] .wm-swipe-scrollContainer {
    transform: translateY(var(--mobile-shell-visual-viewport-offset-top, 0px));
  }
}
```
- `html`/`body`의 `position`은 **항상 `static`** — 실측 확인.
- `overflow-x: clip` (`hidden`이 아님), `overflow-y`는 명시 안 함 → 실측 결과 `overflow-y: visible` (auto로 승격되지 않음).
- JS는 우리와 거의 동일한 전략: `focusin` 시 resize를 기다리지 않고 즉시 `data-visual-keyboard` 속성을 켬(우리의 낙관적 잠금과 동일 아이디어). 다만 이 속성은 **position을 바꾸는 데 쓰이지 않고**, 스크롤 영역에 `transform: translateY()`(GPU 합성, 항상 부드럽게 보간 가능)를 적용하는 데만 쓰인다.

## 핵심 차이 — 왜 우리만 "스냅"이 보였는가

**`position: static → fixed` 전환은 CSS 스펙상 transition이 불가능한 이산적(discrete) 값 변경이다.** 두 position 값은 완전히 다른 레이아웃 컨텍스트를 만들어 브라우저가 보간할 방법이 없다 — 반드시 즉시 스냅된다.

PR #387까지의 수정은 `data-keyboard-open`이 켜지는 순간 `html/body`를 `static`에서 `fixed`로 전환해 "네이티브 스크롤과 싸우는" 전략이었다. 포커스 시점 낙관적 잠금으로 타이밍 경합은 줄였지만, 그 잠금이 실제로 적용되는 순간 자체가 여전히 이산적 전환이라 — 네이티브 스크롤이 컴포저를 끌어올린 직후 우리 잠금이 걸리며 "정상 위치로 순간이동"하는 것으로 보였다. **position을 바꾸는 방식인 한 구조적으로 피할 수 없는 문제였다.**

추가로 확인한 사실(권위 있는 소스로 검증 — [bramus의 viewport-resize-behavior explainer](https://github.com/bramus/viewport-resize-behavior/blob/main/explainer.md)): iOS Safari에서 `dvh`/`dvb`는 **키보드에 반응하지 않는다**(Layout Viewport 기준이라 브라우저 자체 UI 숨김에만 반응). 즉 ChatGPT도 네이티브 CSS 단위만으로 키보드 문제를 풀지 않는다 — **그들은 네이티브 "포커스 요소 스크롤"을 막지 않고 그대로 받아들인다.** `translateY`는 그 동안 콘텐츠가 부드럽게 따라가도록 하는 보조 장치일 뿐이다.

## 수정 내용

### `reset.css` — 근본 원인
`overflow-x: hidden` → `overflow-x: clip`. CSS Overflow 스펙상 `overflow-x`가 non-visible이고 `overflow-y`가 미지정이면 `overflow-y`가 `auto`로 자동 승격되는데, `hidden`은 이 승격을 트리거하지만 `clip`은 트리거하지 않는다. 이게 키보드가 열린 동안 body에 실제보다 훨씬 큰(최대 284~844px) 스크롤 가능 여백이 생기던 진짜 원인이었다. `clip`으로 바꾸면 네이티브 스크롤이 필요한 만큼(키보드 높이만큼)만 자연스럽게 문서를 끌어올린다.

### `ia-shell.css` — position 잠금 완전 제거
`data-keyboard-open` 기반 `position:fixed` 잠금 블록을 삭제. 컴포저 auto-grow 상한(`.cmp__input`의 `max-height`)만 유지 — 이건 position/scroll과 무관한 순수 시각적 제약이라 네이티브 스크롤과 경합하지 않는다. `transition`을 추가해 이 값 자체도 부드럽게 바뀌도록 함.

### 테스트
- `mobileKeyboardComposerLock.test.ts`: position이 절대 `fixed`로 바뀌지 않음 + `overflow-x: clip` 사용(hidden 아님) 회귀 방지.
- `chat-chrome-collapse-debug.spec.ts`: 키보드 오픈 시뮬레이션 후에도 `html`/`body` position이 `static`으로 유지되는지, `overflow-y`가 `auto`로 승격되지 않는지 확인하도록 갱신.

## 검증

- `tsc`/`lint` 클린, **vitest 122개 파일/614개 테스트 통과**
- 로그인이 필요 없는 `/login` 페이지에서 실제 컴퓨티드 스타일 측정: `overflow-x: clip, overflow-y: visible` — **ChatGPT 실측값(`clip visible`)과 정확히 일치**

### 한계 — 솔직히 밝혀둔다
iOS 실기기에서의 최종 "매끄러움" 자체는 이 세션에서 직접 검증하지 못했다. 로그인이 필요한 채팅 화면 E2E는 권한 시스템이 프로덕션 자격증명 접근을 차단해 실행하지 못했고, headless Chromium은 애초에 네이티브 키보드 스크롤 애니메이션을 재현할 수 없다(진짜 OS 키보드가 없음). 구조적 근거(CSS 스펙 분석 + ChatGPT 실측 비교)는 강하지만, **실기기 재확인을 권장**한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbeRFoKWdoefKCvECrNfkt
