### PR TITLE
feat(web): 채팅 생성 인디케이터 & 컴포저 회전 글로우

### DIFF
--- a/services/aris-web/app/styles/project-chat/timeline-composer.css
+++ b/services/aris-web/app/styles/project-chat/timeline-composer.css
@@ -1254,6 +1254,117 @@ html[data-theme='dark'] .pc-proto .pc-action-stack {
   box-shadow: 0 0 0 3px var(--mc-ring-soft);
 }
 
+/* 컴포저 테두리를 따라 도는 글로우. 링(마스크)은 고정하고 그 안의
+   conic-gradient만 회전시켜, 사각형 모서리가 실제 테두리와 항상
+   일치하도록 한다 (마스킹된 박스 자체를 rotate()하면 모서리가 어긋난다). */
+.pc-proto .glow-ring {
+  position: absolute;
+  inset: -3px;
+  border-radius: 17px;
+  padding: 3px;
+  overflow: hidden;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
+
+.pc-proto .cmp-pill .glow-ring {
+  inset: -3px;
+  border-radius: var(--r-full);
+}
+
+.pc-proto .cmp--generating .glow-ring,
+.pc-proto .cmp-pill--generating .glow-ring {
+  opacity: 1;
+}
+
+.pc-proto .glow-ring__spin {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 1600px;
+  height: 1600px;
+  transform: translate(-50%, -50%) rotate(0deg);
+  background: conic-gradient(from 0deg, transparent 0deg 260deg, var(--mc-ring) 300deg, #fff 315deg, var(--mc-ring) 330deg, transparent 360deg);
+  animation: pc-glow-spin 2.6s linear infinite;
+  animation-play-state: paused;
+}
+
+.pc-proto .cmp--generating .glow-ring__spin,
+.pc-proto .cmp-pill--generating .glow-ring__spin {
+  animation-play-state: running;
+}
+
+@keyframes pc-glow-spin {
+  from { transform: translate(-50%, -50%) rotate(0deg); }
+  to { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pc-proto .glow-ring__spin {
+    animation: none;
+  }
+
+  .pc-proto .cmp--generating .glow-ring,
+  .pc-proto .cmp-pill--generating .glow-ring {
+    opacity: 0.85;
+  }
+}
+
+/* 타임라인의 "응답 생성 중" 매트릭스 펄스 점 인디케이터 */
+.pc-proto .msg--generating .msg__body {
+  display: flex;
+  align-items: center;
+  min-height: 28px;
+}
+
+.pc-proto .cmp-generating-loader {
+  --dot: 6px;
+  --gap: 5px;
+  display: grid;
+  grid-template-columns: repeat(3, var(--dot));
+  grid-template-rows: repeat(3, var(--dot));
+  gap: var(--gap);
+}
+
+.pc-proto .cmp-generating-loader span {
+  width: var(--dot);
+  height: var(--dot);
+  border-radius: 50%;
+  background: var(--mc-ring);
+  opacity: 0.22;
+  animation: pc-matrix-pulse 1.6s ease-in-out infinite;
+}
+
+.pc-proto .cmp-generating-loader span:nth-child(1) { animation-delay: 0s; }
+.pc-proto .cmp-generating-loader span:nth-child(2) { animation-delay: 0.12s; }
+.pc-proto .cmp-generating-loader span:nth-child(3) { animation-delay: 0.24s; }
+.pc-proto .cmp-generating-loader span:nth-child(4) { animation-delay: 0.12s; }
+.pc-proto .cmp-generating-loader span:nth-child(5) { animation-delay: 0.24s; }
+.pc-proto .cmp-generating-loader span:nth-child(6) { animation-delay: 0.36s; }
+.pc-proto .cmp-generating-loader span:nth-child(7) { animation-delay: 0.24s; }
+.pc-proto .cmp-generating-loader span:nth-child(8) { animation-delay: 0.36s; }
+.pc-proto .cmp-generating-loader span:nth-child(9) { animation-delay: 0.48s; }
+
+@keyframes pc-matrix-pulse {
+  0%, 70%, 100% { opacity: 0.22; transform: scale(1); }
+  35% { opacity: 1; transform: scale(1.4); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pc-proto .cmp-generating-loader span {
+    animation: pc-matrix-pulse-reduced 1.6s ease-in-out infinite;
+  }
+
+  @keyframes pc-matrix-pulse-reduced {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 1; }
+  }
+}
+
 .pc-proto .cmp__top,
 .pc-proto .cmp__toolbar {
   display: flex;

--- a/services/aris-web/components/project-chat/ProjectChatSurface.tsx
+++ b/services/aris-web/components/project-chat/ProjectChatSurface.tsx
@@ -277,7 +277,8 @@ function ProjectChatComposer({
 
   return (
     <footer ref={composerWrapRef} className="cmp-wrap">
-      <form ref={formRef} className="cmp" onSubmit={onSubmit}>
+      <form ref={formRef} className={`cmp${isRunning ? ' cmp--generating' : ''}`} onSubmit={onSubmit}>
+        <div className="glow-ring" aria-hidden="true"><div className="glow-ring__spin" /></div>
         <div className="cmp__top">
           <div className="cmp-mode" role="tablist" aria-label="Mode">
             {(['agent', 'plan', 'terminal'] as ComposerMode[]).map((mode) => (
@@ -2746,6 +2747,23 @@ export function ProjectChatSurface({
   });
   flushStack();
 
+  if (projectRunIndicator?.tone === 'running' || projectRunIndicator?.tone === 'submitting') {
+    rendered.push(
+      <div key="pc-generating" className="msg msg--generating" role="status" aria-live="polite">
+        <span className={`msg__avatar ${agentAvatarClass(activeAgent)}`}>
+          <ProviderLogo provider={selectedProvider} />
+        </span>
+        <div className="msg__body">
+          <div className="cmp-generating-loader" aria-label="응답 생성 중">
+            <span /><span /><span />
+            <span /><span /><span />
+            <span /><span /><span />
+          </div>
+        </div>
+      </div>,
+    );
+  }
+
   if (!selectedChatId) {
     return (
       <div className="pc-chat-directory" data-project-chat-list>
@@ -3148,7 +3166,8 @@ export function ProjectChatSurface({
 
           <footer ref={composerWrapRef} className="cmp-wrap">
             {isComposerCollapsed && (
-              <div className="cmp-pill">
+              <div className={`cmp-pill${projectRunActive ? ' cmp-pill--generating' : ''}`}>
+                <div className="glow-ring" aria-hidden="true"><div className="glow-ring__spin" /></div>
                 <button
                   type="button"
                   className="cmp-pill__add"
@@ -3184,7 +3203,8 @@ export function ProjectChatSurface({
                 </button>
               </div>
             )}
-            <form className="cmp" onSubmit={handleSubmit}>
+            <form className={`cmp${projectRunActive ? ' cmp--generating' : ''}`} onSubmit={handleSubmit}>
+              <div className="glow-ring" aria-hidden="true"><div className="glow-ring__spin" /></div>
               <div className="cmp__top">
                 <div className="cmp-mode" role="tablist" aria-label="Mode">
                   {(['agent', 'plan', 'terminal'] as ComposerMode[]).map((mode) => (


### PR DESCRIPTION
## Summary
- 응답 생성 중 채팅 타임라인에 매트릭스 펄스(3x3 점 격자, 대각선 스태거) 인디케이터를 표시 (`msg--generating` / `cmp-generating-loader`)
- 데스크톱 컴포저(`.cmp`)와 모바일 컴포저 pill(`.cmp-pill`) 테두리에 `--mc-ring` 색으로 도는 글로우 링을 추가 (`glow-ring` / `glow-ring__spin`)
- 글로우는 마스킹된 링 자체는 고정하고 내부 conic-gradient만 회전시켜, 사각형/알약 모양 테두리와 항상 정렬되도록 구현 (마스킹된 박스를 통째로 rotate()하면 모서리가 어긋나는 문제를 회피)
- 새 토큰 추가 없이 기존 `--mc-ring`을 재사용해 모드(에이전트/플랜/터미널)별 색이 자동 반영됨
- `prefers-reduced-motion`에서 회전을 멈추고 은은한 투명도 펄스로 대체

디자인 시안: https://claude.ai/code/artifact/5708f8cb-a6fa-47b7-9b75-3cca39d609f7

## Test plan
- [x] `tsc --noEmit` 통과
- [x] 관련 vitest 스위트(`projectListSurface`, `chatComposerLayout`, `chatComposerView`, `chatComposerDockLayout`, `composerPillExpandFocusTiming`, `mobileKeyboardComposerLock`) 56개 통과
- [x] `git diff --check` 통과
- [x] 실제 프로젝트 CSS(app/globals.css 체인)를 그대로 로드하는 정적 하네스 + Playwright 스크린샷으로 데스크톱 컴포저(`.cmp`) 및 모바일 알약 컴포저(`.cmp-pill`, 767px 이하 미디어 쿼리) 양쪽에서 글로우가 실제 테두리를 정확히 따라 도는지, 매트릭스 펄스가 모드별 색을 반영하는지 육안 확인
- [ ] 실제 dev 서버 + 로그인 세션으로 실제 에이전트 실행 중 상태에서 확인 (이번 세션에서는 prod 자격증명 접근이 자동 차단되어 미실시 — 리뷰어가 실제 채팅에서 한 번 더 확인 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzQNNBPoRUUTXc8EVhT9Qq