### PR TITLE
fix(web): 키보드 판정을 포커스-수명 기반으로 전환 (ChatGPT data-visual-keyboard 모델)

### DIFF
--- a/services/aris-web/components/layout/ViewportHeightSync.tsx
+++ b/services/aris-web/components/layout/ViewportHeightSync.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { dispatchSessionScrollPhaseEvent } from '@/lib/hooks/useSessionScrollOrchestrator';
 import { recordScrollDebugEvent } from '@/lib/scroll/scrollDebug';
+import { computeKeyboardOpen } from '@/components/layout/viewportKeyboardState';
 
 export const VIEWPORT_LAYOUT_CHANGE_EVENT = 'aris:viewport-layout-change';
 
@@ -32,9 +33,11 @@ const isTextInputElement = (element: Element | null): boolean => {
   return (element as HTMLElement).isContentEditable === true;
 };
 
+
 export function ViewportHeightSync() {
   useEffect(() => {
     const root = document.documentElement;
+    const coarsePointerQuery = window.matchMedia?.('(pointer: coarse)') ?? null;
     let lastNoKeyboardHeight = window.visualViewport?.height ?? window.innerHeight;
     let lastInnerWidth = window.innerWidth;
     let optimisticKeyboardOpenUntil = 0;
@@ -79,7 +82,14 @@ export function ViewportHeightSync() {
         ? KEYBOARD_INSET_THRESHOLD_FOCUSED_PX
         : KEYBOARD_INSET_THRESHOLD_DEFAULT_PX;
       const withinOptimisticWindow = performance.now() < optimisticKeyboardOpenUntil;
-      const keyboardOpen = bottomInset > threshold || withinOptimisticWindow;
+      const coarsePointer = coarsePointerQuery?.matches ?? false;
+      const keyboardOpen = computeKeyboardOpen({
+        bottomInset,
+        threshold,
+        withinOptimisticWindow,
+        focusedTextInput,
+        coarsePointer,
+      });
       const keyboardInset = keyboardOpen ? bottomInset : 0;
       const visualViewportBottomInset = keyboardOpen ? 0 : bottomInset;
 
@@ -124,6 +134,7 @@ export function ViewportHeightSync() {
           keyboardOpen,
           threshold,
           focusedTextInput,
+          coarsePointer,
           withinOptimisticWindow,
         },
       });
@@ -162,7 +173,10 @@ export function ViewportHeightSync() {
       optimisticKeyboardOpenUntil = performance.now() + OPTIMISTIC_KEYBOARD_LOCK_MS;
       clearFocusResyncTimeouts();
       updateViewportHeight('document:focusin');
-      [100, 300, 600].forEach((delay) => {
+      // 800ms 재sync는 낙관 창(700ms) 만료 직후를 재평가하기 위한 것 —
+      // 이게 없으면 마지막 재sync(600ms)에서 낙관 창으로 true가 기록된 뒤
+      // 다음 이벤트까지 stale-true로 남는다(fine pointer 환경에서 확인됨).
+      [100, 300, 600, 800].forEach((delay) => {
         const id = window.setTimeout(() => {
           updateViewportHeight(`document:focusin:resync:${delay}ms`);
         }, delay);

--- a/services/aris-web/components/layout/viewportKeyboardState.ts
+++ b/services/aris-web/components/layout/viewportKeyboardState.ts
@@ -1,0 +1,24 @@
+// 키보드 열림 판정. 터치(coarse pointer) 기기에서는 "텍스트 입력이 포커스된
+// 동안"을 곧 키보드 열림으로 본다(ChatGPT 웹의 data-visual-keyboard와 동일한
+// 포커스-수명 모델). 기하 측정(bottomInset)이 보조로 남는 이유와 한계:
+// interactive-widget=resizes-content가 적용되는 iOS/Android에서는 키보드가
+// 열릴 때 layout viewport(innerHeight)까지 함께 줄어들어
+// bottomInset = innerHeight - vvHeight - offsetTop ≈ 0 이 되므로, 기하
+// 측정만으로는 키보드를 영원히 감지할 수 없다(실기기 실측 2026-07-10:
+// innerH=399, vv h=399, top=347 → inset 0, kb=false로 오판 → 키보드 게이트
+// CSS 전체 미발동). 낙관적 타이머(700ms)도 iOS 키보드 확정(+714ms)과
+// 스크롤(+827ms)보다 먼저 만료되어 경주에서 진다. 포커스 수명 기반이 둘 다에
+// 면역이다 — 게이트되는 CSS 규칙은 전부 라이브 측정값
+// (--visual-viewport-height/offset-top) 기반이라, 하드웨어 키보드 등으로
+// 실제 가상 키보드가 없으면 자연히 no-op이 된다. fine pointer(데스크톱)를
+// 제외하는 이유는 --app-vh 동결이 포커스 내내 이어지면 창 크기 조절이
+// 반영되지 않기 때문.
+export const computeKeyboardOpen = (input: {
+  bottomInset: number;
+  threshold: number;
+  withinOptimisticWindow: boolean;
+  focusedTextInput: boolean;
+  coarsePointer: boolean;
+}): boolean => (input.focusedTextInput && input.coarsePointer)
+  || input.bottomInset > input.threshold
+  || input.withinOptimisticWindow;

--- a/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
+++ b/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
@@ -107,7 +107,20 @@ describe('mobile keyboard composer — cooperates with native scroll instead of 
     // 최대한 빨리 정확한 값을 참조하도록 이 메커니즘은 유지한다.
     expect(viewportHeightSync).toContain('OPTIMISTIC_KEYBOARD_LOCK_MS');
     expect(viewportHeightSync).toContain('optimisticKeyboardOpenUntil = performance.now() + OPTIMISTIC_KEYBOARD_LOCK_MS');
-    expect(viewportHeightSync).toContain('const keyboardOpen = bottomInset > threshold || withinOptimisticWindow;');
     expect(viewportHeightSync).toMatch(/handleDocumentFocusOut[\s\S]*?optimisticKeyboardOpenUntil = 0;/);
+  });
+
+  it('keeps data-keyboard-open true for the whole focus lifetime on touch devices (ChatGPT model)', () => {
+    // 실기기 3차 실측: interactive-widget=resizes-content 하에서는 innerHeight도
+    // 함께 줄어 bottomInset이 0이 되므로 기하 측정으로는 키보드를 감지할 수
+    // 없고, 700ms 낙관적 창은 iOS 키보드 확정(+714ms)·스크롤(+827ms)보다
+    // 먼저 만료된다. 판정은 포커스-수명 기반 computeKeyboardOpen을 쓴다.
+    expect(viewportHeightSync).toContain(
+      "import { computeKeyboardOpen } from '@/components/layout/viewportKeyboardState';",
+    );
+    expect(viewportHeightSync).toMatch(
+      /const keyboardOpen = computeKeyboardOpen\(\{[\s\S]*?focusedTextInput,[\s\S]*?coarsePointer,[\s\S]*?\}\);/,
+    );
+    expect(viewportHeightSync).not.toContain('const keyboardOpen = bottomInset > threshold || withinOptimisticWindow;');
   });
 });

--- a/services/aris-web/tests/viewportKeyboardState.test.ts
+++ b/services/aris-web/tests/viewportKeyboardState.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { computeKeyboardOpen } from '@/components/layout/viewportKeyboardState';
+
+describe('computeKeyboardOpen — 포커스-수명 기반 키보드 판정', () => {
+  it('resizes-content 세계(iOS 실측 2026-07-10)에서 기하 인셋이 0이어도 포커스 중이면 키보드 열림', () => {
+    // 실기기 3차 캡처: innerH=399, vv h=399, top=347
+    // → bottomInset = max(0, 399 - 399 - 347) = 0.
+    // 낙관적 700ms 창은 iOS 키보드 확정(+714ms)/스크롤(+827ms) 전에 만료됐다.
+    // 기존 판정(inset || optimistic)은 여기서 false → 키보드 게이트 CSS 전체
+    // 미발동 → 팬-추종 transform이 발동하지 못해 컴포저가 화면 밖으로 밀렸다.
+    expect(
+      computeKeyboardOpen({
+        bottomInset: 0,
+        threshold: 60,
+        withinOptimisticWindow: false,
+        focusedTextInput: true,
+        coarsePointer: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('데스크톱(fine pointer)에서는 포커스만으로 키보드 열림으로 보지 않는다', () => {
+    // 하드웨어 키보드 환경에서 포커스-수명 모델을 적용하면 --app-vh 동결이
+    // 포커스 내내 이어져 창 크기 조절이 반영되지 않는 회귀가 생긴다.
+    expect(
+      computeKeyboardOpen({
+        bottomInset: 0,
+        threshold: 120,
+        withinOptimisticWindow: false,
+        focusedTextInput: true,
+        coarsePointer: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('구세계(innerHeight 불변) 기하 측정은 그대로 동작한다', () => {
+    // interactive-widget 미지원 브라우저: innerH=746, vv h=399 → inset 347.
+    expect(
+      computeKeyboardOpen({
+        bottomInset: 347,
+        threshold: 120,
+        withinOptimisticWindow: false,
+        focusedTextInput: false,
+        coarsePointer: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('포커스 직후 낙관적 창 안에서는 측정 전에도 키보드 열림', () => {
+    expect(
+      computeKeyboardOpen({
+        bottomInset: 0,
+        threshold: 60,
+        withinOptimisticWindow: true,
+        focusedTextInput: true,
+        coarsePointer: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('블러 후(포커스 없음, 인셋 없음)에는 키보드 닫힘', () => {
+    expect(
+      computeKeyboardOpen({
+        bottomInset: 0,
+        threshold: 120,
+        withinOptimisticWindow: false,
+        focusedTextInput: false,
+        coarsePointer: true,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## 실측 데이터 (실기기 3차, 2026-07-10)

```
vv h=399 top=347 | innerH=399 sY=347 kb=false   ← 키보드가 떠 있는데 kb=false
body sh=399 doc sh=746 | shell h=399 | cmp -99..44
+0ms    focusin textarea.cmp__input
+714ms  vv.resize h=399 top=0      ← 낙관 창(700ms) 만료 직후
+827ms  win.scroll sY=347          ← iOS 포커스 스크롤, 이때 kb=false
```

## 확정된 원인 — 기하 판정이 resizes-content 세계에서 구조적으로 불능

`ViewportHeightSync`의 키보드 판정:

```ts
const bottomInset = Math.max(0, layoutViewportHeight - height - viewportOffsetTop);
const keyboardOpen = bottomInset > threshold || withinOptimisticWindow;
```

이 휴리스틱은 "키보드가 열려도 `innerHeight`는 그대로, visual viewport만 줄어든다"는 옛 세계용 설계다. 그런데 **#387에서 추가한 `interactive-widget=resizes-content`가 iOS에서 실제로 동작하면서** 키보드 오픈 시 `innerHeight`도 함께 746→399로 줄어든다:

```
bottomInset = 399 − 399 − 347 → max(0, −347) = 0
```

**기하 측정으로는 키보드를 영원히 감지할 수 없게 됐다.** 남은 것은 700ms 낙관 창뿐인데, 이번 실측에서 iOS의 키보드 확정은 +714ms, 포커스 스크롤은 +827ms — 창 만료 후다. 그래서 `data-keyboard-open`에 게이트된 규칙 전체(#396 min-height 축소, #398 팬-추종 transform)가 **한 번도 발동하지 못했다**. 2차 실측(+106/107ms)에서 동작한 것은 키보드 애니메이션이 낙관 창 안에 든 타이밍 운이었다.

## ChatGPT 웹과의 마지막 구조 차이

transform 대상(#398), offsetTop 변수, min-height 축소(#396)까지 등가가 된 지금, 남은 차이는 **"상태를 언제 켜두는가"** 하나였다:

| | ChatGPT | ARIS (기존) |
|---|---|---|
| 키보드 상태 | `focusin`→켬, `focusout`→끔. **포커스 수명 전체** | 기하 측정(resizes-content가 파괴) + 700ms 타이머(OS 애니메이션과 경주) |
| iOS가 스크롤을 +827ms에 실행하면 | 게이트 살아 있음 → 팬-추종 발동 | 게이트 죽어 있음 → 미발동 |

## 수정

터치(coarse pointer) 기기에서 **텍스트 입력 포커스 = 키보드 열림**으로 판정한다(`computeKeyboardOpen`, 순수 함수로 분리). 안전한 이유: 게이트되는 CSS 규칙은 전부 라이브 측정값(`--visual-viewport-height`/`--visual-viewport-offset-top`) 기반이라 실제 가상 키보드가 없으면(하드웨어 키보드 등) 자연히 no-op이다. fine pointer(데스크톱)는 제외 — `--app-vh` 동결이 포커스 내내 이어져 창 크기 조절이 반영되지 않는 회귀를 차단.

검증 중 발견한 기존 잠복 버그도 함께 수정: focusin 재sync가 600ms에서 끝나 낙관 창 만료(700ms)를 아무도 재평가하지 않아 데스크톱에서 `data-keyboard-open`이 stale-true로 남던 문제 — 800ms 재sync 추가.

## 검증

- `tsc` 클린, vitest 125 파일/**630 테스트** 통과 (`computeKeyboardOpen` 단위 테스트 5건 — 실측값 그대로 사용: inset 0 + 포커스 + coarse → true 등)
- **런타임 검증** (공개 `/login`, Playwright): 터치 컨텍스트에서 포커스 후 **+1200ms(실기기 실패 구간)에도 `kb=true` 유지**, blur 시 `false`, 데스크톱 fine pointer는 +1200ms에 `false`
- 배포 후 실기기 오버레이 기대값: 키보드 오픈 내내 `kb=true`, iOS 스크롤(`sY`/`top=347`)이 늦게 오더라도 팬-추종 transform이 발동해 `cmp`가 화면 하단 정위치

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxfd4yi1xRpXZHvjuggvTW
