### PR TITLE
refactor(web): 모바일 키보드 대응을 네이티브 팬 단일 모델로 복원

### DIFF
--- a/services/aris-web/app/layout.tsx
+++ b/services/aris-web/app/layout.tsx
@@ -116,10 +116,13 @@ export const viewport: Viewport = {
   maximumScale: 1,
   userScalable: false,
   viewportFit: 'cover',
-  // Android/Chrome: 키보드가 열릴 때 레이아웃 뷰포트 자체를 줄여서(visual
-  // viewport가 아니라) 100dvh 등 CSS 단위가 자연스럽게 따라가게 한다.
-  // iOS Safari는 이 속성을 지원하지 않아 무시되므로 부작용이 없다.
-  interactiveWidget: 'resizes-content',
+  // interactiveWidget은 의도적으로 지정하지 않는다(기본값 resizes-visual).
+  // 키보드 대응은 네이티브 팬 모델을 쓴다: 레이아웃 뷰포트는 그대로 두고
+  // 브라우저가 visual viewport를 팬해서 포커스된 입력을 키보드 위로
+  // 보여주게 한다(ia-shell.css의 모델 결정 주석 참고). 과거
+  // resizes-content를 지정했을 때 iOS가 이를 실제로 적용하면서(구식
+  // 리서치와 달리 최신 iOS는 지원함) 레이아웃 축소와 네이티브 팬이 이중
+  // 보정되어 컴포저가 화면 밖으로 밀리는 버그 연쇄가 시작됐다.
 };
 
 export default function RootLayout({

--- a/services/aris-web/app/styles/ia-shell.css
+++ b/services/aris-web/app/styles/ia-shell.css
@@ -859,107 +859,45 @@ html[data-theme='dark'] .m-theme-toggle__item--active {
   min-height: 0;
 }
 
-/* 모바일 키보드 대응: 네이티브 스크롤과 "싸우지" 않고 "협력"한다.
-   (ChatGPT 웹 모바일의 실제 구현을 조사해 확인한 전략 — html/body는 position을
-   절대 바꾸지 않고, 포커스된 입력을 화면에 보이도록 끌어올리는 브라우저
-   네이티브 동작을 그대로 둔다.)
+/* 모바일 키보드 대응 — 네이티브 팬 모델 (모델 결정, 2026-07-10)
 
-   1차 시도는 data-keyboard-open일 때 html/body를 position:fixed로 강제
-   잠갔다. CSS 자체는 정확했지만 position:static → fixed 전환은 스펙상
-   transition이 불가능한 이산적(discrete) 값 변경이라, 네이티브 스크롤이
-   컴포저를 끌어올린 "직후" 이 잠금이 뒤늦게 걸리며 순간이동(스냅)하는
-   것으로 보였다.
+   불변식: 키보드가 열려도 우리 레이아웃은 1px도 반응하지 않는다.
 
-   2차 시도는 position:fixed 잠금과 함께 셸의 높이 추적(.aris-ia-shell/
-   .pc-proto/.shell가 --visual-viewport-height를 따르던 규칙)까지 통째로
-   제거하고, reset.css의 overflow-x: hidden → clip 전환만으로 충분하다고
-   판단했다. 이건 틀렸다: overflow-x: clip은 overflow-y가 auto로 자동
-   승격되는 것만 막을 뿐, .aris-ia-shell/.pc-proto/.shell이 여전히 얼어붙은
-   --app-vh(키보드가 열린 동안 이전 높이에 고정)를 그대로 쓰고 있었다.
-   셸 전체가 실제로 보이는 영역보다 훨씬 커진 채로 남아 있었고, 그 차이
-   (최대 수백 px)만큼 네이티브 "포커스 요소 스크롤"이 페이지 전체를
-   과도하게 끌어올려 컴포저가 화면 맨 위까지 튀는 현상으로 재현됐다
-   (실기기 스크린샷으로 확인).
+   키보드가 열리면 iOS/Android가 visual viewport를 팬해서 포커스된 입력을
+   키보드 위로 보여준다. 셸은 --app-vh(키보드 오픈 중 이전 높이에 동결)로
+   고정돼 있으므로 컴포저는 문서상 제자리(셸 바닥)에 그대로 있고, 팬 된
+   뷰포트가 바라보는 자리가 정확히 컴포저다. 브라우저가 전부 한다 —
+   우리가 계산하거나 보정할 것이 없다.
 
-   최종 수정: 셸 높이 추적을 되살리되(아래), position은 여전히 절대
-   바꾸지 않는다. height/min-height는 숫자 값이라 position과 달리
-   transition으로 부드럽게 이어진다 — 셸이 실제 보이는 영역에 맞춰
-   부드럽게 줄어들므로, 컴포저는 애초에 축소된 셸의 바닥 근처에 남아있게
-   되어 네이티브 스크롤이 거의/전혀 필요하지 않다. overflow-x: clip은
-   부수적인 방어 조치로 남겨둔다(auto 승격을 막는 것 자체는 여전히 유효).
+   이 모델이 과거에 깨졌던 진짜 원인(실기기 오버레이 실측으로 확정)은
+   레이아웃이 아니라 키보드 감지였다: bottomInset = innerHeight − vvHeight
+   − offsetTop 이 네이티브 팬(offsetTop 증가) 순간 0이 되어 "키보드
+   닫힘"으로 오판 → --app-vh 동결이 풀려 셸이 붕괴 → 컴포저가 팬 된
+   뷰포트 꼭대기로 순간이동. 지금은 포커스-수명 기반 판정
+   (viewportKeyboardState.ts)이 팬과 무관하게 kb=true를 유지하므로 동결이
+   깨지지 않는다.
 
-   .cmp__input의 auto-grow 상한도 같은 이유로 유지한다 — position/scroll과
-   무관하게 입력창 자체가 과도하게 커지지 않도록 하는 순수 시각적 제약. */
+   과거 이 자리에 있었던 축소 모델 보정들(키보드 오픈 시 html/body/래퍼
+   min-height를 --visual-viewport-height로 축소, offsetTop만큼 translateY
+   팬-추종)은 interactive-widget=resizes-content(제거됨)와 함께 걷어냈다.
+   두 모델이 공존하면 이중 보정이 된다: 셸 축소가 컴포저를 347px 올리고
+   iOS 팬이 또 347px 올려 컴포저가 화면 밖으로 나갔다. 키보드 대응
+   레이아웃 규칙을 다시 추가하고 싶다면 그것이 팬 모델의 불변식("레이아웃
+   무반응")을 깨는지 먼저 물어야 한다.
+
+   overflow-x: clip(reset.css)은 유지 — overflow-y의 auto 승격을 막아
+   문서에 불법 스크롤 여백이 생기는 것을 방지하는 팬 모델의 전제 조건. */
 @media (max-width: 767px) {
   .pc-proto .cmp__input {
     transition: max-height 150ms var(--ease-smooth, ease);
   }
 
+  /* 키보드 오픈 중 컴포저 auto-grow 상한. 레이아웃(셸 기하)이 아니라
+     입력창 자체의 시각적 제약이라 팬 모델의 불변식과 충돌하지 않는다.
+     --visual-viewport-height는 항상 라이브 값이므로 키보드 위 실공간
+     기준으로 상한이 잡힌다. */
   html[data-keyboard-open='true'] .app-shell-ia--chat-screen .pc-proto .cmp__input {
     max-height: min(200px, calc(var(--visual-viewport-height, 100dvh) * 0.3));
-  }
-
-  /* 실기기 진단 오버레이 실측(2026-07-09)으로 확정된 마지막 원인:
-     키보드가 열리면 레이아웃 뷰포트(innerHeight)가 746→399로 줄고
-     (interactive-widget=resizes-content가 최신 iOS에서 실제 동작),
-     셸도 399로 정상 축소됐지만(#393), body만 reset.css의
-     min-height: var(--app-vh) — 키보드 오픈 중 이전 높이 746에
-     얼어붙는 값 — 를 유지해 문서가 뷰포트보다 정확히 347px 커졌다.
-     iOS는 그 여백만큼 문서를 스크롤해(sY=347) 포커스된 컴포저를
-     화면 위로 밀어올렸다(cmp rect -99..44). 347 = 746 - 399.
-
-     이 override는 원래 PR #386에 있었는데 #388에서 overflow-x: clip을
-     근본 수정으로 오판하며 삭제된 것이 회귀 지점이다 — clip은
-     overflow-y의 auto 승격만 막을 뿐 min-height 746은 없애지 못한다.
-
-     키보드가 열려 있는 동안 html/body도 실제 보이는 높이를 따르게 해
-     스크롤 여백 자체를 제거한다. position/overflow는 건드리지 않으므로
-     (#387의 position:fixed 스냅 문제와 무관) 부드럽게 동작한다.
-     data-keyboard-open은 포커스 즉시 낙관적으로 켜지므로(#387) iOS의
-     스크롤(+150ms 시점)보다 먼저 적용된다. */
-  html[data-keyboard-open='true'],
-  html[data-keyboard-open='true'] body {
-    min-height: var(--visual-viewport-height, 100dvh);
-  }
-
-  /* body의 min-height만 줄여서는 부족하다(실측: bodyMinHeight 399로
-     적용돼도 bodyScrollHeight는 746 유지) — 문서 높이는 자식 중 가장 큰
-     박스가 결정하는데, .app-shell-ia(min-height: var(--app-vh))와
-     .m-main(min-height: var(--app-vh))이 얼어붙은 746을 유지하며 body를
-     떠받치고 있었다. --app-vh를 참조하는 래퍼 체인 전체를 함께 줄인다. */
-  html[data-keyboard-open='true'] .app-shell-ia--chat-screen,
-  html[data-keyboard-open='true'] .app-shell-ia--chat-screen .m-main {
-    min-height: var(--visual-viewport-height, 100dvh);
-  }
-
-  /* iOS의 네이티브 "포커스 요소 스크롤"을 따라간다(팬-추종, ChatGPT 웹과
-     동일 패턴). 실기기 오버레이 실측(2026-07-09, 2차): 위 min-height 축소가
-     정확히 적용돼 body sh=399가 됐는데도 iOS는 포커스 시점의 옛
-     레이아웃(콘텐츠 746) 기준으로 미리 결정한 스크롤(sY=347)을 그대로
-     실행하고, 콘텐츠가 줄어든 뒤에도 스크롤 위치를 다시 클램프하지
-     않는다(doc sh=746 = scrollTop 347 + clientHeight 399). 즉 콘텐츠
-     축소만으로는 이 스크롤을 막을 수 없다.
-
-     그래서 스크롤과 싸우지 않고 그만큼 콘텐츠를 따라 내린다:
-     --visual-viewport-offset-top은 ViewportHeightSync가 vv.scroll/resize
-     마다 갱신하는 실측값(= 뷰포트가 밀려난 양, 347로 확인됨)이며, 이만큼
-     translateY하면 뷰포트가 바라보는 자리(347..746)에 콘텐츠(0..399)가
-     정확히 겹친다. 스크롤이 없으면(안드로이드/정상 축소) 0px라 no-op.
-     스크롤 이벤트와 같은 태스크에서 CSS 변수가 갱신되므로 다음 페인트
-     전에 반영된다 — transition은 오히려 추종 지연을 만들므로 두지 않는다
-     (ChatGPT도 이 transform에 transition을 걸지 않는다).
-
-     transform의 대상은 반드시 세로 클리핑이 없는 최상위(app-shell)여야
-     한다. 1차 시도는 .pc-proto에 걸었는데, .pc-proto는 overflow: hidden인
-     .m-main / .m-main-scroll--project-chat-detail(높이 399) 안에 있어서
-     translateY(347)로 내려간 하단 347px — 컴포저 포함 — 이 통째로
-     클리핑되어 화면에서 사라졌다(격리 스크린샷 재현으로 확정: 화면엔 빈
-     래퍼와 헤더 슬리버만 남음). transform은 rect 좌표만 보면 정상이라
-     rect 기반 검증으로는 잡히지 않는다 — 클리핑은 픽셀에만 나타난다.
-     app-shell의 조상은 html/body뿐이고 둘 다 overflow-x: clip(세로는
-     visible)이라 아래로 내려간 콘텐츠가 잘리지 않고 그대로 렌더된다. */
-  html[data-keyboard-open='true'] .app-shell-ia--chat-screen {
-    transform: translateY(var(--visual-viewport-offset-top, 0px));
   }
 }
 

--- a/services/aris-web/app/styles/ui-responsive.css
+++ b/services/aris-web/app/styles/ui-responsive.css
@@ -120,14 +120,13 @@
   }
 
   .app-shell-ia--chat-screen .aris-ia-shell {
-    /* --app-vh는 키보드가 열린 동안 이전(더 큰) 높이에 고정되므로 그대로 쓰면
-       채팅 화면 전체가 실제로 보이는 영역보다 커진 채로 남는다. 그 여백만큼
-       네이티브 "포커스 요소 스크롤"이 페이지 전체를 과도하게 끌어올리게 되므로
-       (컴포저가 화면 맨 위로 튀는 현상의 원인) 항상 실제 보이는 높이를 따르는
-       --visual-viewport-height를 쓴다. position은 절대 바꾸지 않고 height만
-       숫자로 바뀌므로 transition으로 부드럽게 이어진다. */
-    min-height: var(--visual-viewport-height, 100dvh);
-    transition: min-height 200ms var(--ease-smooth, ease);
+    /* 네이티브 팬 모델: --app-vh는 키보드 오픈 중 이전 높이에 동결된다 —
+       그게 정확히 원하는 것이다. 셸 기하가 키보드에 반응하지 않아야
+       브라우저의 visual viewport 팬이 컴포저를 키보드 위 제자리에
+       보여준다(ia-shell.css 모델 결정 주석 참고). 라이브 값
+       (--visual-viewport-height)으로 바꾸면 셸 축소 + 네이티브 팬의 이중
+       보정으로 컴포저가 화면 밖으로 나간다. */
+    min-height: var(--app-vh, 100dvh);
   }
 
   .m-sb {
@@ -323,30 +322,25 @@
      동일한 선택자 체인으로 작성한다(파일 로드 순서상 이 파일이 나중이라
      동률일 때 이 규칙이 이긴다).
 
-     --app-vh가 아니라 --visual-viewport-height를 쓴다: --app-vh는 키보드가
-     열린 동안 이전(더 큰) 높이에 고정되는데, 이 셸이 그 얼어붙은 높이를
-     그대로 쓰면 실제 보이는 영역보다 커진 채로 남아 네이티브 "포커스 요소
-     스크롤"이 그 차이만큼 페이지 전체를 과도하게 끌어올린다(컴포저가 화면
-     맨 위로 튀는 현상). position은 절대 바꾸지 않으므로(static 유지)
-     height 변화 자체는 transition으로 부드럽게 이어진다. */
+     네이티브 팬 모델: --app-vh는 키보드 오픈 중 이전 높이에 동결된다 —
+     그게 정확히 원하는 것이다. 셸 기하가 키보드에 반응하지 않아야
+     브라우저의 visual viewport 팬이 컴포저(동결된 셸의 바닥)를 키보드 위
+     제자리에 보여준다(ia-shell.css 모델 결정 주석 참고). */
   .m-main-scroll--project-chat-detail .pc-proto {
-    min-height: var(--visual-viewport-height, 100dvh);
-    transition: min-height 200ms var(--ease-smooth, ease);
+    min-height: var(--app-vh, 100dvh);
   }
 
   .pc-parallel {
-    height: var(--visual-viewport-height, 100dvh);
+    height: var(--app-vh, 100dvh);
     min-height: 0;
-    transition: height 200ms var(--ease-smooth, ease);
   }
 
   .m-main-scroll--project-chat-detail .pc-proto .shell {
     /* 부모 min-height 기준의 % 해석에 기대지 않도록 명시 높이를 사용한다.
        헤더 표시/숨김에 따라 흔들리지 않도록 상수로 고정한다(스크롤 시
        공간 확보는 .tl의 padding-top 쪽에서 처리한다). */
-    height: var(--visual-viewport-height, 100dvh);
+    height: var(--app-vh, 100dvh);
     min-height: 0;
-    transition: height 200ms var(--ease-smooth, ease);
   }
 
   .pc-proto .ch {

--- a/services/aris-web/components/layout/viewportKeyboardState.ts
+++ b/services/aris-web/components/layout/viewportKeyboardState.ts
@@ -1,18 +1,18 @@
 // 키보드 열림 판정. 터치(coarse pointer) 기기에서는 "텍스트 입력이 포커스된
 // 동안"을 곧 키보드 열림으로 본다(ChatGPT 웹의 data-visual-keyboard와 동일한
 // 포커스-수명 모델). 기하 측정(bottomInset)이 보조로 남는 이유와 한계:
-// interactive-widget=resizes-content가 적용되는 iOS/Android에서는 키보드가
-// 열릴 때 layout viewport(innerHeight)까지 함께 줄어들어
-// bottomInset = innerHeight - vvHeight - offsetTop ≈ 0 이 되므로, 기하
-// 측정만으로는 키보드를 영원히 감지할 수 없다(실기기 실측 2026-07-10:
-// innerH=399, vv h=399, top=347 → inset 0, kb=false로 오판 → 키보드 게이트
-// CSS 전체 미발동). 낙관적 타이머(700ms)도 iOS 키보드 확정(+714ms)과
-// 스크롤(+827ms)보다 먼저 만료되어 경주에서 진다. 포커스 수명 기반이 둘 다에
-// 면역이다 — 게이트되는 CSS 규칙은 전부 라이브 측정값
-// (--visual-viewport-height/offset-top) 기반이라, 하드웨어 키보드 등으로
-// 실제 가상 키보드가 없으면 자연히 no-op이 된다. fine pointer(데스크톱)를
-// 제외하는 이유는 --app-vh 동결이 포커스 내내 이어지면 창 크기 조절이
-// 반영되지 않기 때문.
+// bottomInset = innerHeight - vvHeight - offsetTop 은 브라우저가 포커스된
+// 입력을 보여주려고 visual viewport를 팬하는 순간(offsetTop 증가) 0으로
+// 떨어져 "키보드 닫힘"으로 오판한다. 이 오판이 --app-vh 동결을 풀어 셸을
+// 붕괴시키는 것이 "컴포저가 화면 꼭대기로 튀는" 버그의 원래 뿌리였다
+// (실기기 실측 2026-07-10: vv h=399, top=347 → inset 0, kb=false).
+// resizes-content류 뷰포트 축소 환경에서도 innerHeight가 함께 줄어 같은
+// 방식으로 0이 된다. 낙관적 타이머(700ms)도 iOS 키보드 확정(+714ms)과
+// 스크롤(+827ms)보다 먼저 만료되어 경주에서 진다. 포커스 수명 기반은 이
+// 모두에 면역이다 — 이 판정이 켜 두는 것(--app-vh 동결, 컴포저 max-height
+// 상한)은 실제 가상 키보드가 없으면(하드웨어 키보드 등) 자연히 no-op이라
+// 오래 켜 두어도 안전하다. fine pointer(데스크톱)를 제외하는 이유는
+// --app-vh 동결이 포커스 내내 이어지면 창 크기 조절이 반영되지 않기 때문.
 export const computeKeyboardOpen = (input: {
   bottomInset: number;
   threshold: number;

--- a/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
+++ b/services/aris-web/tests/mobileKeyboardComposerLock.test.ts
@@ -34,54 +34,31 @@ describe('mobile keyboard composer — cooperates with native scroll instead of 
     expect(resetCss).not.toMatch(/html,\s*body\s*\{[^}]*overflow-x:\s*hidden;/s);
   });
 
-  it('shrinks html/body min-height to the live visual viewport while the keyboard is open', () => {
-    // 실기기 진단 오버레이 실측으로 확정된 마지막 원인: reset.css의
-    // min-height: var(--app-vh)는 키보드 오픈 중 이전 높이(746)에 얼어붙어
-    // 문서가 뷰포트(399)보다 커지고, iOS가 그 여백만큼 문서를 스크롤해
-    // (sY=347=746-399) 컴포저를 화면 위로 밀어올렸다. 키보드가 열려 있는
-    // 동안은 html/body의 min-height도 실제 보이는 높이를 따라야 한다.
-    // (이 override는 PR #386에 있다가 #388에서 잘못 삭제됐던 규칙이다.)
-    expect(iaShellCss).toMatch(
-      /html\[data-keyboard-open='true'\],\s*\n\s*html\[data-keyboard-open='true'\] body\s*\{[^}]*min-height:\s*var\(--visual-viewport-height, 100dvh\);/,
-    );
-  });
-
-  it('also shrinks the --app-vh wrapper chain (.app-shell-ia--chat-screen, .m-main) while the keyboard is open', () => {
-    // body의 min-height만 줄여서는 부족하다(격리 재현 실측: bodyMinHeight가
-    // 399로 적용돼도 bodyScrollHeight는 746 유지). 문서 높이는 자식 중 가장
-    // 큰 박스가 결정하는데 .app-shell-ia와 .m-main이 각각
-    // min-height: var(--app-vh)로 얼어붙은 746을 유지하며 body를 떠받치고
-    // 있었다. 래퍼 체인 전체가 함께 줄어야 스크롤 여백이 사라진다.
-    expect(iaShellCss).toMatch(
-      /html\[data-keyboard-open='true'\] \.app-shell-ia--chat-screen,\s*\n\s*html\[data-keyboard-open='true'\] \.app-shell-ia--chat-screen \.m-main\s*\{[^}]*min-height:\s*var\(--visual-viewport-height, 100dvh\);/,
-    );
-  });
-
-  it('follows the native focus scroll with translateY(--visual-viewport-offset-top) on the unclipped app-shell root', () => {
-    // 실기기 오버레이 실측(2차): 콘텐츠 축소(body sh=399)가 정확히 적용돼도
-    // iOS는 포커스 시점의 옛 레이아웃 기준으로 미리 결정한 스크롤(sY=347)을
-    // 그대로 실행하고 이후 클램프하지 않는다. 콘텐츠 축소만으로는 막을 수
-    // 없으므로, ChatGPT 웹과 동일하게 밀려난 만큼(offsetTop) 콘텐츠를 따라
-    // 내려 뷰포트가 바라보는 자리에 콘텐츠를 겹친다. 스크롤이 없으면 0px라
-    // no-op이므로 안드로이드/정상 축소 경로에는 영향이 없다.
-    expect(iaShellCss).toMatch(
-      /html\[data-keyboard-open='true'\] \.app-shell-ia--chat-screen\s*\{[^}]*transform:\s*translateY\(var\(--visual-viewport-offset-top, 0px\)\);/,
-    );
-  });
-
-  it('never applies the pan-follow transform inside the overflow-hidden wrapper chain', () => {
-    // 회귀 방지: 1차 팬-추종은 .pc-proto에 transform을 걸었는데, .pc-proto는
-    // overflow: hidden인 .m-main/.m-main-scroll(높이=뷰포트) 안에 있어서
-    // 내려간 하단 347px — 컴포저 포함 — 이 통째로 클리핑되어 화면에서
-    // 사라졌다. rect 좌표는 클리핑의 영향을 받지 않아 rect 검증으로는 안
-    // 잡힌다. transform은 세로 클리핑이 없는 app-shell 루트에만 건다.
+  it('keyboard-open never changes layout geometry — the native pan model invariant', () => {
+    // 네이티브 팬 모델의 불변식: 키보드가 열려도 우리 레이아웃은 1px도
+    // 반응하지 않는다. 브라우저의 visual viewport 팬이 유일한 대응
+    // 메커니즘이다. 과거 축소 모델 보정들(min-height 축소, translateY
+    // 팬-추종)은 네이티브 팬과 이중 보정되어 컴포저를 화면 밖으로 밀었다
+    // (실기기 오버레이 실측으로 확정). data-keyboard-open에 게이트된
+    // 규칙에는 기하(min-height/height/transform/position)를 바꾸는 선언이
+    // 없어야 한다 — 허용되는 것은 입력창 자체의 max-height 상한뿐.
     const withoutComments = iaShellCss.replace(/\/\*[\s\S]*?\*\//g, '');
-    expect(withoutComments).not.toMatch(
-      /\.pc-proto[^{]*\{[^}]*transform:\s*translateY\(var\(--visual-viewport-offset-top/,
-    );
-    expect(withoutComments).not.toMatch(
-      /\.m-main[^{]*\{[^}]*transform:\s*translateY\(var\(--visual-viewport-offset-top/,
-    );
+    const gatedBlocks = [...withoutComments.matchAll(/\[data-keyboard-open='true'\][^{]*\{([^}]*)\}/g)];
+    expect(gatedBlocks.length).toBeGreaterThan(0);
+    for (const [, body] of gatedBlocks) {
+      expect(body).not.toMatch(/(?<!max-)(min-height|height)\s*:/);
+      expect(body).not.toMatch(/transform\s*:/);
+      expect(body).not.toMatch(/position\s*:/);
+    }
+  });
+
+  it('does not opt into interactive-widget viewport resizing (the pan model relies on the resizes-visual default)', () => {
+    // interactive-widget=resizes-content를 지정하면 iOS가 키보드 오픈 시
+    // 레이아웃 뷰포트까지 줄인다(최신 iOS는 실제로 지원). 그러면 뷰포트
+    // 단위/라이브 변수 기반 축소와 네이티브 팬이 이중 보정되는 하이브리드가
+    // 되어 컴포저가 화면 밖으로 나간다 — 이 지정이 버그 연쇄의 시작점이었다.
+    const rootLayout = readFileSync(resolve(__dirname, '../app/layout.tsx'), 'utf8');
+    expect(rootLayout).not.toContain("interactiveWidget: 'resizes-content'");
   });
 
   it('still preserves the intentional page-scroll model on mobile (iOS toolbar auto-hide)', () => {

--- a/services/aris-web/tests/mobileKeyboardShellHeightTracking.test.ts
+++ b/services/aris-web/tests/mobileKeyboardShellHeightTracking.test.ts
@@ -6,31 +6,38 @@ import { readCssWithImports } from './helpers/readAppStyles';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const uiResponsiveCss = readCssWithImports(resolve(__dirname, '../app/styles/ui-responsive.css'));
 
-describe('mobile chat shell tracks the live visual viewport height', () => {
-  // 실기기 스크린샷으로 재확인된 회귀: overflow-x: clip 수정만으로는 부족했다.
-  // .aris-ia-shell/.pc-proto/.shell이 여전히 얼어붙은 --app-vh(키보드가 열린
-  // 동안 이전 높이에 고정)를 쓰고 있었고, 셸 전체가 실제 보이는 영역보다
-  // 훨씬 커진 채로 남아 네이티브 "포커스 요소 스크롤"이 그 차이만큼 페이지를
-  // 과도하게 끌어올려 컴포저가 화면 맨 위까지 튀었다. position은 절대 건드리지
-  // 않고(전과 동일) 셸의 height/min-height만 --visual-viewport-height를
-  // 따르도록 복원한다 — 숫자 값이라 transition으로 부드럽게 이어진다.
+describe('mobile chat shell keeps keyboard-frozen geometry (native pan model)', () => {
+  // 네이티브 팬 모델의 불변식: 키보드가 열려도 셸 기하는 1px도 반응하지
+  // 않는다. --app-vh는 키보드 오픈 중 이전 높이에 동결되는데, 그게 정확히
+  // 원하는 것이다 — 셸이 가만히 있어야 브라우저의 visual viewport 팬이
+  // 컴포저(동결된 셸의 바닥)를 키보드 위 제자리에 보여준다.
+  // 라이브 값(--visual-viewport-height)으로 바꾸면 셸 축소 + 네이티브 팬의
+  // 이중 보정이 되어 컴포저가 화면 밖으로 나간다(실기기 오버레이 실측으로
+  // 확정된 회귀 — 이 파일의 이전 버전이 바로 그 회귀를 강제하고 있었다).
 
-  it('drives .aris-ia-shell, .pc-proto and .shell from --visual-viewport-height, not the keyboard-frozen --app-vh', () => {
+  it('drives .aris-ia-shell, .pc-proto and .shell from the keyboard-frozen --app-vh', () => {
     expect(uiResponsiveCss).toMatch(
-      /\.app-shell-ia--chat-screen \.aris-ia-shell \{[^}]*min-height:\s*var\(--visual-viewport-height, 100dvh\);/s,
+      /\.app-shell-ia--chat-screen \.aris-ia-shell \{[^}]*min-height:\s*var\(--app-vh, 100dvh\);/s,
     );
     expect(uiResponsiveCss).toMatch(
-      /\.m-main-scroll--project-chat-detail \.pc-proto \{[^}]*min-height:\s*var\(--visual-viewport-height, 100dvh\);/s,
+      /\.m-main-scroll--project-chat-detail \.pc-proto \{[^}]*min-height:\s*var\(--app-vh, 100dvh\);/s,
     );
     expect(uiResponsiveCss).toMatch(
-      /\.m-main-scroll--project-chat-detail \.pc-proto \.shell \{[^}]*height:\s*var\(--visual-viewport-height, 100dvh\);/s,
+      /\.m-main-scroll--project-chat-detail \.pc-proto \.shell \{[^}]*height:\s*var\(--app-vh, 100dvh\);/s,
     );
   });
 
-  it('transitions height/min-height smoothly instead of snapping (position is never touched, so this is safe)', () => {
-    const shellBlock = uiResponsiveCss.match(/\.m-main-scroll--project-chat-detail \.pc-proto \.shell \{([^}]*)\}/s)?.[1] ?? '';
-    expect(shellBlock).toContain('transition: height 200ms');
-    const ariaShellBlock = uiResponsiveCss.match(/\.app-shell-ia--chat-screen \.aris-ia-shell \{([^}]*)\}/s)?.[1] ?? '';
-    expect(ariaShellBlock).toContain('transition: min-height 200ms');
+  it('never references the live --visual-viewport-height for shell geometry', () => {
+    const withoutComments = uiResponsiveCss.replace(/\/\*[\s\S]*?\*\//g, '');
+    const shellBlocks = [
+      /\.app-shell-ia--chat-screen \.aris-ia-shell \{([^}]*)\}/s,
+      /\.m-main-scroll--project-chat-detail \.pc-proto \{([^}]*)\}/s,
+      /\.pc-parallel \{([^}]*)\}/s,
+      /\.m-main-scroll--project-chat-detail \.pc-proto \.shell \{([^}]*)\}/s,
+    ];
+    for (const pattern of shellBlocks) {
+      const block = withoutComments.match(pattern)?.[1] ?? '';
+      expect(block).not.toContain('--visual-viewport-height');
+    }
   });
 });

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -693,17 +693,14 @@ describe('project list surface', () => {
     expect(homeClient).toContain('{shouldShowBottomNav && <BottomNav activeTab={activeTab} onTabChange={handleTabChange} />}');
     expect(homeClient).toContain("className={`app-shell app-shell-ia${shouldShowBottomNav ? '' : ' app-shell-ia--chat-screen'}${projectSurfaceMode === 'panel' ? ' app-shell-ia--project-panel' : ''}`}");
     expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.app-shell-ia--chat-screen\s*\{[^}]*padding-bottom:\s*0;/s);
-    // --app-vh가 아니라 --visual-viewport-height를 쓴다: --app-vh는 키보드가
-    // 열린 동안 이전 높이에 고정되는데, 이 셸들이 그 얼어붙은 높이를 그대로
-    // 쓰면 실제 보이는 영역보다 커진 채로 남아 네이티브 "포커스 요소 스크롤"이
-    // 그 차이만큼 페이지 전체를 과도하게 끌어올린다(컴포저가 화면 맨 위로
-    // 튀는 회귀, 실기기로 확인됨). position은 건드리지 않으므로 height 값
-    // 자체의 전환은 transition으로 부드럽게 이어진다.
-    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.app-shell-ia--chat-screen \.aris-ia-shell\s*\{[^}]*min-height:\s*var\(--visual-viewport-height,\s*100dvh\);/s);
+    // 네이티브 팬 모델: 셸 기하는 키보드 오픈 중 동결되는 --app-vh를 쓴다.
+    // 라이브 값(--visual-viewport-height)으로 바꾸면 셸 축소 + 네이티브 팬의
+    // 이중 보정이 되어 컴포저가 화면 밖으로 나간다(실기기 실측으로 확정).
+    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.app-shell-ia--chat-screen \.aris-ia-shell\s*\{[^}]*min-height:\s*var\(--app-vh,\s*100dvh\);/s);
     // 모바일 채팅 화면은 앱 탑바를 항상 렌더링하지 않으므로(1줄 헤더 병합)
     // .pc-proto/.shell 높이 계산에서 더 이상 그 48px을 빼지 않는다.
-    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.m-main-scroll--project-chat-detail \.pc-proto\s*\{[^}]*min-height:\s*var\(--visual-viewport-height,\s*100dvh\);/s);
-    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.m-main-scroll--project-chat-detail \.pc-proto \.shell\s*\{[^}]*height:\s*var\(--visual-viewport-height,\s*100dvh\);[^}]*min-height:\s*0;/s);
+    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.m-main-scroll--project-chat-detail \.pc-proto\s*\{[^}]*min-height:\s*var\(--app-vh,\s*100dvh\);/s);
+    expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.m-main-scroll--project-chat-detail \.pc-proto \.shell\s*\{[^}]*height:\s*var\(--app-vh,\s*100dvh\);[^}]*min-height:\s*0;/s);
     expect(uiCss).toMatch(/@media\s*\(max-width:\s*767px\)\s*\{[\s\S]*?\.app-shell-ia--chat-screen \.m-top\s*\{[^}]*display:\s*none;/s);
     // 채팅 헤더는 스크롤 숨김 시 이동시키지 않고 언마운트되며(React 쪽), 표시
     // 중에는 타임라인 위 오버레이라 .tl/.shell__main의 박스 크기를 흔들지 않는다.

--- a/services/aris-web/tests/viewportKeyboardState.test.ts
+++ b/services/aris-web/tests/viewportKeyboardState.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { computeKeyboardOpen } from '@/components/layout/viewportKeyboardState';
 
 describe('computeKeyboardOpen — 포커스-수명 기반 키보드 판정', () => {
-  it('resizes-content 세계(iOS 실측 2026-07-10)에서 기하 인셋이 0이어도 포커스 중이면 키보드 열림', () => {
+  it('네이티브 팬 중(기하 인셋 0, iOS 실측 2026-07-10)에도 포커스 중이면 키보드 열림', () => {
     // 실기기 3차 캡처: innerH=399, vv h=399, top=347
     // → bottomInset = max(0, 399 - 399 - 347) = 0.
     // 낙관적 700ms 창은 iOS 키보드 확정(+714ms)/스크롤(+827ms) 전에 만료됐다.


### PR DESCRIPTION
## 사용자 요구

> 컴포저가 올라간 다음에 위치를 계산해서 다시 내려오는 구조를 원하지 않는다. 네이티브 스크롤로 자연스럽게 올라간 자리에 컴포저가 가만히 있으면 된다. 왜 브라우저랑 계속 싸우려고 하냐.

정당한 요구이고, 이 PR이 그대로 구현한다: **키보드가 열려도 우리 레이아웃은 1px도 반응하지 않는다.** 브라우저의 visual viewport 팬이 유일한 대응 메커니즘이다.

## 어쩌다 싸우게 됐나 — 전체 히스토리의 재해석

이 앱은 **원래 이 모델이었다.** `--app-vh`를 키보드 오픈 중 동결하는 설계(#307)가 바로 "레이아웃은 가만히, 네이티브 팬이 컴포저를 보여준다"는 팬 모델이다.

**원래 모델이 깨졌던 진짜 원인**(3차 실기기 실측으로 역산 확정)은 레이아웃이 아니라 **키보드 감지**였다:

```
bottomInset = innerHeight(746) − vvHeight(399) − offsetTop(347) = 0
```

브라우저가 네이티브 팬을 실행하는 바로 그 순간 offsetTop이 커지며 이 수식이 0이 되어 "키보드 닫힘"으로 오판 → `--app-vh` 동결 해제 → 셸 746→399 붕괴 → 컴포저가 팬 된 뷰포트 꼭대기로 순간이동. **팬 모델은 무죄였고, 감지기가 팬을 키보드 닫힘으로 읽고 셸을 무너뜨린 것이다.**

그 증상을 오진해 #387이 `interactive-widget=resizes-content`(뷰포트 축소 모델)를 얹으면서 두 모델이 공존하는 하이브리드가 됐다: 셸 축소가 컴포저를 347px 올리고, iOS 팬이 또 347px 올려 컴포저가 화면 밖으로. 이후 #393/#396/#398은 전부 그 하이브리드를 지탱하는 보정의 탑이었다.

감지 버그는 #399(포커스-수명 판정)가 이미 고쳤다. 이제 보정의 탑을 걷어내고 팬 모델 하나로 복원한다.

## 변경

**제거** (축소 모델과 그 보정 전부):
- `interactive-widget=resizes-content` 메타태그 (#387) → 기본값 `resizes-visual` 복귀
- 키보드 게이트 html/body/래퍼 `min-height` 축소 (#396)
- `translateY(--visual-viewport-offset-top)` 팬-추종 transform (#398)
- 셸의 `--visual-viewport-height` 라이브 추적 (#393) → `--app-vh` 동결값 복원

**유지** (모델과 무관하게 정당한 수정들):
- `overflow-x: clip` (#388) — 문서의 불법 스크롤 여백 방지, 팬 모델의 전제 조건
- 필 포커스 타이밍 (#389)
- **포커스-수명 키보드 판정 (#399)** — 팬 모델의 원래 버그를 고치는 핵심. `--app-vh` 동결이 팬 중에도 유지된다
- 컴포저 auto-grow 상한 — 셸 기하가 아닌 입력창 자체의 시각 제약
- 진단 오버레이 (#395)

## 검증

- `tsc` 클린, vitest 125 파일/**628 테스트** 통과. **팬 모델 불변식 단언 신설**: `data-keyboard-open` 게이트 규칙에 기하 선언(min-height/height/transform/position) 금지, `interactiveWidget` 부재
- 격리 재현(컴파일 번들 CSS 주입, 실측 조건 재현 — kb=true, vv 399, offsetTop 347, `--app-vh` 746 동결):

```
BEFORE == AFTER (기하 스냅샷·스크린샷 바이트 단위 동일)
문서 오버플로 0 (bodyScrollHeight = 746 = 뷰포트)
컴포저 671..738 고정 = 팬 된 뷰포트(347..746)가 바라보는 자리
appShell transform: none
```

- 렌더된 viewport 메타에서 `interactive-widget` 부재 확인: `width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, user-scalable=no`
- 배포 후 실기기 기대 동작: 컴포저 터치 → 키보드와 함께 화면이 자연스럽게 팬 → 컴포저가 키보드 위 그 자리에 정지. 오버레이 수치로는 `kb=true` 유지 + `cmp` rect는 문서 기준 변화 없음(팬은 rect에 안 나타남)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxfd4yi1xRpXZHvjuggvTW
