### PR TITLE
feat(web): 채팅 헤더에 프로젝트명 브레드크럼 추가

### DIFF
--- a/services/aris-web/app/styles/project-chat/timeline-composer.css
+++ b/services/aris-web/app/styles/project-chat/timeline-composer.css
@@ -95,7 +95,33 @@
   flex: 1;
 }
 
+.pc-proto .ch__breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.pc-proto .ch__breadcrumb-project {
+  flex-shrink: 2;
+  min-width: 36px;
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-tertiary);
+  font-size: 14px;
+  font-weight: 550;
+}
+
+.pc-proto .ch__breadcrumb-sep {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  opacity: 0.5;
+}
+
 .pc-proto .ch__title {
+  min-width: 36px;
   font-size: 14px;
   font-weight: 650;
   color: var(--text-primary);

--- a/services/aris-web/components/project-chat/ProjectChatSurface.tsx
+++ b/services/aris-web/components/project-chat/ProjectChatSurface.tsx
@@ -2992,7 +2992,11 @@ export function ProjectChatSurface({
               <ChevronLeft size={18} />
             </button>
             <div className="ch__title-wrap">
-              <span className="ch__title">{activeChat?.title ?? 'Project chat'}</span>
+              <div className="ch__breadcrumb">
+                <span className="ch__breadcrumb-project" title={session.projectName}>{projectName}</span>
+                <span className="ch__breadcrumb-sep" aria-hidden="true">|</span>
+                <span className="ch__title">{activeChat?.title ?? 'Project chat'}</span>
+              </div>
               <span className="ch__status"><span className="ch__status-dot" />{projectStatusLabel(session.status)}</span>
               {projectRunIndicator && (
                 <span className="ch__running-indicator" role="status" aria-live="polite" data-tone={projectRunIndicator.tone}>


### PR DESCRIPTION
## Summary
- 채팅 화면 상단 헤더(`.ch__title`)가 채팅 제목만 표시해 어떤 프로젝트인지 알기 어려운 문제 개선
- `session`에 이미 전달되던 `projectName`(단축 표시명)을 채팅 제목 앞에 `|` 구분선으로 붙여 브레드크럼 형태로 렌더링
- 좁은 화면/긴 텍스트에서도 프로젝트명·채팅 제목이 완전히 사라지지 않도록 각각 최소 폭(36px)을 보장

## Test plan
- [x] `tsc --noEmit` 통과
- [x] dev 서버(worktree, 포트 2234) + Playwright로 실제 로그인 후 프로젝트 챗 화면에서 "ARIS | Project chat" 렌더링 확인 (데스크톱/모바일 뷰포트)
- [x] DOM에 인위적으로 긴 프로젝트명/채팅 제목을 주입해 truncate 동작 및 완전 소실 방지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)