### PR TITLE
fix(web): 팬-추종 transform을 클리핑되는 .pc-proto에서 app-shell 루트로 이동

### DIFF
--- a/services/aris-web/app/styles/ia-shell.css
+++ b/services/aris-web/app/styles/ia-shell.css
@@ -947,8 +947,18 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
      정확히 겹친다. 스크롤이 없으면(안드로이드/정상 축소) 0px라 no-op.
      스크롤 이벤트와 같은 태스크에서 CSS 변수가 갱신되므로 다음 페인트
      전에 반영된다 — transition은 오히려 추종 지연을 만들므로 두지 않는다
-     (ChatGPT도 이 transform에 transition을 걸지 않는다). */
-  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main-scroll--project-chat-detail .pc-proto {
+     (ChatGPT도 이 transform에 transition을 걸지 않는다).
+
+     transform의 대상은 반드시 세로 클리핑이 없는 최상위(app-shell)여야
+     한다. 1차 시도는 .pc-proto에 걸었는데, .pc-proto는 overflow: hidden인
+     .m-main / .m-main-scroll--project-chat-detail(높이 399) 안에 있어서
+     translateY(347)로 내려간 하단 347px — 컴포저 포함 — 이 통째로
+     클리핑되어 화면에서 사라졌다(격리 스크린샷 재현으로 확정: 화면엔 빈
+     래퍼와 헤더 슬리버만 남음). transform은 rect 좌표만 보면 정상이라
+     rect 기반 검증으로는 잡히지 않는다 — 클리핑은 픽셀에만 나타난다.
+     app-shell의 조상은 html/body뿐이고 둘 다 overflow-x: clip(세로는
+     visible)이라 아래로 내려간 콘텐츠가 잘리지 않고 그대로 렌더된다. */
+  html[data-keyboard-open='true'] .app-shell-ia--chat-screen {
     transform: translateY(var(--visual-viewport-offset-top, 0px));
   }
 }

--- a/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
+++ b/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
@@ -57,7 +57,7 @@ describe('mobile keyboard composer — cooperates with native scroll instead of 
     );
   });
 
-  it('follows the native focus scroll with translateY(--visual-viewport-offset-top) while the keyboard is open', () => {
+  it('follows the native focus scroll with translateY(--visual-viewport-offset-top) on the unclipped app-shell root', () => {
     // 실기기 오버레이 실측(2차): 콘텐츠 축소(body sh=399)가 정확히 적용돼도
     // iOS는 포커스 시점의 옛 레이아웃 기준으로 미리 결정한 스크롤(sY=347)을
     // 그대로 실행하고 이후 클램프하지 않는다. 콘텐츠 축소만으로는 막을 수
@@ -65,7 +65,22 @@ describe('mobile keyboard composer — cooperates with native scroll instead of 
     // 내려 뷰포트가 바라보는 자리에 콘텐츠를 겹친다. 스크롤이 없으면 0px라
     // no-op이므로 안드로이드/정상 축소 경로에는 영향이 없다.
     expect(iaShellCss).toMatch(
-      /html\[data-keyboard-open='true'\] \.app-shell-ia--chat-screen \.m-main-scroll--project-chat-detail \.pc-proto\s*\{[^}]*transform:\s*translateY\(var\(--visual-viewport-offset-top, 0px\)\);/,
+      /html\[data-keyboard-open='true'\] \.app-shell-ia--chat-screen\s*\{[^}]*transform:\s*translateY\(var\(--visual-viewport-offset-top, 0px\)\);/,
+    );
+  });
+
+  it('never applies the pan-follow transform inside the overflow-hidden wrapper chain', () => {
+    // 회귀 방지: 1차 팬-추종은 .pc-proto에 transform을 걸었는데, .pc-proto는
+    // overflow: hidden인 .m-main/.m-main-scroll(높이=뷰포트) 안에 있어서
+    // 내려간 하단 347px — 컴포저 포함 — 이 통째로 클리핑되어 화면에서
+    // 사라졌다. rect 좌표는 클리핑의 영향을 받지 않아 rect 검증으로는 안
+    // 잡힌다. transform은 세로 클리핑이 없는 app-shell 루트에만 건다.
+    const withoutComments = iaShellCss.replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(withoutComments).not.toMatch(
+      /\.pc-proto[^{]*\{[^}]*transform:\s*translateY\(var\(--visual-viewport-offset-top/,
+    );
+    expect(withoutComments).not.toMatch(
+      /\.m-main[^{]*\{[^}]*transform:\s*translateY\(var\(--visual-viewport-offset-top/,
     );
   });
 


### PR DESCRIPTION
## 배경

PR #397(팬-추종 translateY) 배포 후 증상이 오히려 악화됐다: 컴포저가 화면 꼭대기 너머까지 사라짐. "구조 재설계" 방향으로 승인받고 채팅 화면 스크롤 구조를 전수 조사한 결과, **모바일 채팅 상세 화면은 이미 내부 스크롤 앱셸 구조였다** — `.tl`(타임라인)이 유일한 스크롤러이고, `.m-main`/`.m-main-scroll--project-chat-detail`은 `overflow: hidden`, 셸은 고정 높이, 모든 JS 스크롤 로직은 `.tl`만 대상. 재구축할 것은 없었고, 진짜 결함은 #397 자체에 있었다.

## 확정된 원인 — transform이 overflow: hidden 래퍼 안에서 클리핑

#397은 `translateY(var(--visual-viewport-offset-top))`를 `.pc-proto`에 걸었다. 그런데 `.pc-proto`는 `overflow: hidden`인 `.m-main`과 `.m-main-scroll--project-chat-detail`(높이=뷰포트, 키보드 오픈 시 399px) **안에** 있다. 347px 내려간 콘텐츠의 하단 347px — 컴포저 포함 — 이 통째로 클리핑되어 화면에서 사라진다. 화면에는 빈 래퍼와 상단 슬리버만 남는다 = 실기기 증상 그대로.

**#397의 격리 검증이 이걸 놓친 이유**: rect 좌표(getBoundingClientRect)는 클리핑의 영향을 받지 않는다. rect만 보면 컴포저는 "정위치"였다. 클리핑은 픽셀에만 나타난다.

## 스크린샷 기반 격리 재현 (실제 번들 CSS, 실기기 조건 재현)

| | 배포 CSS (.pc-proto transform) | 수정 (app-shell transform) |
|---|---|---|
| 화면 구성 (elementFromPoint) | 30~300px: 빈 `.m-main-scroll`, 370~390px: `.ch` 슬리버 | 30px: `.ch`, 150px: `.msg`, 370~390px: `.cmp` |
| 컴포저 뷰포트 rect | 671..738 (화면 밖) | **324..391 (하단 정위치)** |
| 문서 스크롤 여유 | 0 (오버플로가 hidden 래퍼에 갇힘 → iOS 팬을 따라갈 공간 자체가 없음) | 347 (스크롤 후 콘텐츠와 뷰포트 정확히 겹침) |
| 스크린샷 | 빈 화면 + 헤더 슬리버 | 헤더/메시지/컴포저 정상 |

## 수정

transform 대상을 세로 클리핑이 없는 최상위로 이동:

```css
html[data-keyboard-open='true'] .app-shell-ia--chat-screen {
  transform: translateY(var(--visual-viewport-offset-top, 0px));
}
```

`.app-shell-ia--chat-screen`의 조상은 html/body뿐이고 둘 다 `overflow-x: clip`(세로는 visible)이라 내려간 콘텐츠가 잘리지 않고 그대로 렌더된다. ChatGPT의 transform 대상도 세로 클리핑 없는 위치라는 전제가 있었는데, 규칙만 이식하고 그 전제를 놓쳤던 것.

- 키보드 닫힘/스크롤 없음(안드로이드) 경로: `--visual-viewport-offset-top`이 0px라 no-op — 기존과 동일
- transform이 keyboard-open 중에만 걸리므로 평상시 fixed-containing-block 부작용 없음

## 검증

- `tsc` 클린, vitest 124 파일/**624 테스트** 통과 (클리핑 회귀 방지 단언 1건 추가: `.pc-proto`/`.m-main` 계열에 팬-추종 transform 금지)
- 워크트리 컴파일 번들 CSS로 격리 재현 PASS (위 표의 "수정" 열)
- 배포 후 실기기 오버레이(`?vvdebug=1`) 기대값: 키보드 오픈 시 `cmp`가 화면 하단(뷰포트 안)에 위치. `sY`/`doc sh` 수치는 남아 있어도 정상(콘텐츠가 스크롤을 따라가는 설계)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxfd4yi1xRpXZHvjuggvTW
