### PR TITLE
fix(web): iOS 네이티브 포커스 스크롤을 팬-추종(translateY offsetTop)으로 흡수

### DIFF
--- a/services/aris-web/app/styles/ia-shell.css
+++ b/services/aris-web/app/styles/ia-shell.css
@@ -931,6 +931,26 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main {
     min-height: var(--visual-viewport-height, 100dvh);
   }
+
+  /* iOS의 네이티브 "포커스 요소 스크롤"을 따라간다(팬-추종, ChatGPT 웹과
+     동일 패턴). 실기기 오버레이 실측(2026-07-09, 2차): 위 min-height 축소가
+     정확히 적용돼 body sh=399가 됐는데도 iOS는 포커스 시점의 옛
+     레이아웃(콘텐츠 746) 기준으로 미리 결정한 스크롤(sY=347)을 그대로
+     실행하고, 콘텐츠가 줄어든 뒤에도 스크롤 위치를 다시 클램프하지
+     않는다(doc sh=746 = scrollTop 347 + clientHeight 399). 즉 콘텐츠
+     축소만으로는 이 스크롤을 막을 수 없다.
+
+     그래서 스크롤과 싸우지 않고 그만큼 콘텐츠를 따라 내린다:
+     --visual-viewport-offset-top은 ViewportHeightSync가 vv.scroll/resize
+     마다 갱신하는 실측값(= 뷰포트가 밀려난 양, 347로 확인됨)이며, 이만큼
+     translateY하면 뷰포트가 바라보는 자리(347..746)에 콘텐츠(0..399)가
+     정확히 겹친다. 스크롤이 없으면(안드로이드/정상 축소) 0px라 no-op.
+     스크롤 이벤트와 같은 태스크에서 CSS 변수가 갱신되므로 다음 페인트
+     전에 반영된다 — transition은 오히려 추종 지연을 만들므로 두지 않는다
+     (ChatGPT도 이 transform에 transition을 걸지 않는다). */
+  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main-scroll--project-chat-detail .pc-proto {
+    transform: translateY(var(--visual-viewport-offset-top, 0px));
+  }
 }
 
 .app-shell-ia--project-panel .aris-ia-shell {

--- a/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
+++ b/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
@@ -57,6 +57,18 @@ describe('mobile keyboard composer — cooperates with native scroll instead of 
     );
   });
 
+  it('follows the native focus scroll with translateY(--visual-viewport-offset-top) while the keyboard is open', () => {
+    // 실기기 오버레이 실측(2차): 콘텐츠 축소(body sh=399)가 정확히 적용돼도
+    // iOS는 포커스 시점의 옛 레이아웃 기준으로 미리 결정한 스크롤(sY=347)을
+    // 그대로 실행하고 이후 클램프하지 않는다. 콘텐츠 축소만으로는 막을 수
+    // 없으므로, ChatGPT 웹과 동일하게 밀려난 만큼(offsetTop) 콘텐츠를 따라
+    // 내려 뷰포트가 바라보는 자리에 콘텐츠를 겹친다. 스크롤이 없으면 0px라
+    // no-op이므로 안드로이드/정상 축소 경로에는 영향이 없다.
+    expect(iaShellCss).toMatch(
+      /html\[data-keyboard-open='true'\] \.app-shell-ia--chat-screen \.m-main-scroll--project-chat-detail \.pc-proto\s*\{[^}]*transform:\s*translateY\(var\(--visual-viewport-offset-top, 0px\)\);/,
+    );
+  });
+
   it('still preserves the intentional page-scroll model on mobile (iOS toolbar auto-hide)', () => {
     // layout.css가 모바일에서 .app-shell-ia--chat-screen을 의도적으로
     // overflow:visible/height:auto로 두는 것은 이번 재설계와 방향이 같다 —


### PR DESCRIPTION
## 배경

PR #396(min-height 축소) 배포 후 사용자가 진단 오버레이(#395)로 2차 실측 데이터를 제공했다:

```
vv h=399 top=347 | innerH=399 sY=347 kb=true
body sh=399 doc sh=746 | shell h=399 | cmp -99..44
+106ms vv.resize h=399 top=347
+107ms win.scroll sY=347
```

## 데이터가 말하는 것

**#396은 정확히 작동했다** — `body sh=399`(1차 실측에서 746이었던 값). 콘텐츠 체인 전체가 실제 보이는 높이로 줄었다.

**그럼에도 스크롤이 남았다** — `sY=347`. 타임라인이 결정적이다: `vv.resize`(+106ms)와 `win.scroll`(+107ms)이 사실상 동시에 실행됐다. iOS는 포커스 시점의 **옛 레이아웃(콘텐츠 746)** 기준으로 "347만큼 스크롤"을 미리 결정해두고, 우리 콘텐츠가 같은 프레임에 399로 줄었는데도 그 스크롤을 그대로 실행한다. 그리고 일반 브라우저와 달리 **콘텐츠가 줄어든 뒤에도 스크롤 위치를 다시 클램프하지 않는다** — `doc sh=746`은 캔버스가 원래 746이어서가 아니라 `scrollTop(347) + clientHeight(399)`를 수용하도록 보고되는 값이다.

결론: **콘텐츠 축소만으로는 이 스크롤을 막을 수 없다.** 남은 선택지는 스크롤을 되돌리며 싸우거나(1프레임 튐 유발), 스크롤된 만큼 콘텐츠를 따라 내리는 것뿐이다.

## 수정 — 팬-추종 (ChatGPT 웹과 동일 패턴)

ChatGPT 웹 번들에서 이전에 추출했던 iOS 전용 규칙이 정확히 이 상황을 위한 것이었다:

```css
@supports (-webkit-touch-callout: none) {
  [data-visual-keyboard] .wm-swipe-scrollContainer {
    transform: translateY(var(--mobile-shell-visual-viewport-offset-top, 0px));
  }
}
```

우리의 대응물: `--visual-viewport-offset-top`은 `ViewportHeightSync`가 `vv.scroll`/`vv.resize`마다 갱신해온 실측값(이번 실측에서 347로 정확히 보고됨)인데, **지금껏 CSS 어디에서도 소비되지 않고 있었다.** 키보드 오픈 중 `.pc-proto`를 이 값만큼 `translateY`하면:

- 뷰포트가 바라보는 문서 구간(347..746)에 콘텐츠(0..399)가 정확히 겹친다 — 컴포저는 뷰포트 하단, 헤더는 뷰포트 상단
- 스크롤이 없는 환경(안드로이드, 또는 iOS가 언젠가 스크롤을 안 하게 되면)에서는 `0px`라 no-op
- 스크롤 이벤트와 같은 태스크에서 CSS 변수가 갱신되므로 다음 페인트 전에 반영 — transition은 추종 지연만 만들므로 두지 않는다(ChatGPT도 이 transform에 transition 없음)

## 검증

격리 재현(실제 번들 CSS 주입 + 실기기 조건 완전 재현: 뷰포트 746→399, `--app-vh` 746 고정, offsetTop 347):

```
transform: matrix(1,0,0,1,0,347) 적용 확인
컴포저: 밀려난 뷰포트 기준 361..399 — 하단 정위치 (수정 전 실기기: -99..44, 화면 밖)
키보드 닫힘(offsetTop 0): transform none, 컴포저 746 복귀
```

- `tsc` 클린, vitest 124 파일/**623 테스트** 통과(회귀 방지 단언 1건 추가)
- 배포 후 오버레이 재확인 기대값: `cmp`가 화면 안(대략 360..399 근처), 스크롤이 있어도(`sY=347`) 컴포저 정위치

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbeRFoKWdoefKCvECrNfkt
