### PR TITLE
fix(web): 축소된 컴포저 pill 터치 시 확장 후 포커스로 순서를 바로잡음

### DIFF
--- a/services/aris-web/components/project-chat/ProjectChatSurface.tsx
+++ b/services/aris-web/components/project-chat/ProjectChatSurface.tsx
@@ -1394,6 +1394,30 @@ export function ProjectChatSurface({
       setModelSelectorOpen(false);
     }
   }, [isComposerCollapsed]);
+  // expandComposer() 호출 직후 같은 틱에서 곧바로 focus()하면 문제가 있다:
+  // pill 상태의 .cmp 폼은 opacity:0 + pointer-events:none으로만 숨겨져 있는데
+  // (포커스 자체는 가능해야 pill 탭이 즉시 키보드를 열 수 있다), React가 아직
+  // 리렌더를 커밋하기 전이라 그 "숨겨진" 상태의 요소를 포커스하게 된다. 브라우저의
+  // 네이티브 "포커스 요소 스크롤"이 투명/pointer-events:none 요소는 스크롤 대상에서
+  // 제외하는 것으로 보여, 키보드는 열리지만 컴포저는 제자리에서 확장 애니메이션만
+  // 재생되고 키보드 위로 올라오지 않았다. collapsed -> expanded 전환이 실제로
+  // 커밋되어 페인트된 다음 프레임에 포커스해야 그 스크롤이 정상적으로 트리거된다.
+  // pendingComposerFocusRef는 "이 확장 다음에 포커스할 의도가 있었는지"만 표시한다
+  // (예: 이미지 업로드 후의 expandComposer()처럼 포커스를 원치 않는 호출도 있음).
+  const wasComposerCollapsedRef = useRef(isComposerCollapsed);
+  const pendingComposerFocusRef = useRef(false);
+  useEffect(() => {
+    const wasCollapsed = wasComposerCollapsedRef.current;
+    wasComposerCollapsedRef.current = isComposerCollapsed;
+    if (!wasCollapsed || isComposerCollapsed || !pendingComposerFocusRef.current) {
+      return;
+    }
+    pendingComposerFocusRef.current = false;
+    const raf = requestAnimationFrame(() => {
+      composerInputRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isComposerCollapsed]);
   const [actionSheetOpen, setActionSheetOpen] = useState(false);
   const [pendingImageAttachments, setPendingImageAttachments] = useState<ChatImageAttachment[]>([]);
   const [isUploadingImages, setIsUploadingImages] = useState(false);
@@ -1413,9 +1437,17 @@ export function ProjectChatSurface({
       const rest = current.trimStart();
       return rest ? `${entry.command} ${rest}` : `${entry.command} `;
     });
-    expandComposer();
-    composerInputRef.current?.focus();
-  }, [expandComposer, recordRecentSkill]);
+    if (isComposerCollapsed) {
+      // 축소 상태에서 열린 액션시트라면 expandComposer()가 만드는 collapsed
+      // -> expanded 전환을 위 useEffect가 감지해 리렌더 이후 안전하게 포커스한다.
+      pendingComposerFocusRef.current = true;
+      expandComposer();
+    } else {
+      // 이미 펼쳐진 상태(폼 안의 + 버튼)라면 숨김 상태 관련 타이밍 문제가 없어
+      // 곧바로 포커스해도 안전하다.
+      composerInputRef.current?.focus();
+    }
+  }, [expandComposer, isComposerCollapsed, recordRecentSkill]);
 
   const handleImageFilesSelected = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files ?? []);
@@ -3126,8 +3158,8 @@ export function ProjectChatSurface({
                   className="cmp-pill__body"
                   aria-label="메시지 입력 열기"
                   onClick={() => {
+                    pendingComposerFocusRef.current = true;
                     expandComposer();
-                    composerInputRef.current?.focus();
                   }}
                 >
                   <span className={`cmp-pill__text${prompt.trim() || pendingImageAttachments.length > 0 ? ' cmp-pill__text--draft' : ''}`}>

--- a/services/aris-web/tests/composerPillExpandFocusTiming.test.ts
+++ b/services/aris-web/tests/composerPillExpandFocusTiming.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const surface = readFileSync(
+  resolve(__dirname, '../components/project-chat/ProjectChatSurface.tsx'),
+  'utf8',
+);
+
+describe('composer pill expand -> focus timing', () => {
+  it('defers focus() to a requestAnimationFrame after the collapsed -> expanded transition commits', () => {
+    // pill 상태의 .cmp 폼은 opacity:0 + pointer-events:none으로 숨겨져 있을 뿐이라
+    // (포커스 자체는 가능해야 pill 탭이 즉시 키보드를 열 수 있다) expandComposer()
+    // 직후 같은 틱에서 focus()하면 아직 리렌더 전인 숨김 상태의 요소를 포커스하게
+    // 되어, 네이티브 "포커스 요소 스크롤"이 그 요소를 스크롤 대상에서 제외한다 —
+    // 키보드는 열리지만 컴포저가 제자리에서 확장 애니메이션만 재생된다.
+    expect(surface).toMatch(
+      /if \(!wasCollapsed \|\| isComposerCollapsed \|\| !pendingComposerFocusRef\.current\) \{\s*\n\s*return;\s*\n\s*\}\s*\n\s*pendingComposerFocusRef\.current = false;\s*\n\s*const raf = requestAnimationFrame\(\(\) => \{\s*\n\s*composerInputRef\.current\?\.focus\(\);/,
+    );
+  });
+
+  it('does not call focus() synchronously right after expandComposer() at the pill tap and skill-select call sites', () => {
+    expect(surface).not.toMatch(/expandComposer\(\);\s*\n\s*composerInputRef\.current\?\.focus\(\);/);
+  });
+
+  it('sets the pending-focus intent before expanding from a collapsed pill tap', () => {
+    expect(surface).toMatch(
+      /onClick=\{\(\) => \{\s*\n\s*pendingComposerFocusRef\.current = true;\s*\n\s*expandComposer\(\);\s*\n\s*\}\}/,
+    );
+  });
+
+  it('still focuses immediately when a skill is picked while the composer is already expanded (no hidden-element race there)', () => {
+    expect(surface).toMatch(
+      /if \(isComposerCollapsed\) \{[\s\S]*?pendingComposerFocusRef\.current = true;[\s\S]*?expandComposer\(\);\s*\n\s*\} else \{[\s\S]*?composerInputRef\.current\?\.focus\(\);\s*\n\s*\}\s*\n\s*\}, \[expandComposer, isComposerCollapsed, recordRecentSkill\]\);/,
+    );
+  });
+});


### PR DESCRIPTION
## 배경

"컴포저가 축소된 상태에서 컴포저를 터치하면 키보드 위로 컴포저가 자연스럽게 올라오지 않고 가만히 있는 채로 확장되는 이슈가 있음"이라는 신고를 받고 코드를 조사해 근본 원인을 찾았다.

## 원인

pill(축소) 상태에서도 실제 `.cmp` 폼(텍스트영역 포함)은 DOM에 항상 존재한다 — `opacity: 0` + `pointer-events: none`으로만 시각적으로 숨겨져 있다. 기존 코드 주석에 이미 그 이유가 명시돼 있었다: "포커스 가능해야 pill 탭 → 키보드 오픈이 한 제스처로 이어진다."

문제는 pill의 `onClick`과 스킬 선택 핸들러가:
```tsx
onClick={() => {
  expandComposer();               // React state setter — 비동기
  composerInputRef.current?.focus();  // 같은 틱에서 곧바로 호출
}}
```
`expandComposer()`는 `setIsComposerCollapsed(false)`를 호출하는 React state setter라 리렌더가 비동기로 커밋된다. 그런데 바로 다음 줄에서 같은 이벤트 틱에 `.focus()`를 호출하므로, **이 시점의 텍스트영역은 아직 `opacity:0`/`pointer-events:none` 상태 그대로다.**

브라우저의 네이티브 "포커스 요소를 화면에 보이도록 스크롤" 동작은 투명하고 상호작용 불가능한 요소를 스크롤 대상에서 제외하는 것으로 보인다 — 그 결과 키보드는 열리지만 컴포저를 끌어올리는 스크롤은 트리거되지 않고, 리렌더가 커밋된 뒤 재생되는 확장 애니메이션(`opacity 0→1`, `translateY 12px→0`)만 제자리에서 보인다.

## 수정

`expandComposer()` 직후의 동기 `.focus()` 호출을 제거하고, `isComposerCollapsed`가 `true → false`로 실제 전환된 뒤 `requestAnimationFrame`으로 한 프레임 미룬 `useEffect`에서 포커스하도록 옮겼다. 이렇게 하면 포커스 시점에 텍스트영역이 이미 리렌더 커밋 + 페인트를 거쳐 불투명·상호작용 가능한 상태이므로, 네이티브 스크롤이 정상적으로 트리거될 것으로 기대된다.

- **pill 탭** (`cmp-pill__body` 버튼): 축소 상태에서만 렌더되므로 항상 collapsed→expanded 전환이다. `pendingComposerFocusRef.current = true` 표시 후 `expandComposer()`만 호출.
- **스킬 선택** (액션시트): 축소 상태였다면 위와 동일하게 처리. **이미 펼쳐진 상태**(폼 안의 `+` 버튼으로 연 액션시트)였다면 숨김 상태 관련 타이밍 문제가 없으므로 기존처럼 즉시 `.focus()`.
- **이미지 업로드 후** `expandComposer()`: 원래도 포커스를 하지 않던 호출이라, `pendingComposerFocusRef`를 세팅하지 않아 새로 포커스가 발생하지 않도록 명시적으로 남겨뒀다(의도치 않은 동작 변경 방지).

## 검증
- `tsc`/`lint` 클린, **vitest 123개 파일/618개 테스트 통과**(신규 4개 포함, 소스 텍스트 단언으로 타이밍 수정과 각 호출부의 의도된 동작 회귀 방지)
- dev 서버 기동 확인(런타임 에러 없음)

### 한계
로그인 기반 채팅 화면에서의 실제 터치 상호작용은 권한 시스템이 프로덕션 자격증명 접근을 차단해 이 세션에서 직접 검증하지 못했다. 원인 분석은 CSS(`opacity:0`/`pointer-events:none`인 채로 숨겨짐이 코드 주석에 명시)와 React 렌더링 타이밍(state setter의 비동기 커밋)이라는 두 가지 확실한 사실에 근거하며, 표준적인 "state 갱신 후 DOM 커밋을 기다렸다가 side effect 실행" 패턴으로 수정했다. 실기기 재확인을 권장한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbeRFoKWdoefKCvECrNfkt
