### PR TITLE
fix(web): 모바일 채팅 셸이 실제 보이는 뷰포트 높이를 다시 따르도록 복원

### DIFF
--- a/services/aris-web/app/styles/ia-shell.css
+++ b/services/aris-web/app/styles/ia-shell.css
@@ -864,25 +864,32 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
    절대 바꾸지 않고, 포커스된 입력을 화면에 보이도록 끌어올리는 브라우저
    네이티브 동작을 그대로 둔다.)
 
-   이전 시도는 data-keyboard-open일 때 html/body를 position:fixed로 강제
+   1차 시도는 data-keyboard-open일 때 html/body를 position:fixed로 강제
    잠갔다. CSS 자체는 정확했지만 position:static → fixed 전환은 스펙상
    transition이 불가능한 이산적(discrete) 값 변경이라, 네이티브 스크롤이
    컴포저를 끌어올린 "직후" 이 잠금이 뒤늦게 걸리며 순간이동(스냅)하는
-   것으로 보였다 — "화면 맨 위로 과도하게 올라갔다가 정상 위치로 순간이동".
+   것으로 보였다.
 
-   근본 수정은 reset.css에서 overflow-x: hidden을 overflow-x: clip으로
-   바꾼 것이다: CSS Overflow 스펙상 overflow-x가 non-visible이고 overflow-y가
-   미지정이면 overflow-y가 auto로 자동 승격되는데(hidden은 이 승격을
-   트리거), 이게 키보드가 열린 동안 body에 실제보다 훨씬 큰 스크롤 가능
-   여백을 만든 진짜 원인이었다. clip은 이 승격을 트리거하지 않으므로,
-   네이티브 스크롤이 필요한 만큼(키보드 높이만큼)만 자연스럽게 문서를
-   끌어올리고 — 이게 ChatGPT/Claude 같은 서비스가 "매끄럽게" 느껴지는 이유다:
-   그들도 이 문제를 막지 않고, 막을 필요가 없도록 구조 자체를 정직하게
-   유지한다.
+   2차 시도는 position:fixed 잠금과 함께 셸의 높이 추적(.aris-ia-shell/
+   .pc-proto/.shell가 --visual-viewport-height를 따르던 규칙)까지 통째로
+   제거하고, reset.css의 overflow-x: hidden → clip 전환만으로 충분하다고
+   판단했다. 이건 틀렸다: overflow-x: clip은 overflow-y가 auto로 자동
+   승격되는 것만 막을 뿐, .aris-ia-shell/.pc-proto/.shell이 여전히 얼어붙은
+   --app-vh(키보드가 열린 동안 이전 높이에 고정)를 그대로 쓰고 있었다.
+   셸 전체가 실제로 보이는 영역보다 훨씬 커진 채로 남아 있었고, 그 차이
+   (최대 수백 px)만큼 네이티브 "포커스 요소 스크롤"이 페이지 전체를
+   과도하게 끌어올려 컴포저가 화면 맨 위까지 튀는 현상으로 재현됐다
+   (실기기 스크린샷으로 확인).
 
-   .cmp__input의 auto-grow 상한만 남겨둔다 — position/scroll과 무관하게
-   입력창 자체가 과도하게 커지지 않도록 하는 순수 시각적 제약이라 여기엔
-   영향이 없다. */
+   최종 수정: 셸 높이 추적을 되살리되(아래), position은 여전히 절대
+   바꾸지 않는다. height/min-height는 숫자 값이라 position과 달리
+   transition으로 부드럽게 이어진다 — 셸이 실제 보이는 영역에 맞춰
+   부드럽게 줄어들므로, 컴포저는 애초에 축소된 셸의 바닥 근처에 남아있게
+   되어 네이티브 스크롤이 거의/전혀 필요하지 않다. overflow-x: clip은
+   부수적인 방어 조치로 남겨둔다(auto 승격을 막는 것 자체는 여전히 유효).
+
+   .cmp__input의 auto-grow 상한도 같은 이유로 유지한다 — position/scroll과
+   무관하게 입력창 자체가 과도하게 커지지 않도록 하는 순수 시각적 제약. */
 @media (max-width: 767px) {
   .pc-proto .cmp__input {
     transition: max-height 150ms var(--ease-smooth, ease);

--- a/services/aris-web/app/styles/ui-responsive.css
+++ b/services/aris-web/app/styles/ui-responsive.css
@@ -120,7 +120,14 @@
   }
 
   .app-shell-ia--chat-screen .aris-ia-shell {
-    min-height: var(--app-vh, 100dvh);
+    /* --app-vh는 키보드가 열린 동안 이전(더 큰) 높이에 고정되므로 그대로 쓰면
+       채팅 화면 전체가 실제로 보이는 영역보다 커진 채로 남는다. 그 여백만큼
+       네이티브 "포커스 요소 스크롤"이 페이지 전체를 과도하게 끌어올리게 되므로
+       (컴포저가 화면 맨 위로 튀는 현상의 원인) 항상 실제 보이는 높이를 따르는
+       --visual-viewport-height를 쓴다. position은 절대 바꾸지 않고 height만
+       숫자로 바뀌므로 transition으로 부드럽게 이어진다. */
+    min-height: var(--visual-viewport-height, 100dvh);
+    transition: min-height 200ms var(--ease-smooth, ease);
   }
 
   .m-sb {
@@ -314,22 +321,32 @@
      더 이상 그 높이를 빼지 않는다. ia-shell.css의 더 구체적인
      `.m-main-scroll--project-chat-detail .pc-proto` 규칙을 이겨야 하므로
      동일한 선택자 체인으로 작성한다(파일 로드 순서상 이 파일이 나중이라
-     동률일 때 이 규칙이 이긴다). */
+     동률일 때 이 규칙이 이긴다).
+
+     --app-vh가 아니라 --visual-viewport-height를 쓴다: --app-vh는 키보드가
+     열린 동안 이전(더 큰) 높이에 고정되는데, 이 셸이 그 얼어붙은 높이를
+     그대로 쓰면 실제 보이는 영역보다 커진 채로 남아 네이티브 "포커스 요소
+     스크롤"이 그 차이만큼 페이지 전체를 과도하게 끌어올린다(컴포저가 화면
+     맨 위로 튀는 현상). position은 절대 바꾸지 않으므로(static 유지)
+     height 변화 자체는 transition으로 부드럽게 이어진다. */
   .m-main-scroll--project-chat-detail .pc-proto {
-    min-height: var(--app-vh, 100dvh);
+    min-height: var(--visual-viewport-height, 100dvh);
+    transition: min-height 200ms var(--ease-smooth, ease);
   }
 
   .pc-parallel {
-    height: var(--app-vh, 100dvh);
+    height: var(--visual-viewport-height, 100dvh);
     min-height: 0;
+    transition: height 200ms var(--ease-smooth, ease);
   }
 
   .m-main-scroll--project-chat-detail .pc-proto .shell {
     /* 부모 min-height 기준의 % 해석에 기대지 않도록 명시 높이를 사용한다.
        헤더 표시/숨김에 따라 흔들리지 않도록 상수로 고정한다(스크롤 시
        공간 확보는 .tl의 padding-top 쪽에서 처리한다). */
-    height: var(--app-vh, 100dvh);
+    height: var(--visual-viewport-height, 100dvh);
     min-height: 0;
+    transition: height 200ms var(--ease-smooth, ease);
   }
 
   .pc-proto .ch {

--- a/services/aris-web/tests/mobileKeyboardShellHeightTracking.test.ts
+++ b/services/aris-web/tests/mobileKeyboardShellHeightTracking.test.ts
@@ -1,0 +1,36 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { readCssWithImports } from './helpers/readAppStyles';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const uiResponsiveCss = readCssWithImports(resolve(__dirname, '../app/styles/ui-responsive.css'));
+
+describe('mobile chat shell tracks the live visual viewport height', () => {
+  // 실기기 스크린샷으로 재확인된 회귀: overflow-x: clip 수정만으로는 부족했다.
+  // .aris-ia-shell/.pc-proto/.shell이 여전히 얼어붙은 --app-vh(키보드가 열린
+  // 동안 이전 높이에 고정)를 쓰고 있었고, 셸 전체가 실제 보이는 영역보다
+  // 훨씬 커진 채로 남아 네이티브 "포커스 요소 스크롤"이 그 차이만큼 페이지를
+  // 과도하게 끌어올려 컴포저가 화면 맨 위까지 튀었다. position은 절대 건드리지
+  // 않고(전과 동일) 셸의 height/min-height만 --visual-viewport-height를
+  // 따르도록 복원한다 — 숫자 값이라 transition으로 부드럽게 이어진다.
+
+  it('drives .aris-ia-shell, .pc-proto and .shell from --visual-viewport-height, not the keyboard-frozen --app-vh', () => {
+    expect(uiResponsiveCss).toMatch(
+      /\.app-shell-ia--chat-screen \.aris-ia-shell \{[^}]*min-height:\s*var\(--visual-viewport-height, 100dvh\);/s,
+    );
+    expect(uiResponsiveCss).toMatch(
+      /\.m-main-scroll--project-chat-detail \.pc-proto \{[^}]*min-height:\s*var\(--visual-viewport-height, 100dvh\);/s,
+    );
+    expect(uiResponsiveCss).toMatch(
+      /\.m-main-scroll--project-chat-detail \.pc-proto \.shell \{[^}]*height:\s*var\(--visual-viewport-height, 100dvh\);/s,
+    );
+  });
+
+  it('transitions height/min-height smoothly instead of snapping (position is never touched, so this is safe)', () => {
+    const shellBlock = uiResponsiveCss.match(/\.m-main-scroll--project-chat-detail \.pc-proto \.shell \{([^}]*)\}/s)?.[1] ?? '';
+    expect(shellBlock).toContain('transition: height 200ms');
+    const ariaShellBlock = uiResponsiveCss.match(/\.app-shell-ia--chat-screen \.aris-ia-shell \{([^}]*)\}/s)?.[1] ?? '';
+    expect(ariaShellBlock).toContain('transition: min-height 200ms');
+  });
+});

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -693,11 +693,17 @@ describe('project list surface', () => {
     expect(homeClient).toContain('{shouldShowBottomNav && <BottomNav activeTab={activeTab} onTabChange={handleTabChange} />}');
     expect(homeClient).toContain("className={`app-shell app-shell-ia${shouldShowBottomNav ? '' : ' app-shell-ia--chat-screen'}${projectSurfaceMode === 'panel' ? ' app-shell-ia--project-panel' : ''}`}");
     expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.app-shell-ia--chat-screen\s*\{[^}]*padding-bottom:\s*0;/s);
-    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.app-shell-ia--chat-screen \.aris-ia-shell\s*\{[^}]*min-height:\s*var\(--app-vh,\s*100dvh\);/s);
+    // --app-vh가 아니라 --visual-viewport-height를 쓴다: --app-vh는 키보드가
+    // 열린 동안 이전 높이에 고정되는데, 이 셸들이 그 얼어붙은 높이를 그대로
+    // 쓰면 실제 보이는 영역보다 커진 채로 남아 네이티브 "포커스 요소 스크롤"이
+    // 그 차이만큼 페이지 전체를 과도하게 끌어올린다(컴포저가 화면 맨 위로
+    // 튀는 회귀, 실기기로 확인됨). position은 건드리지 않으므로 height 값
+    // 자체의 전환은 transition으로 부드럽게 이어진다.
+    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.app-shell-ia--chat-screen \.aris-ia-shell\s*\{[^}]*min-height:\s*var\(--visual-viewport-height,\s*100dvh\);/s);
     // 모바일 채팅 화면은 앱 탑바를 항상 렌더링하지 않으므로(1줄 헤더 병합)
     // .pc-proto/.shell 높이 계산에서 더 이상 그 48px을 빼지 않는다.
-    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.m-main-scroll--project-chat-detail \.pc-proto\s*\{[^}]*min-height:\s*var\(--app-vh,\s*100dvh\);/s);
-    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.m-main-scroll--project-chat-detail \.pc-proto \.shell\s*\{[^}]*height:\s*var\(--app-vh,\s*100dvh\);[^}]*min-height:\s*0;/s);
+    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.m-main-scroll--project-chat-detail \.pc-proto\s*\{[^}]*min-height:\s*var\(--visual-viewport-height,\s*100dvh\);/s);
+    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.m-main-scroll--project-chat-detail \.pc-proto \.shell\s*\{[^}]*height:\s*var\(--visual-viewport-height,\s*100dvh\);[^}]*min-height:\s*0;/s);
     expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.app-shell-ia--chat-screen \.m-top\s*\{[^}]*display:\s*none;/s);
     // 채팅 헤더는 스크롤 숨김 시 이동시키지 않고 언마운트되며(React 쪽), 표시
     // 중에는 타임라인 위 오버레이라 .tl/.shell__main의 박스 크기를 흔들지 않는다.


### PR DESCRIPTION
## 배경

PR #388(overflow-x: hidden → clip) 배포 후 스크린샷으로 "확장된 컴포저 터치 시 위로 밀려올라가는 버그 재발" 신고를 받았다. 실기기 스크린샷: 컴포저가 화면 맨 위(상태바 근처)에 붙어 있고, 그 아래 키보드가 나타나기 전까지 큰 검은 빈 공간이 있음 — 원래 버그(PR #386/#387이 다루던 것)가 그대로 재현된 모습이었다.

## 재진단

PR #388에서 "overflow-x: clip이 근본 수정"이라고 판단해, `.aris-ia-shell`/`.pc-proto`/`.shell`이 `--visual-viewport-height`를 따르던 높이 추적 규칙(PR #386/#387에서 도입)을 통째로 제거했다. 이건 **틀린 진단이었다.**

Playwright로 `/login` 페이지에서 실제 번들 CSS를 추출해 격리된 정적 페이지에 주입하고, 채팅 화면과 동일한 DOM 구조를 만들어 `--visual-viewport-height`를 직접 조작해 재현했다:

**수정 전(현재 main)**: `--visual-viewport-height`를 844px→380px로 바꿔도 `.shell`의 계산된 `height`는 **844px에 그대로 머묾**. `.aris-ia-shell`/`.pc-proto`도 마찬가지. 이 셸들은 여전히 얼어붙은 `--app-vh`(키보드가 열린 동안 이전 높이에 고정됨, `ViewportHeightSync`의 의도된 동작)를 참조하고 있었다.

이게 진짜 문제다: `overflow-x: clip`은 `overflow-y`가 `auto`로 자동 승격되는 것만 막을 뿐, 셸 자체가 실제 보이는 영역보다 최대 수백 px 더 큰 채로 남아있는 건 막지 못한다. 그 차이만큼 네이티브 "포커스 요소를 화면에 보이도록 스크롤"이 페이지 전체를 과도하게 끌어올려 컴포저가 화면 맨 위까지 튀는 것 — 정확히 사용자가 보여준 증상과 일치한다.

## 수정

**position은 여전히 절대 바꾸지 않는다** — PR #388에서 배운 교훈(position:static → fixed 전환은 transition 불가능한 이산적 값 변경이라 스냅을 유발한다)은 그대로 유지한다.

대신 `.aris-ia-shell`/`.pc-proto`/`.pc-parallel`/`.shell`의 `height`/`min-height`를 `--visual-viewport-height`로 복원했다. 이 값들은 **숫자**라 `position`과 달리 `transition`으로 부드럽게 이어진다 — 200ms transition을 추가해, 셸이 키보드 상태에 맞춰 부드럽게 줄어들도록 했다. 셸이 실제 보이는 영역에 맞게 줄어들면 컴포저는 애초에 축소된 셸의 바닥 근처에 남아있게 되어, 네이티브 스크롤이 거의/전혀 필요 없어진다.

## 검증

같은 격리 재현 방법으로 수정 후 재확인:
```
before (visualViewportHeight=844px): .shell height = 844px, 컴포저 top:806~bottom:844
after  (visualViewportHeight=380px): .shell height = 380px, 컴포저 top:342~bottom:380
```
셸이 정확히 380px로 줄고, 컴포저는 축소된 영역의 하단에 자연스럽게 위치 — 큰 스크롤이 전혀 필요 없다.

- `tsc`/`lint` 클린, **vitest 124개 파일/620개 테스트 통과** (신규 2개 추가, `projectListSurface.test.ts`의 stale `--app-vh` 단언 3건을 `--visual-viewport-height`로 갱신)
- 신규 회귀 방지 테스트(`mobileKeyboardShellHeightTracking.test.ts`)로 이 세 규칙이 `--app-vh`가 아니라 `--visual-viewport-height`를 참조하고, `transition`이 걸려 있는지 고정

### 남은 한계
이번엔 실측(정적 CSS 주입 재현)으로 셸 높이가 실제로 줄어드는 것까지 확인했지만, iOS 실기기에서 이 축소가 **키보드 애니메이션과 얼마나 자연스럽게 동기화되는지**(네이티브 애니메이션과 우리 CSS transition의 타이밍 일치 여부)는 headless 환경의 근본적 한계로 확인하지 못했다. 실기기 재확인을 권장하며, 여전히 문제가 있다면 이번엔 `visualViewport` 실측값(height/offsetTop)과 함께 스크린샷을 공유해 주시면 훨씬 빠르게 좁힐 수 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbeRFoKWdoefKCvECrNfkt
