### PR TITLE
fix(web): 키보드 오픈 중 body와 --app-vh 래퍼 체인의 min-height를 실제 뷰포트로 축소

### DIFF
--- a/services/aris-web/app/styles/ia-shell.css
+++ b/services/aris-web/app/styles/ia-shell.css
@@ -898,6 +898,39 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen .pc-proto .cmp__input {
     max-height: min(200px, calc(var(--visual-viewport-height, 100dvh) * 0.3));
   }
+
+  /* 실기기 진단 오버레이 실측(2026-07-09)으로 확정된 마지막 원인:
+     키보드가 열리면 레이아웃 뷰포트(innerHeight)가 746→399로 줄고
+     (interactive-widget=resizes-content가 최신 iOS에서 실제 동작),
+     셸도 399로 정상 축소됐지만(#393), body만 reset.css의
+     min-height: var(--app-vh) — 키보드 오픈 중 이전 높이 746에
+     얼어붙는 값 — 를 유지해 문서가 뷰포트보다 정확히 347px 커졌다.
+     iOS는 그 여백만큼 문서를 스크롤해(sY=347) 포커스된 컴포저를
+     화면 위로 밀어올렸다(cmp rect -99..44). 347 = 746 - 399.
+
+     이 override는 원래 PR #386에 있었는데 #388에서 overflow-x: clip을
+     근본 수정으로 오판하며 삭제된 것이 회귀 지점이다 — clip은
+     overflow-y의 auto 승격만 막을 뿐 min-height 746은 없애지 못한다.
+
+     키보드가 열려 있는 동안 html/body도 실제 보이는 높이를 따르게 해
+     스크롤 여백 자체를 제거한다. position/overflow는 건드리지 않으므로
+     (#387의 position:fixed 스냅 문제와 무관) 부드럽게 동작한다.
+     data-keyboard-open은 포커스 즉시 낙관적으로 켜지므로(#387) iOS의
+     스크롤(+150ms 시점)보다 먼저 적용된다. */
+  html[data-keyboard-open='true'],
+  html[data-keyboard-open='true'] body {
+    min-height: var(--visual-viewport-height, 100dvh);
+  }
+
+  /* body의 min-height만 줄여서는 부족하다(실측: bodyMinHeight 399로
+     적용돼도 bodyScrollHeight는 746 유지) — 문서 높이는 자식 중 가장 큰
+     박스가 결정하는데, .app-shell-ia(min-height: var(--app-vh))와
+     .m-main(min-height: var(--app-vh))이 얼어붙은 746을 유지하며 body를
+     떠받치고 있었다. --app-vh를 참조하는 래퍼 체인 전체를 함께 줄인다. */
+  html[data-keyboard-open='true'] .app-shell-ia--chat-screen,
+  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main {
+    min-height: var(--visual-viewport-height, 100dvh);
+  }
 }
 
 .app-shell-ia--project-panel .aris-ia-shell {

--- a/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
+++ b/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
@@ -34,6 +34,29 @@ describe('mobile keyboard composer — cooperates with native scroll instead of 
     expect(resetCss).not.toMatch(/html,\s*body\s*\{[^}]*overflow-x:\s*hidden;/s);
   });
 
+  it('shrinks html/body min-height to the live visual viewport while the keyboard is open', () => {
+    // 실기기 진단 오버레이 실측으로 확정된 마지막 원인: reset.css의
+    // min-height: var(--app-vh)는 키보드 오픈 중 이전 높이(746)에 얼어붙어
+    // 문서가 뷰포트(399)보다 커지고, iOS가 그 여백만큼 문서를 스크롤해
+    // (sY=347=746-399) 컴포저를 화면 위로 밀어올렸다. 키보드가 열려 있는
+    // 동안은 html/body의 min-height도 실제 보이는 높이를 따라야 한다.
+    // (이 override는 PR #386에 있다가 #388에서 잘못 삭제됐던 규칙이다.)
+    expect(iaShellCss).toMatch(
+      /html\[data-keyboard-open='true'\],\s*\n\s*html\[data-keyboard-open='true'\] body\s*\{[^}]*min-height:\s*var\(--visual-viewport-height, 100dvh\);/,
+    );
+  });
+
+  it('also shrinks the --app-vh wrapper chain (.app-shell-ia--chat-screen, .m-main) while the keyboard is open', () => {
+    // body의 min-height만 줄여서는 부족하다(격리 재현 실측: bodyMinHeight가
+    // 399로 적용돼도 bodyScrollHeight는 746 유지). 문서 높이는 자식 중 가장
+    // 큰 박스가 결정하는데 .app-shell-ia와 .m-main이 각각
+    // min-height: var(--app-vh)로 얼어붙은 746을 유지하며 body를 떠받치고
+    // 있었다. 래퍼 체인 전체가 함께 줄어야 스크롤 여백이 사라진다.
+    expect(iaShellCss).toMatch(
+      /html\[data-keyboard-open='true'\] \.app-shell-ia--chat-screen,\s*\n\s*html\[data-keyboard-open='true'\] \.app-shell-ia--chat-screen \.m-main\s*\{[^}]*min-height:\s*var\(--visual-viewport-height, 100dvh\);/,
+    );
+  });
+
   it('still preserves the intentional page-scroll model on mobile (iOS toolbar auto-hide)', () => {
     // layout.css가 모바일에서 .app-shell-ia--chat-screen을 의도적으로
     // overflow:visible/height:auto로 두는 것은 이번 재설계와 방향이 같다 —


### PR DESCRIPTION
## 배경

컴포저가 키보드 오픈 시 화면 맨 위로 밀리는 버그를 4번(#386, #387, #388, #393) 고쳤으나 실기기에서 계속 재현됐다. PR #395의 진단 오버레이를 배포해 사용자가 재현 순간의 스크린샷을 제공했고, **이번에는 실측 데이터로 원인이 확정됐다.**

## 실측 데이터 (실기기, 2026-07-09)

```
vv h=399 top=347 | innerH=399 sY=347 kb=true
body sh=746 doc sh=746 | shell h=399 | cmp -99..44
+0ms   focusin textarea.cmp__input
+150ms vv.resize h=399 top=347
+151ms win.scroll sY=347
```

세 가지 사실이 확정됐다:

1. **키보드가 열리면 레이아웃 뷰포트(`innerHeight`)가 746→399로 줄어든다.** PR #387에서 추가한 `interactive-widget=resizes-content` 메타태그가 최신 iOS에서 실제로 동작하고 있다(과거 리서치의 "iOS 미지원" 정보는 구식이었다). 이는 유리한 조건이다 — 레이아웃이 함께 줄면 만사가 단순해진다.
2. **셸은 399로 정상 축소됐다** (`shell h=399`) — #393의 수정은 작동하고 있다.
3. **body만 746에 남아 있었다** (`body sh=746`): `reset.css`의 `min-height: var(--app-vh)`가 키보드 오픈 중 이전 높이에 얼어붙는 값을 그대로 쓰기 때문. 문서(746)가 뷰포트(399)보다 커진 347px의 여백만큼 iOS가 문서를 스크롤(`sY=347`)해 포커스된 컴포저를 화면 밖으로 밀어냈다(`cmp -99..44` — 화면 위로 99px 초과). **347 = 746 − 399. 수치가 정확히 맞아떨어진다.**

이 body min-height override는 원래 **PR #386에 있었는데 #388에서 잘못 삭제된 규칙**이다 — 당시 `overflow-x: clip`을 근본 수정으로 오판했는데, clip은 `overflow-y`의 auto 승격만 막을 뿐 min-height 746은 없애지 못한다.

## 수정

`html[data-keyboard-open='true']`일 때:
- `html`/`body`의 `min-height`를 `--visual-viewport-height`로 축소
- **래퍼 체인도 함께 축소** — 격리 재현에서 body만 줄여서는 부족함을 실측으로 확인했다(bodyMinHeight가 399로 적용돼도 bodyScrollHeight는 746 유지). 문서 높이는 자식 중 가장 큰 박스가 결정하는데, `.app-shell-ia`와 `.m-main`이 각각 `min-height: var(--app-vh)`로 746을 유지하며 body를 떠받치고 있었다.

`position`/`overflow`는 건드리지 않으므로(#387의 position:fixed 스냅 문제와 무관) 부드럽게 동작하고, `data-keyboard-open`은 포커스 즉시 낙관적으로 켜지므로(#387) iOS의 스크롤(+150ms)보다 먼저 적용된다.

## 검증

실기기 실측 조건을 정확히 재현한 격리 테스트(실제 번들 CSS 주입, 뷰포트 746→399 축소, `--app-vh` 746 고정, `--visual-viewport-height` 399):

```
BEFORE: bodyScrollHeight=746 → 스크롤 여백 347px (실기기와 동일한 FAIL)
AFTER:  bodyScrollHeight=399 = 뷰포트, 여백 0, 컴포저 361..399 정위치 (PASS)
400px을 넘는 요소: [] (없음)
```

- `tsc`/`lint` 클린, vitest 124 파일/622 테스트 통과 (회귀 방지 단언 2건 추가)
- 진단 오버레이(#395)는 그대로 유지 — 배포 후 사용자가 같은 방법으로 재확인 가능하고, 이번에는 `body sh`가 `vv h`와 같아지고 `sY=0`이 유지되는 것을 오버레이 숫자로 직접 볼 수 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbeRFoKWdoefKCvECrNfkt
