### PR TITLE
debug(web): 모바일 키보드-컴포저 버그 실기기 진단 오버레이 추가

### DIFF
--- a/services/aris-web/app/layout.tsx
+++ b/services/aris-web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import { ReactGrabDevBoot } from '@/components/dev/ReactGrabDevBoot';
+import { ViewportDebugOverlay } from '@/components/dev/ViewportDebugOverlay';
 import { ViewportHeightSync } from '@/components/layout/ViewportHeightSync';
 import { normalizeAppBasePath, withAppBasePath } from '@/lib/routing/appPath';
 
@@ -135,6 +136,7 @@ export default function RootLayout({
       <body>
         {process.env.NODE_ENV === 'development' ? <ReactGrabDevBoot /> : null}
         <ViewportHeightSync />
+        <ViewportDebugOverlay />
         {children}
       </body>
     </html>

--- a/services/aris-web/components/dev/ViewportDebugOverlay.tsx
+++ b/services/aris-web/components/dev/ViewportDebugOverlay.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const STORAGE_KEY = 'aris.vv-debug';
+const MAX_EVENTS = 12;
+
+/**
+ * 모바일 키보드-컴포저 버그의 실기기 진단용 오버레이.
+ *
+ * headless 브라우저는 iOS Safari의 비주얼 뷰포트 패닝(키보드가 열릴 때
+ * 레이아웃 뷰포트는 그대로 두고 보이는 영역만 이동시키며, 필요하면 없던
+ * 스크롤 공간까지 만들어 문서를 밀어올리는 동작)을 재현하지 못한다.
+ * 이 오버레이는 재현 순간의 실제 값(visualViewport.height/offsetTop,
+ * scrollY, 문서/셸 높이, 이벤트 타임라인)을 화면에 직접 그려서,
+ * 스크린샷 한 장으로 원인을 확정할 수 있게 한다.
+ *
+ * 활성화: 아무 페이지나 ?vvdebug=1 을 붙여 접속(localStorage에 저장되어
+ * 유지됨). 비활성화: ?vvdebug=0.
+ *
+ * 오버레이 자체는 vv.offsetTop만큼 top을 보정하므로 뷰포트가 패닝된
+ * 상태에서도 항상 화면 안에 남는다.
+ */
+function readEnabled(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  try {
+    const param = new URLSearchParams(window.location.search).get('vvdebug');
+    if (param === '1') {
+      window.localStorage.setItem(STORAGE_KEY, '1');
+      return true;
+    }
+    if (param === '0') {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return false;
+    }
+    return window.localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+type Snapshot = {
+  vvHeight: number;
+  vvOffsetTop: number;
+  innerHeight: number;
+  scrollY: number;
+  bodyScrollHeight: number;
+  docScrollHeight: number;
+  shellHeight: number | null;
+  cmpTop: number | null;
+  cmpBottom: number | null;
+  keyboardOpen: string;
+};
+
+function takeSnapshot(): Snapshot {
+  const shell = document.querySelector('[data-project-chat-screen] .shell, .pc-proto .shell');
+  const cmp = document.querySelector('.cmp-wrap .cmp');
+  const shellRect = shell?.getBoundingClientRect();
+  const cmpRect = cmp?.getBoundingClientRect();
+  return {
+    vvHeight: Math.round(window.visualViewport?.height ?? -1),
+    vvOffsetTop: Math.round(window.visualViewport?.offsetTop ?? -1),
+    innerHeight: window.innerHeight,
+    scrollY: Math.round(window.scrollY),
+    bodyScrollHeight: document.body.scrollHeight,
+    docScrollHeight: document.documentElement.scrollHeight,
+    shellHeight: shellRect ? Math.round(shellRect.height) : null,
+    cmpTop: cmpRect ? Math.round(cmpRect.top) : null,
+    cmpBottom: cmpRect ? Math.round(cmpRect.bottom) : null,
+    keyboardOpen: document.documentElement.dataset.keyboardOpen ?? '-',
+  };
+}
+
+export function ViewportDebugOverlay() {
+  const [enabled, setEnabled] = useState(false);
+  const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
+  const [events, setEvents] = useState<string[]>([]);
+  const focusEpochRef = useRef<number>(0);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    setEnabled(readEnabled());
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const pushEvent = (label: string) => {
+      const t = focusEpochRef.current
+        ? `+${Math.round(performance.now() - focusEpochRef.current)}ms`
+        : 't?';
+      setEvents((current) => [...current.slice(-(MAX_EVENTS - 1)), `${t} ${label}`]);
+    };
+
+    const refresh = () => {
+      if (rafRef.current !== null) {
+        return;
+      }
+      rafRef.current = window.requestAnimationFrame(() => {
+        rafRef.current = null;
+        setSnapshot(takeSnapshot());
+      });
+    };
+
+    const onFocusIn = (event: FocusEvent) => {
+      const target = event.target as HTMLElement | null;
+      focusEpochRef.current = performance.now();
+      pushEvent(`focusin ${target?.tagName?.toLowerCase() ?? '?'}.${(target?.className ?? '').toString().split(' ')[0]}`);
+      refresh();
+    };
+    const onFocusOut = () => {
+      pushEvent('focusout');
+      refresh();
+    };
+    const onVvResize = () => {
+      const vv = window.visualViewport;
+      pushEvent(`vv.resize h=${Math.round(vv?.height ?? -1)} top=${Math.round(vv?.offsetTop ?? -1)}`);
+      refresh();
+    };
+    const onVvScroll = () => {
+      const vv = window.visualViewport;
+      pushEvent(`vv.scroll h=${Math.round(vv?.height ?? -1)} top=${Math.round(vv?.offsetTop ?? -1)}`);
+      refresh();
+    };
+    const onWindowScroll = () => {
+      pushEvent(`win.scroll sY=${Math.round(window.scrollY)}`);
+      refresh();
+    };
+
+    document.addEventListener('focusin', onFocusIn, { passive: true } as AddEventListenerOptions);
+    document.addEventListener('focusout', onFocusOut, { passive: true } as AddEventListenerOptions);
+    window.visualViewport?.addEventListener('resize', onVvResize, { passive: true } as AddEventListenerOptions);
+    window.visualViewport?.addEventListener('scroll', onVvScroll, { passive: true } as AddEventListenerOptions);
+    window.addEventListener('scroll', onWindowScroll, { passive: true });
+    // 이벤트가 발생하지 않는 변화(레이아웃 전환 등)도 주기적으로 갱신한다.
+    const interval = window.setInterval(refresh, 300);
+    refresh();
+
+    return () => {
+      document.removeEventListener('focusin', onFocusIn);
+      document.removeEventListener('focusout', onFocusOut);
+      window.visualViewport?.removeEventListener('resize', onVvResize);
+      window.visualViewport?.removeEventListener('scroll', onVvScroll);
+      window.removeEventListener('scroll', onWindowScroll);
+      window.clearInterval(interval);
+      if (rafRef.current !== null) {
+        window.cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, [enabled]);
+
+  if (!enabled || !snapshot) {
+    return null;
+  }
+
+  const s = snapshot;
+  return (
+    <div
+      data-vv-debug-overlay
+      style={{
+        position: 'fixed',
+        // 비주얼 뷰포트가 패닝돼도 항상 보이도록 offsetTop만큼 보정한다.
+        top: s.vvOffsetTop + 44,
+        left: 4,
+        right: 4,
+        zIndex: 2147483000,
+        pointerEvents: 'none',
+        background: 'rgba(0, 0, 0, 0.78)',
+        color: '#7dff9a',
+        font: '10px/1.45 ui-monospace, Menlo, monospace',
+        padding: '6px 8px',
+        borderRadius: 6,
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-all',
+      }}
+    >
+      {`vv h=${s.vvHeight} top=${s.vvOffsetTop} | innerH=${s.innerHeight} sY=${s.scrollY} kb=${s.keyboardOpen}
+body sh=${s.bodyScrollHeight} doc sh=${s.docScrollHeight} | shell h=${s.shellHeight ?? '-'} | cmp ${s.cmpTop ?? '-'}..${s.cmpBottom ?? '-'}
+${events.join('\n')}`}
+    </div>
+  );
+}


### PR DESCRIPTION
## 배경

모바일 키보드 오픈 시 컴포저가 화면 맨 위로 밀려 올라가는 버그가 4번의 수정(#386, #387, #388, #393) 후에도 실기기에서 계속 재현되고 있다.

**4번 모두 실패한 공통 원인은 검증 환경이다.** headless 브라우저는 iOS Safari의 핵심 동작 — 키보드가 열릴 때 레이아웃 뷰포트는 그대로 두고 **비주얼 뷰포트만 패닝(pan)**하며, 필요하면 존재하지 않던 스크롤 공간까지 만들어 문서를 밀어올리는 동작 — 을 구조적으로 재현하지 못한다. 그래서 모든 수정이 시뮬레이션에서는 통과했고 실기기에서만 깨졌다.

CLAUDE.md의 디버깅 지침("수정 시도 2회를 넘으면 멈추고 로깅을 추가해 가정을 재검증하라")에 따라, 5번째 추측성 수정 대신 **실기기에서 재현 순간의 실제 값을 화면에 직접 그리는 진단 오버레이**를 추가한다.

## 내용

`components/dev/ViewportDebugOverlay.tsx` (신규), `app/layout.tsx`에 마운트.

표시 항목:
- `visualViewport.height` / `offsetTop`, `window.innerHeight` / `scrollY`, `body`/`document` `scrollHeight`, `.shell` 높이, 컴포저 rect, `data-keyboard-open`
- 이벤트 타임라인: `focusin`/`focusout`, `vv.resize`/`vv.scroll`, `window.scroll` — 포커스 시점 기준 `+ms`로 기록

오버레이 자체는 `vv.offsetTop`만큼 top을 보정하므로 **뷰포트가 패닝된(버그가 재현된) 상태에서도 항상 화면 안에 남는다** — 재현 순간 스크린샷 한 장으로 어떤 메커니즘(문서 스크롤? 비주얼 뷰포트 팬? 셸 축소 불발? 조합?)이 컴포저를 밀어올리는지 확정할 수 있다.

## 사용법

1. 아무 페이지나 `?vvdebug=1`을 붙여 접속 — 예: `https://aris.lawdigest.kr/?vvdebug=1` (localStorage에 저장되어 이후 페이지 이동에도 유지)
2. 채팅 화면에서 버그 재현(확장된 컴포저 터치 → 키보드 오픈)
3. 재현된 상태에서 스크린샷 — 화면의 검은 디버그 박스에 모든 값이 담김
4. 끄기: `?vvdebug=0`

플래그가 없으면 아무것도 렌더링하지 않으므로 일반 사용자에게 영향 없음.

## 검증
- `tsc`/`lint` 클린, vitest 124 파일/620 테스트 통과
- dev 서버 실측: 오버레이 렌더링, `focusin` 이벤트 기록(낙관적 잠금의 `kb=true` 전환 포함), localStorage 지속, `?vvdebug=0` 비활성화 모두 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbeRFoKWdoefKCvECrNfkt
