### PR TITLE
refactor(web): Workspace 사이드바를 workspace/ 모듈로 추출 (PR-0, 기능 동일)

### DIFF
--- a/services/aris-web/components/project-chat/ProjectChatSurface.tsx
+++ b/services/aris-web/components/project-chat/ProjectChatSurface.tsx
@@ -19,18 +19,12 @@ import {
   ArrowDown,
   ArrowUp,
   AtSign,
-  Bot,
   ChevronLeft,
   ChevronRight,
-  Clock,
   Clock3,
   Copy,
-  ExternalLink,
-  File as FileIcon,
   FileText,
-  FolderOpen,
   Loader2,
-  Maximize2,
   MessageSquareText,
   Mic,
   MoreHorizontal,
@@ -47,7 +41,6 @@ import {
 } from 'lucide-react';
 import { ProviderLogo } from '@/components/ui/ProviderLogo';
 import { WorkspaceFileEditor } from '@/components/files/WorkspaceFileEditor';
-import { SubagentPanel } from '@/components/project-chat/SubagentPanel';
 import { isTerminalRunStatus } from '@/lib/happy/chatRuntime';
 import { hydratePersistedPermissions, mergeRenderablePermissions } from '@/lib/happy/permissions';
 import { withAppBasePath } from '@/lib/routing/appPath';
@@ -99,7 +92,6 @@ import {
   isProjectRunStatusEvent,
   eventCommand,
 } from '@/components/project-chat/helpers/projectChatEvents';
-import { GitActionMark } from '@/components/project-chat/helpers/actionMarks';
 import { useComposerAutoGrow } from '@/components/project-chat/helpers/useComposerAutoGrow';
 import { useMobileChatChrome } from '@/components/project-chat/helpers/useMobileChatChrome';
 import { AppChromeMenuItems } from '@/components/layout/AppChromeMenu';
@@ -123,6 +115,8 @@ import { ProjectRunStatusChip } from '@/components/project-chat/ProjectRunStatus
 import { ProjectActionCard } from '@/components/project-chat/ProjectActionCard';
 import { ProjectPermissionRequestMessage } from '@/components/project-chat/ProjectPermissionRequestMessage';
 import { buildProjectChatTimelineItems } from '@/components/project-chat/permissionsTimeline';
+import { WorkspaceSidebar } from '@/components/project-chat/workspace/WorkspaceSidebar';
+import { ProjectPreviewOverlay } from '@/components/project-chat/workspace/PreviewOverlay';
 import { useDensityStore } from './cmd-display/densityStore';
 import { computeAutoDensity } from './cmd-display/densityRules';
 import { MiniStack, type MiniStackItem } from './cmd-display/MiniStack';
@@ -2870,149 +2864,31 @@ export function ProjectChatSurface({
               />
             </div>
           </div>
-          <aside ref={workspaceRef} className="shell__workspace ws ws-pane pc-parallel-workspace" aria-label={`${projectName} workspace`}>
-            <div className="ws__head ws-pane__header">
-              <div className="ws__title ws-pane__title"><PanelRight size={14} />Workspace</div>
-              <div className="ws__actions ws-pane__actions">
-                <button type="button" className="ws__action ws-pane__action btn btn--ghost btn--icon btn--sm" aria-label="Open files" onClick={() => activateWorkspaceTab('files')}>
-                  <FileText size={13} />
-                </button>
-                <button type="button" className="ws__action ws-pane__action btn btn--ghost btn--icon btn--sm" aria-label="Close workspace" onClick={closeWorkspacePanel}>
-                  <X size={13} />
-                </button>
-              </div>
-            </div>
-            <div className="ws__tabs" role="tablist">
-              <button type="button" className="ws__tab" data-tab="run" aria-pressed={workspaceTab === 'run'} onClick={() => activateWorkspaceTab('run')}><Clock size={12} />Run</button>
-              <button type="button" className="ws__tab" data-tab="files" aria-pressed={workspaceTab === 'files'} onClick={() => activateWorkspaceTab('files')}><FileIcon size={12} />Files</button>
-              <button type="button" className="ws__tab" data-tab="git" aria-pressed={workspaceTab === 'git'} onClick={() => activateWorkspaceTab('git')}><GitActionMark size={12} />Git</button>
-              <button type="button" className="ws__tab" data-tab="terminal" aria-pressed={workspaceTab === 'terminal'} onClick={() => activateWorkspaceTab('terminal')}><Terminal size={12} />Terminal</button>
-              <button type="button" className="ws__tab" data-tab="context" aria-pressed={workspaceTab === 'context'} onClick={() => activateWorkspaceTab('context')}><PanelsTopLeft size={12} />Context</button>
-              <button type="button" className="ws__tab" data-tab="subagents" aria-pressed={workspaceTab === 'subagents'} onClick={() => activateWorkspaceTab('subagents')}><Bot size={12} />Subagents</button>
-            </div>
-            <div className="ws__status">
-              <div className="ws__status-left">
-                <span className={`ws__model ws__model--${providerFromAgent(activeWorkspaceChat?.agent ?? session.agent)}`}>
-                  <span className="ws__model-dot" />{activeWorkspaceChat?.title ?? 'Panel'}
-                </span>
-                <span className="ws__pill"><span className="ws__pill-dot" />{activeWorkspacePanelRuntime?.branch ?? 'project'}</span>
-              </div>
-              <div className="ws__status-right">
-                <span>{activeWorkspacePanelId ? `#${activeWorkspacePanelId.slice(-4)}` : 'no panel'}</span>
-              </div>
-            </div>
-            <div className="ws__body">
-              <div className={`ws__pane${workspaceTab === 'run' ? ' ws__pane--active' : ''}`} data-pane="run">
-                <div className="run-summary">
-                  <div className="run-summary__cell"><span className="run-summary__label">Panel</span><span className="run-summary__value">{activeWorkspacePanelId ? activeWorkspacePanelId.slice(-4) : '-'}</span></div>
-                  <div className="run-summary__cell"><span className="run-summary__label">Branch</span><span className="run-summary__value">{activeWorkspacePanelRuntime?.branch ?? '-'}</span></div>
-                  <div className="run-summary__cell"><span className="run-summary__label">Runtime</span><span className="run-summary__value">{activeWorkspacePanelRuntime?.runtimeSessionId ? 'ready' : 'project'}</span></div>
-                </div>
-                <div className="ws-card ws-card--run">
-                  <div className="ws-card__head">
-                    <div className="ws-card__title">{activeWorkspaceChat?.title ?? '선택된 패널이 없습니다.'}</div>
-                    <div className="ws-card__meta">{activeWorkspacePanelRuntime?.worktreePath ?? projectPath}</div>
-                  </div>
-                  <div className="ws-empty-state">선택된 패널의 worktree 기준 상태입니다.</div>
-                </div>
-              </div>
-              <div className={`ws__pane${workspaceTab === 'files' ? ' ws__pane--active' : ''}`} data-pane="files">
-                <div className="file-tree__head">
-                  <span className="file-tree__cwd" title={workspaceFiles.currentPath}>{workspaceFiles.currentPath}</span>
-                  <button type="button" className="file-tree__refresh" aria-label="Refresh files" onClick={() => workspaceFiles.refresh()} disabled={workspaceFiles.loading}>
-                    <RefreshCcw size={11} />
-                  </button>
-                </div>
-                <div className="file-tree">
-                  {workspaceFiles.parentPath && (
-                    <button type="button" className="file-row file-row--parent" onClick={() => workspaceFiles.goUp()}>
-                      <span className="file-row__icon file-row__icon--dir"><FolderOpen size={13} /></span>
-                      <span className="file-row__name">..</span>
-                      <span className="file-row__meta">parent</span>
-                    </button>
-                  )}
-                  {workspaceFiles.loading && workspaceFiles.items.length === 0 && <div className="file-row file-row--state">Loading…</div>}
-                  {workspaceFiles.error && <div className="file-row file-row--state file-row--error">{workspaceFiles.error}</div>}
-                  {!workspaceFiles.loading && !workspaceFiles.error && workspaceFiles.items.length === 0 && <div className="file-row file-row--state">빈 디렉터리</div>}
-                  {workspaceFiles.items.map((file: WorkspaceFileItem) => (
-                    <button
-                      key={file.path}
-                      type="button"
-                      className={`file-row${selectedWorkspaceFile === file.path ? ' file-row--selected' : ''}`}
-                      onClick={() => {
-                        if (file.isDirectory) {
-                          workspaceFiles.cdInto(file);
-                        } else {
-                          openWorkspaceFilePreview(file);
-                        }
-                      }}
-                    >
-                      <span className={`file-row__icon${file.isDirectory ? ' file-row__icon--dir' : ''}`}>
-                        {file.isDirectory ? <FolderOpen size={13} /> : <FileText size={13} />}
-                      </span>
-                      <span className="file-row__name">{file.name}</span>
-                      <span className="file-row__meta">{file.isDirectory ? 'dir' : 'file'}</span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div className={`ws__pane${workspaceTab === 'git' ? ' ws__pane--active' : ''}`} data-pane="git">
-                <div className="file-tree__head">
-                  <span className="file-tree__cwd" title={workspaceGitOverview?.workspacePath ?? activeWorkspacePanelRuntime?.worktreePath ?? ''}>
-                    {workspaceGitOverview?.branch ?? activeWorkspacePanelRuntime?.branch ?? 'branch pending'}
-                  </span>
-                  <button type="button" className="file-tree__refresh" aria-label="Refresh Git" onClick={refreshWorkspaceGit} disabled={workspaceGitLoading}>
-                    <RefreshCcw size={11} />
-                  </button>
-                </div>
-                <div className="pc-panel-git-summary">
-                  <span data-tone={workspaceGitOverview?.isClean ? 'ready' : 'pending'}>{workspaceGitOverview?.isClean ? 'clean' : 'dirty'}</span>
-                  <span>staged {workspaceGitOverview?.stagedCount ?? 0}</span>
-                  <span>changed {workspaceGitOverview?.unstagedCount ?? 0}</span>
-                  <span>untracked {workspaceGitOverview?.untrackedCount ?? 0}</span>
-                  <span>ahead {workspaceGitOverview?.ahead ?? 0} / behind {workspaceGitOverview?.behind ?? 0}</span>
-                </div>
-                <div className="file-tree">
-                  {workspaceGitLoading && <div className="file-row file-row--state">Loading Git status…</div>}
-                  {workspaceGitError && <div className="file-row file-row--state file-row--error">{workspaceGitError}</div>}
-                  {!workspaceGitLoading && !workspaceGitError && workspaceGitOverview?.files.length === 0 && (
-                    <div className="file-row file-row--state">변경된 파일이 없습니다.</div>
-                  )}
-                  {workspaceGitOverview?.files.slice(0, 60).map((file) => (
-                    <div key={`${file.path}:${file.indexStatus}:${file.workTreeStatus}`} className="pc-panel-git-file">
-                      <span>{file.indexStatus}{file.workTreeStatus}</span>
-                      <strong title={file.path}>{file.path}</strong>
-                      <em>{file.conflicted ? 'conflict' : file.untracked ? 'new' : file.staged ? 'staged' : 'modified'}</em>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              <div className={`ws__pane${workspaceTab === 'terminal' ? ' ws__pane--active' : ''}`} data-pane="terminal">
-                <div className="term">
-                  <div className="term__head"><span className="term__tag">bash · selected panel</span><span className="term__dim">{activeWorkspacePanelRuntime?.runtimeSessionId ?? projectId}</span></div>
-                  <div className="term__body">
-                    <div className="term__line"><span className="term__prompt">~/aris$</span><span>{draftTerminalCommand}</span></div>
-                    <div className="term__line"><span className="term__dim">cwd · {activeWorkspacePanelRuntime?.worktreePath ?? projectPath}</span></div>
-                  </div>
-                </div>
-              </div>
-              <div className={`ws__pane${workspaceTab === 'context' ? ' ws__pane--active' : ''}`} data-pane="context">
-                <div className="ctx-group">
-                  <div className="ctx-group__head"><span className="ctx-group__title">Panel context</span><span className="ctx-group__count">{contextItems.length}</span></div>
-                  {contextItems.map((item) => (
-                    <button key={item.id} type="button" className="ctx-item" onClick={() => handleCopy(item.name, 'Context item')}>
-                      <FileText size={13} className="ctx-item__icon" />
-                      <span className="ctx-item__name">{item.name}</span>
-                      <span className="ctx-item__tokens">{item.tokens}</span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div className={`ws__pane${workspaceTab === 'subagents' ? ' ws__pane--active' : ''}`} data-pane="subagents">
-                <SubagentPanel sessionId={session.id} chatId={activeChat?.id ?? null} active={workspaceTab === 'subagents'} />
-              </div>
-            </div>
-          </aside>
+          <WorkspaceSidebar
+            variant="panel"
+            workspaceRef={workspaceRef}
+            projectName={projectName}
+            workspaceTab={workspaceTab}
+            activateWorkspaceTab={activateWorkspaceTab}
+            closeWorkspacePanel={closeWorkspacePanel}
+            workspaceFiles={workspaceFiles}
+            selectedWorkspaceFile={selectedWorkspaceFile}
+            openWorkspaceFilePreview={openWorkspaceFilePreview}
+            workspaceGitOverview={workspaceGitOverview}
+            workspaceGitLoading={workspaceGitLoading}
+            workspaceGitError={workspaceGitError}
+            refreshWorkspaceGit={refreshWorkspaceGit}
+            activeWorkspacePanelRuntime={activeWorkspacePanelRuntime}
+            draftTerminalCommand={draftTerminalCommand}
+            contextItems={contextItems}
+            handleCopy={handleCopy}
+            session={session}
+            activeChat={activeChat}
+            projectPath={projectPath}
+            activeWorkspaceChat={activeWorkspaceChat}
+            activeWorkspacePanelId={activeWorkspacePanelId}
+            projectId={projectId}
+          />
         </div>
       ) : (
       <>
@@ -3414,368 +3290,65 @@ export function ProjectChatSurface({
           </footer>
         </main>
 
-        <aside ref={workspaceRef} className="shell__workspace ws ws-pane" aria-label={`${projectName} workspace`}>
-          <div className="ws__head ws-pane__header">
-            <div className="ws__title ws-pane__title"><PanelRight size={14} />Workspace</div>
-            <div className="ws__actions ws-pane__actions">
-              <button type="button" className="ws__action ws-pane__action btn btn--ghost btn--icon btn--sm" aria-label="Open preview" onClick={() => setPreviewState('open')}>
-                <Maximize2 size={13} />
-              </button>
-              <button type="button" className="ws__action ws-pane__action btn btn--ghost btn--icon btn--sm" aria-label="Open files" onClick={() => activateWorkspaceTab('files')}>
-                <FileText size={13} />
-              </button>
-              <button type="button" className="ws__action ws-pane__action btn btn--ghost btn--icon btn--sm" aria-label="Close workspace" onClick={closeWorkspacePanel}>
-                <X size={13} />
-              </button>
-            </div>
-          </div>
-          <div className="ws__tabs" role="tablist">
-            <button type="button" className="ws__tab" data-tab="run" aria-pressed={workspaceTab === 'run'} onClick={() => activateWorkspaceTab('run')}><Clock size={12} />Run</button>
-            <button type="button" className="ws__tab" data-tab="files" aria-pressed={workspaceTab === 'files'} onClick={() => activateWorkspaceTab('files')}><FileIcon size={12} />Files</button>
-            <button type="button" className="ws__tab" data-tab="git" aria-pressed={workspaceTab === 'git'} onClick={() => activateWorkspaceTab('git')}><GitActionMark size={12} />Git</button>
-            <button type="button" className="ws__tab" data-tab="terminal" aria-pressed={workspaceTab === 'terminal'} onClick={() => activateWorkspaceTab('terminal')}><Terminal size={12} />Terminal</button>
-            <button type="button" className="ws__tab" data-tab="context" aria-pressed={workspaceTab === 'context'} onClick={() => activateWorkspaceTab('context')}><PanelsTopLeft size={12} />Context</button>
-              <button type="button" className="ws__tab" data-tab="subagents" aria-pressed={workspaceTab === 'subagents'} onClick={() => activateWorkspaceTab('subagents')}><Bot size={12} />Subagents</button>
-          </div>
-          <div className="ws__status">
-            <div className="ws__status-left">
-              <span className={`ws__model ws__model--${selectedProvider}`}><span className="ws__model-dot" />{activeModelLabel}</span>
-              <span className="ws__pill"><span className="ws__pill-dot" />{projectStatusLabel(session.status)}</span>
-            </div>
-            <div className="ws__status-right">
-              <span>{tokenLabel}</span>
-              <button
-                type="button"
-                className="ws__stop"
-                aria-label="Stop"
-                disabled={!projectRunActive}
-                onClick={() => { void handleStopActiveChat(); }}
-              >
-                <Square size={10} />
-              </button>
-            </div>
-          </div>
-          <div className="ws__body">
-            <div className={`ws__pane${workspaceTab === 'run' ? ' ws__pane--active' : ''}`} data-pane="run">
-              <div className="run-summary">
-                <div className="run-summary__cell"><span className="run-summary__label">Steps</span><span className="run-summary__value">{visibleEvents.length}</span></div>
-                <div className="run-summary__cell"><span className="run-summary__label">Tokens</span><span className="run-summary__value">{tokenLabel}</span></div>
-                <div className="run-summary__cell"><span className="run-summary__label">Activity</span><span className="run-summary__value">{formatRelativeTime(selectedChatTimestamp)}</span></div>
-              </div>
-              <div className="ws-card ws-card--run">
-                <div className="ws-card__head">
-                  <div className="ws-card__title">Run · {activeChat?.id ? `#${activeChat.id.slice(-4)}` : '#0142'}</div>
-                  <div className="ws-card__meta">{formatRelativeTime(selectedChatTimestamp)} · {tokenLabel} tokens</div>
-                </div>
-                <div className="run-steps">
-                  {runStepItems.length > 0 ? (
-                    runStepItems.map((item) => (
-                      <button key={item.id} type="button" className="run-step ws-run-step" onClick={() => handleCopy(item.cmd, 'Run step')}>
-                        <span className="run-step__dot ws-run-step__dot run-step__dot--done ws-run-step__dot--done" />
-                        <div className="run-step__body ws-run-step__body">
-                          <div className="run-step__title ws-run-step__title">{item.title}</div>
-                          <div className="run-step__cmd ws-run-step__time">{item.cmd}</div>
-                        </div>
-                        <span className="run-step__time ws-run-step__time">{item.time}</span>
-                      </button>
-                    ))
-                  ) : (
-                    <div className="ws-empty-state">실행 기록이 없습니다.</div>
-                  )}
-                </div>
-              </div>
-              <div className="chist ws-card ws-card--history">
-                <div className="chist__head">
-                  <span className="chist__title"><MessageSquareText size={12} />Chat history</span>
-                  <span className="chist__meta">{historyTurnItems.length} turns</span>
-                </div>
-                <div className="chist__list">
-                  {historyTurnItems.length > 0 ? (
-                    historyTurnItems.map((item) => (
-                      <div key={item.id} className="chturn" data-open={visibleExpandedTurnId === item.id ? 'true' : 'false'}>
-                        <button
-                          type="button"
-                          className="chturn__preview"
-                          data-turn-toggle
-                          onClick={() => setExpandedTurnId(visibleExpandedTurnId === item.id ? '__none__' : item.id)}
-                        >
-                          <span className="chturn__avatar">U</span>
-                          <span className="chturn__body">
-                            <span className="chturn__meta">
-                              <span className="chturn__name">You</span>
-                              <span className="chturn__time">{formatRelativeTime(item.timestamp)}</span>
-                              <span className={`chturn__pill ${item.state === 'running' ? 'chturn__pill--run' : 'chturn__pill--ok'}`}>
-                                <span className="chturn__pill-dot" />{item.state}
-                              </span>
-                            </span>
-                            <span className="chturn__text">{item.text}</span>
-                          </span>
-                          <ChevronRight size={12} className="chturn__caret" />
-                        </button>
-                        <div className="chturn__expanded">
-                          <div className="chturn__agent-head">
-                            <span className={`chturn__agent-avatar ${agentAvatarClass(activeAgent)}`}>
-                              <ProviderLogo provider={selectedProvider} />
-                            </span>
-                            <span className="chturn__agent-label"><strong>{agentLabel(activeAgent, activeModelLabel)}</strong></span>
-                            <span className="chturn__agent-final">{item.state === 'running' ? 'In progress' : 'Final'}</span>
-                          </div>
-                          <div className="chturn__agent-text"><MarkdownContent body={item.agentText} /></div>
-                          <div className="chturn__actions">
-                            <button type="button" className="chturn__btn" onClick={() => handleJumpToTurn(item.id)}><ChevronRight size={11} />Jump</button>
-                            <button type="button" className="chturn__btn" data-preview-open onClick={() => setPreviewState('open')}><FileText size={11} />Preview</button>
-                            <button type="button" className="chturn__btn" onClick={() => handleCopy(`${item.text}\n\n${item.agentText}`, 'Turn summary')}><Copy size={11} />Copy</button>
-                          </div>
-                        </div>
-                      </div>
-                    ))
-                  ) : (
-                    <div className="ws-empty-state">대화 기록이 없습니다.</div>
-                  )}
-                </div>
-              </div>
-            </div>
-            <div className={`ws__pane${workspaceTab === 'files' ? ' ws__pane--active' : ''}`} data-pane="files">
-              <div className="file-tree__head">
-                <span className="file-tree__cwd" title={workspaceFiles.currentPath}>{workspaceFiles.currentPath}</span>
-                <button
-                  type="button"
-                  className="file-tree__refresh"
-                  aria-label="Refresh files"
-                  onClick={() => workspaceFiles.refresh()}
-                  disabled={workspaceFiles.loading}
-                >
-                  <RefreshCcw size={11} />
-                </button>
-              </div>
-              <div className="file-tree">
-                {workspaceFiles.parentPath && (
-                  <button
-                    type="button"
-                    className="file-row file-row--parent"
-                    onClick={() => workspaceFiles.goUp()}
-                  >
-                    <span className="file-row__icon file-row__icon--dir">
-                      <FolderOpen size={13} />
-                    </span>
-                    <span className="file-row__name">..</span>
-                    <span className="file-row__meta">parent</span>
-                  </button>
-                )}
-                {workspaceFiles.loading && workspaceFiles.items.length === 0 && (
-                  <div className="file-row file-row--state">Loading…</div>
-                )}
-                {workspaceFiles.error && (
-                  <div className="file-row file-row--state file-row--error">{workspaceFiles.error}</div>
-                )}
-                {!workspaceFiles.loading && !workspaceFiles.error && workspaceFiles.items.length === 0 && (
-                  <div className="file-row file-row--state">빈 디렉터리</div>
-                )}
-                {workspaceFiles.items.map((file: WorkspaceFileItem) => (
-                  <button
-                    key={file.path}
-                    type="button"
-                    className={`file-row${selectedWorkspaceFile === file.path ? ' file-row--selected' : ''}`}
-                    onClick={() => {
-                      if (file.isDirectory) {
-                        workspaceFiles.cdInto(file);
-                      } else {
-                        openWorkspaceFilePreview(file);
-                      }
-                    }}
-                  >
-                    <span className={`file-row__icon${file.isDirectory ? ' file-row__icon--dir' : ''}`}>
-                      {file.isDirectory ? <FolderOpen size={13} /> : <FileText size={13} />}
-                    </span>
-                    <span className="file-row__name">{file.name}</span>
-                    <span className="file-row__meta">{file.isDirectory ? 'dir' : 'file'}</span>
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div className={`ws__pane${workspaceTab === 'git' ? ' ws__pane--active' : ''}`} data-pane="git">
-              <div className="file-tree__head">
-                <span className="file-tree__cwd" title={workspaceGitOverview?.workspacePath ?? activeWorkspacePanelRuntime?.worktreePath ?? projectPath}>
-                  {workspaceGitOverview?.branch ?? activeWorkspacePanelRuntime?.branch ?? 'project branch'}
-                </span>
-                <button
-                  type="button"
-                  className="file-tree__refresh"
-                  aria-label="Refresh Git"
-                  onClick={refreshWorkspaceGit}
-                  disabled={workspaceGitLoading}
-                >
-                  <RefreshCcw size={11} />
-                </button>
-              </div>
-              <div className="pc-panel-git-summary">
-                <span data-tone={workspaceGitOverview?.isClean ? 'ready' : 'pending'}>{workspaceGitOverview?.isClean ? 'clean' : 'dirty'}</span>
-                <span>staged {workspaceGitOverview?.stagedCount ?? 0}</span>
-                <span>changed {workspaceGitOverview?.unstagedCount ?? 0}</span>
-                <span>untracked {workspaceGitOverview?.untrackedCount ?? 0}</span>
-                <span>ahead {workspaceGitOverview?.ahead ?? 0} / behind {workspaceGitOverview?.behind ?? 0}</span>
-              </div>
-              <div className="file-tree">
-                {workspaceGitLoading && <div className="file-row file-row--state">Loading Git status…</div>}
-                {workspaceGitError && <div className="file-row file-row--state file-row--error">{workspaceGitError}</div>}
-                {!workspaceGitLoading && !workspaceGitError && workspaceGitOverview?.files.length === 0 && (
-                  <div className="file-row file-row--state">변경된 파일이 없습니다.</div>
-                )}
-                {workspaceGitOverview?.files.slice(0, 60).map((file) => (
-                  <div key={`${file.path}:${file.indexStatus}:${file.workTreeStatus}`} className="pc-panel-git-file">
-                    <span>{file.indexStatus}{file.workTreeStatus}</span>
-                    <strong title={file.path}>{file.path}</strong>
-                    <em>{file.conflicted ? 'conflict' : file.untracked ? 'new' : file.staged ? 'staged' : 'modified'}</em>
-                  </div>
-                ))}
-              </div>
-            </div>
-            <div className={`ws__pane${workspaceTab === 'terminal' ? ' ws__pane--active' : ''}`} data-pane="terminal">
-              <div className="term">
-                <div className="term__head">
-                  <div className="term__head-left">
-                    <span className="term__dots"><span className="term__dot term__dot--r" /><span className="term__dot term__dot--y" /><span className="term__dot term__dot--g" /></span>
-                    <span className="term__tag">bash · project chat</span>
-                  </div>
-                  <span className="term__dim">{composerMode}</span>
-                </div>
-                <div className="term__body">
-                  <div className="term__line"><span className="term__prompt">~/aris$</span><span>{draftTerminalCommand}</span></div>
-                  <div className="term__line"><span className="term__dim">selected · {selectedWorkspaceFile}</span></div>
-                  <div className="term__line"><span className="term__ok">✓</span><span>ready to run in this project context</span></div>
-                </div>
-              </div>
-              <div className="snip-group">
-                <div className="snip-group__head">
-                  <span className="snip-group__label"><Terminal size={12} />Snippets</span>
-                  <span className="snip-group__count">{terminalSnippets.length}</span>
-                </div>
-                {terminalSnippets.map((snippet) => (
-                  <button
-                    key={snippet.id}
-                    type="button"
-                    className="snip-row"
-                    onClick={() => {
-                      setDraftTerminalCommand(snippet.cmd);
-                      setPrompt((value) => value || snippet.cmd);
-                    }}
-                  >
-                    <span className="snip-row__name">{snippet.name}</span>
-                    <span className="snip-row__cmd">{snippet.cmd}</span>
-                    <span className="snip-row__tag">{snippet.tag}</span>
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div className={`ws__pane${workspaceTab === 'context' ? ' ws__pane--active' : ''}`} data-pane="context">
-              <div className="ctx-summary">
-                <div className="ctx-ring" aria-label={`${tokenLabel} context usage`}>
-                  <svg viewBox="0 0 80 80" width="80" height="80" aria-hidden="true">
-                    <circle className="ctx-ring__track" cx="40" cy="40" r="34" strokeWidth="6" fill="none" />
-                    <circle className="ctx-ring__fill" cx="40" cy="40" r="34" strokeWidth="6" fill="none" strokeDasharray="214" strokeDashoffset="194" strokeLinecap="round" />
-                  </svg>
-                  <div className="ctx-ring__center">9.2%</div>
-                </div>
-                <div className="ctx-summary__body">
-                  <div className="ctx-summary__title">Context usage</div>
-                  <div className="ctx-summary__meta">{tokenLabel} / 200k tokens</div>
-                  <div className="ctx-summary__split">
-                    <div className="ctx-summary__split-cell"><div className="ctx-summary__split-label">Model</div><div className="ctx-summary__split-value">{activeModelLabel}</div></div>
-                    <div className="ctx-summary__split-cell"><div className="ctx-summary__split-label">Mode</div><div className="ctx-summary__split-value">{COMPOSER_MODE_COPY[composerMode]}</div></div>
-                  </div>
-                </div>
-              </div>
-              <div className="ctx-group">
-                <div className="ctx-group__head"><span className="ctx-group__title">Attached context</span><span className="ctx-group__count">{contextItems.length}</span></div>
-                {contextItems.map((item) => (
-                  <button key={item.id} type="button" className="ctx-item" onClick={() => handleCopy(item.name, 'Context item')}>
-                    <FileText size={13} className="ctx-item__icon" />
-                    <span className="ctx-item__name">{item.name}</span>
-                    <span className="ctx-item__tokens">{item.tokens}</span>
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div className={`ws__pane${workspaceTab === 'subagents' ? ' ws__pane--active' : ''}`} data-pane="subagents">
-              <SubagentPanel sessionId={session.id} chatId={activeChat?.id ?? null} active={workspaceTab === 'subagents'} />
-            </div>
-          </div>
-          <div className="ws__footer">
-            <div className="ws__footer-row"><span className="ws__footer-label">Context usage</span><span className="ws__footer-value">{tokenLabel} / 200k</span></div>
-            <div className="ws__footer-bar"><div className="ws__footer-fill" style={{ width: '9.2%' }} /></div>
-            <div className="ws__footer-meta"><span>project scoped</span><span>{fileCount} files</span></div>
-          </div>
-        </aside>
+        <WorkspaceSidebar
+          variant="project"
+          workspaceRef={workspaceRef}
+          projectName={projectName}
+          workspaceTab={workspaceTab}
+          activateWorkspaceTab={activateWorkspaceTab}
+          closeWorkspacePanel={closeWorkspacePanel}
+          workspaceFiles={workspaceFiles}
+          selectedWorkspaceFile={selectedWorkspaceFile}
+          openWorkspaceFilePreview={openWorkspaceFilePreview}
+          workspaceGitOverview={workspaceGitOverview}
+          workspaceGitLoading={workspaceGitLoading}
+          workspaceGitError={workspaceGitError}
+          refreshWorkspaceGit={refreshWorkspaceGit}
+          activeWorkspacePanelRuntime={activeWorkspacePanelRuntime}
+          draftTerminalCommand={draftTerminalCommand}
+          contextItems={contextItems}
+          handleCopy={handleCopy}
+          session={session}
+          activeChat={activeChat}
+          projectPath={projectPath}
+          setPreviewState={setPreviewState}
+          selectedProvider={selectedProvider}
+          activeModelLabel={activeModelLabel}
+          tokenLabel={tokenLabel}
+          projectRunActive={projectRunActive}
+          handleStopActiveChat={handleStopActiveChat}
+          visibleEventsCount={visibleEvents.length}
+          selectedChatTimestamp={selectedChatTimestamp}
+          runStepItems={runStepItems}
+          historyTurnItems={historyTurnItems}
+          visibleExpandedTurnId={visibleExpandedTurnId}
+          setExpandedTurnId={setExpandedTurnId}
+          handleJumpToTurn={handleJumpToTurn}
+          activeAgent={activeAgent}
+          composerMode={composerMode}
+          terminalSnippets={terminalSnippets}
+          setDraftTerminalCommand={setDraftTerminalCommand}
+          setPrompt={setPrompt}
+          fileCount={fileCount}
+        />
       </div>
-      <div className="overlay" data-preview-overlay role="dialog" aria-modal="true" aria-label="Preview">
-        <div className="preview-frame">
-          <div className="preview-topbar">
-            <div className="preview-topbar__nav">
-              <button type="button" className="preview-topbar__btn" aria-label="Back"><ChevronLeft size={13} /></button>
-              <button type="button" className="preview-topbar__btn" aria-label="Refresh" onClick={() => showTransientFeedback('Preview refreshed')}><RefreshCcw size={13} /></button>
-            </div>
-            <div className="preview-url">
-              <span className="preview-url__protocol">https://</span>
-              <span className="preview-url__target">{previewTarget}</span>
-              <span className="preview-url__meta">project</span>
-            </div>
-            <div className="preview-device" role="tablist" aria-label="Preview size">
-              {(['1200', '768', '390'] as const).map((device) => (
-                <button key={device} type="button" aria-pressed={previewDevice === device} onClick={() => setPreviewDevice(device)}>{device}</button>
-              ))}
-            </div>
-            <button type="button" className="preview-topbar__btn" aria-label="Copy preview URL" onClick={() => handleCopy(`https://${previewTarget}`, 'Preview URL')}><ExternalLink size={13} /></button>
-            <button type="button" className="preview-topbar__btn" data-preview-dock aria-label="Dock preview" onClick={() => setPreviewState('dock')}><PanelsTopLeft size={13} /></button>
-            <button type="button" className="preview-topbar__btn" aria-label="Close preview" onClick={() => setPreviewState('closed')}><X size={13} /></button>
-          </div>
-          <div className="preview-canvas" data-preview-size={previewDevice}>
-            <div className="preview-page">
-              <aside className="preview-page__sb">
-                <div className="preview-page__sb-logo">ARIS</div>
-                <div className="preview-page__sb-item preview-page__sb-item--active">{displayProjectName(session)}</div>
-                <div className="preview-page__sb-item">{activeChat?.title ?? 'Project chat'}</div>
-                <div className="preview-page__sb-item">{selectedWorkspaceFile}</div>
-              </aside>
-              <main className="preview-page__main">
-                <h2 className="preview-page__h">{activeChat?.title ?? 'Project chat'}</h2>
-                <p className="preview-page__sub">{agentLabel(activeAgent, activeModelLabel)} · {COMPOSER_MODE_COPY[composerMode]} · {tokenLabel}</p>
-                <div className="preview-page__cards">
-                  <div className="preview-page__card">
-                    <div className="preview-page__card-t">Workspace</div>
-                    <div className="preview-page__card-m">{workspaceTab} · {selectedWorkspaceFile}</div>
-                    <div className="preview-page__bar"><div className="preview-page__bar-fill" style={{ width: '74%' }} /></div>
-                  </div>
-                  <div className="preview-page__card">
-                    <div className="preview-page__card-t">Context</div>
-                    <div className="preview-page__card-m">{projectPath}</div>
-                    <div className="preview-page__bar"><div className="preview-page__bar-fill" style={{ width: '42%' }} /></div>
-                  </div>
-                </div>
-              </main>
-            </div>
-            <div className="preview-controls">
-              <button type="button" aria-label="Zoom out" onClick={() => showTransientFeedback('Preview zoom 90%')}><ChevronLeft size={12} /></button>
-              <span className="preview-controls__zoom">100%</span>
-              <button type="button" aria-label="Zoom in" onClick={() => showTransientFeedback('Preview zoom 110%')}><ChevronRight size={12} /></button>
-              <span className="preview-controls__sep" />
-              <button type="button" aria-label="Screenshot" onClick={() => showTransientFeedback('Screenshot staged')}><Copy size={12} /></button>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div className="preview-dock-wrap" data-preview-dock>
-        <div className="preview-dock">
-          <span className="preview-dock__thumb" />
-          <span className="preview-dock__name">{selectedWorkspaceFile}</span>
-          <span className="preview-dock__meta">{previewDevice}</span>
-          <button type="button" className="preview-dock__btn preview-dock__btn--live" data-preview-open aria-label="Expand preview" onClick={() => setPreviewState('open')}>
-            <Maximize2 size={12} />
-          </button>
-          <button type="button" className="preview-dock__btn" aria-label="Close preview dock" onClick={() => setPreviewState('closed')}>
-            <X size={12} />
-          </button>
-        </div>
-      </div>
+      <ProjectPreviewOverlay
+        previewTarget={previewTarget}
+        previewDevice={previewDevice}
+        setPreviewDevice={setPreviewDevice}
+        setPreviewState={setPreviewState}
+        handleCopy={handleCopy}
+        showTransientFeedback={showTransientFeedback}
+        session={session}
+        activeChat={activeChat}
+        activeAgent={activeAgent}
+        activeModelLabel={activeModelLabel}
+        composerMode={composerMode}
+        workspaceTab={workspaceTab}
+        selectedWorkspaceFile={selectedWorkspaceFile}
+        projectPath={projectPath}
+        tokenLabel={tokenLabel}
+      />
       </>
       )}
       {copyFeedback && <div className="pc-toast" data-copy-feedback role="status">{copyFeedback}</div>}

--- a/services/aris-web/components/project-chat/workspace/PreviewOverlay.tsx
+++ b/services/aris-web/components/project-chat/workspace/PreviewOverlay.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  ExternalLink,
+  Maximize2,
+  PanelsTopLeft,
+  RefreshCcw,
+  X,
+} from 'lucide-react';
+import type { SessionChat, SessionSummary } from '@/lib/happy/types';
+import {
+  COMPOSER_MODE_COPY,
+  agentLabel,
+  displayProjectName,
+  type ComposerMode,
+  type PreviewState,
+  type WorkspaceTab,
+} from '../projectChatSurfaceUtils';
+
+export type PreviewDevice = '1200' | '768' | '390';
+
+export type ProjectPreviewOverlayProps = {
+  previewTarget: string;
+  previewDevice: PreviewDevice;
+  setPreviewDevice: (device: PreviewDevice) => void;
+  setPreviewState: (state: PreviewState) => void;
+  handleCopy: (value: string, label: string) => void;
+  showTransientFeedback: (message: string) => void;
+  session: SessionSummary;
+  activeChat: SessionChat | null;
+  activeAgent: SessionSummary['agent'];
+  activeModelLabel: string;
+  composerMode: ComposerMode;
+  workspaceTab: WorkspaceTab;
+  selectedWorkspaceFile: string;
+  projectPath: string;
+  tokenLabel: string;
+};
+
+export function ProjectPreviewOverlay({
+  previewTarget,
+  previewDevice,
+  setPreviewDevice,
+  setPreviewState,
+  handleCopy,
+  showTransientFeedback,
+  session,
+  activeChat,
+  activeAgent,
+  activeModelLabel,
+  composerMode,
+  workspaceTab,
+  selectedWorkspaceFile,
+  projectPath,
+  tokenLabel,
+}: ProjectPreviewOverlayProps) {
+  return (
+    <>
+      <div className="overlay" data-preview-overlay role="dialog" aria-modal="true" aria-label="Preview">
+        <div className="preview-frame">
+          <div className="preview-topbar">
+            <div className="preview-topbar__nav">
+              <button type="button" className="preview-topbar__btn" aria-label="Back"><ChevronLeft size={13} /></button>
+              <button type="button" className="preview-topbar__btn" aria-label="Refresh" onClick={() => showTransientFeedback('Preview refreshed')}><RefreshCcw size={13} /></button>
+            </div>
+            <div className="preview-url">
+              <span className="preview-url__protocol">https://</span>
+              <span className="preview-url__target">{previewTarget}</span>
+              <span className="preview-url__meta">project</span>
+            </div>
+            <div className="preview-device" role="tablist" aria-label="Preview size">
+              {(['1200', '768', '390'] as const).map((device) => (
+                <button key={device} type="button" aria-pressed={previewDevice === device} onClick={() => setPreviewDevice(device)}>{device}</button>
+              ))}
+            </div>
+            <button type="button" className="preview-topbar__btn" aria-label="Copy preview URL" onClick={() => handleCopy(`https://${previewTarget}`, 'Preview URL')}><ExternalLink size={13} /></button>
+            <button type="button" className="preview-topbar__btn" data-preview-dock aria-label="Dock preview" onClick={() => setPreviewState('dock')}><PanelsTopLeft size={13} /></button>
+            <button type="button" className="preview-topbar__btn" aria-label="Close preview" onClick={() => setPreviewState('closed')}><X size={13} /></button>
+          </div>
+          <div className="preview-canvas" data-preview-size={previewDevice}>
+            <div className="preview-page">
+              <aside className="preview-page__sb">
+                <div className="preview-page__sb-logo">ARIS</div>
+                <div className="preview-page__sb-item preview-page__sb-item--active">{displayProjectName(session)}</div>
+                <div className="preview-page__sb-item">{activeChat?.title ?? 'Project chat'}</div>
+                <div className="preview-page__sb-item">{selectedWorkspaceFile}</div>
+              </aside>
+              <main className="preview-page__main">
+                <h2 className="preview-page__h">{activeChat?.title ?? 'Project chat'}</h2>
+                <p className="preview-page__sub">{agentLabel(activeAgent, activeModelLabel)} · {COMPOSER_MODE_COPY[composerMode]} · {tokenLabel}</p>
+                <div className="preview-page__cards">
+                  <div className="preview-page__card">
+                    <div className="preview-page__card-t">Workspace</div>
+                    <div className="preview-page__card-m">{workspaceTab} · {selectedWorkspaceFile}</div>
+                    <div className="preview-page__bar"><div className="preview-page__bar-fill" style={{ width: '74%' } as CSSProperties} /></div>
+                  </div>
+                  <div className="preview-page__card">
+                    <div className="preview-page__card-t">Context</div>
+                    <div className="preview-page__card-m">{projectPath}</div>
+                    <div className="preview-page__bar"><div className="preview-page__bar-fill" style={{ width: '42%' } as CSSProperties} /></div>
+                  </div>
+                </div>
+              </main>
+            </div>
+            <div className="preview-controls">
+              <button type="button" aria-label="Zoom out" onClick={() => showTransientFeedback('Preview zoom 90%')}><ChevronLeft size={12} /></button>
+              <span className="preview-controls__zoom">100%</span>
+              <button type="button" aria-label="Zoom in" onClick={() => showTransientFeedback('Preview zoom 110%')}><ChevronRight size={12} /></button>
+              <span className="preview-controls__sep" />
+              <button type="button" aria-label="Screenshot" onClick={() => showTransientFeedback('Screenshot staged')}><Copy size={12} /></button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="preview-dock-wrap" data-preview-dock>
+        <div className="preview-dock">
+          <span className="preview-dock__thumb" />
+          <span className="preview-dock__name">{selectedWorkspaceFile}</span>
+          <span className="preview-dock__meta">{previewDevice}</span>
+          <button type="button" className="preview-dock__btn preview-dock__btn--live" data-preview-open aria-label="Expand preview" onClick={() => setPreviewState('open')}>
+            <Maximize2 size={12} />
+          </button>
+          <button type="button" className="preview-dock__btn" aria-label="Close preview dock" onClick={() => setPreviewState('closed')}>
+            <X size={12} />
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/services/aris-web/components/project-chat/workspace/WorkspaceSidebar.tsx
+++ b/services/aris-web/components/project-chat/workspace/WorkspaceSidebar.tsx
@@ -1,0 +1,626 @@
+'use client';
+
+import type { Dispatch, RefObject, SetStateAction } from 'react';
+import {
+  Bot,
+  ChevronRight,
+  Clock,
+  Copy,
+  File as FileIcon,
+  FileText,
+  FolderOpen,
+  Maximize2,
+  MessageSquareText,
+  PanelRight,
+  PanelsTopLeft,
+  RefreshCcw,
+  Square,
+  Terminal,
+  X,
+} from 'lucide-react';
+import { ProviderLogo } from '@/components/ui/ProviderLogo';
+import { SubagentPanel } from '@/components/project-chat/SubagentPanel';
+import { MarkdownContent } from '@/components/chat/MarkdownContent';
+import { GitActionMark } from '@/components/project-chat/helpers/actionMarks';
+import type { SessionChat, SessionSummary } from '@/lib/happy/types';
+import type { WorkspaceFileItem, WorkspaceFilesApi } from '@/lib/hooks/useWorkspaceFiles';
+import {
+  COMPOSER_MODE_COPY,
+  agentAvatarClass,
+  agentLabel,
+  formatRelativeTime,
+  projectStatusLabel,
+  providerFromAgent,
+  type ComposerMode,
+  type ExpandedTurnState,
+  type ModelProvider,
+  type PreviewState,
+  type ProjectPanelGitOverview,
+  type ProjectWorkspacePanelRuntime,
+  type WorkspaceTab,
+} from '../projectChatSurfaceUtils';
+
+export type WorkspaceContextItem = { id: string; name: string; tokens: string };
+export type WorkspaceRunStepItem = { id: string; title: string; cmd: string; time: string };
+export type WorkspaceHistoryTurnItem = {
+  id: string;
+  timestamp: string;
+  state: string;
+  text: string;
+  agentText: string;
+};
+export type WorkspaceTerminalSnippet = { id: string; name: string; cmd: string; tag: string };
+
+type WorkspaceSidebarCommonProps = {
+  workspaceRef: RefObject<HTMLElement | null>;
+  projectName: string;
+  workspaceTab: WorkspaceTab;
+  activateWorkspaceTab: (tab: WorkspaceTab) => void;
+  closeWorkspacePanel: () => void;
+  workspaceFiles: WorkspaceFilesApi;
+  selectedWorkspaceFile: string;
+  openWorkspaceFilePreview: (file: WorkspaceFileItem) => void;
+  workspaceGitOverview: ProjectPanelGitOverview | null;
+  workspaceGitLoading: boolean;
+  workspaceGitError: string | null;
+  refreshWorkspaceGit: () => void;
+  activeWorkspacePanelRuntime: ProjectWorkspacePanelRuntime | null;
+  draftTerminalCommand: string;
+  contextItems: WorkspaceContextItem[];
+  handleCopy: (value: string, label: string) => void;
+  session: SessionSummary;
+  activeChat: SessionChat | null;
+  projectPath: string;
+};
+
+type PanelWorkspaceSidebarProps = WorkspaceSidebarCommonProps & {
+  variant: 'panel';
+  activeWorkspaceChat: SessionChat | null;
+  activeWorkspacePanelId: string | null;
+  projectId: string;
+};
+
+type ProjectWorkspaceSidebarProps = WorkspaceSidebarCommonProps & {
+  variant: 'project';
+  setPreviewState: (state: PreviewState) => void;
+  selectedProvider: ModelProvider;
+  activeModelLabel: string;
+  tokenLabel: string;
+  projectRunActive: boolean;
+  handleStopActiveChat: () => Promise<void>;
+  visibleEventsCount: number;
+  selectedChatTimestamp: string;
+  runStepItems: WorkspaceRunStepItem[];
+  historyTurnItems: WorkspaceHistoryTurnItem[];
+  visibleExpandedTurnId: string | null;
+  setExpandedTurnId: (value: ExpandedTurnState) => void;
+  handleJumpToTurn: (turnId: string) => void;
+  activeAgent: SessionSummary['agent'];
+  composerMode: ComposerMode;
+  terminalSnippets: WorkspaceTerminalSnippet[];
+  setDraftTerminalCommand: (value: string) => void;
+  setPrompt: Dispatch<SetStateAction<string>>;
+  fileCount: number;
+};
+
+export type WorkspaceSidebarProps = PanelWorkspaceSidebarProps | ProjectWorkspaceSidebarProps;
+
+function WorkspaceTabsRow({
+  workspaceTab,
+  activateWorkspaceTab,
+}: Pick<WorkspaceSidebarCommonProps, 'workspaceTab' | 'activateWorkspaceTab'>) {
+  return (
+    <div className="ws__tabs" role="tablist">
+      <button type="button" className="ws__tab" data-tab="run" aria-pressed={workspaceTab === 'run'} onClick={() => activateWorkspaceTab('run')}><Clock size={12} />Run</button>
+      <button type="button" className="ws__tab" data-tab="files" aria-pressed={workspaceTab === 'files'} onClick={() => activateWorkspaceTab('files')}><FileIcon size={12} />Files</button>
+      <button type="button" className="ws__tab" data-tab="git" aria-pressed={workspaceTab === 'git'} onClick={() => activateWorkspaceTab('git')}><GitActionMark size={12} />Git</button>
+      <button type="button" className="ws__tab" data-tab="terminal" aria-pressed={workspaceTab === 'terminal'} onClick={() => activateWorkspaceTab('terminal')}><Terminal size={12} />Terminal</button>
+      <button type="button" className="ws__tab" data-tab="context" aria-pressed={workspaceTab === 'context'} onClick={() => activateWorkspaceTab('context')}><PanelsTopLeft size={12} />Context</button>
+      <button type="button" className="ws__tab" data-tab="subagents" aria-pressed={workspaceTab === 'subagents'} onClick={() => activateWorkspaceTab('subagents')}><Bot size={12} />Subagents</button>
+    </div>
+  );
+}
+
+function WorkspaceFilesPane({
+  workspaceTab,
+  workspaceFiles,
+  selectedWorkspaceFile,
+  openWorkspaceFilePreview,
+}: Pick<
+  WorkspaceSidebarCommonProps,
+  'workspaceTab' | 'workspaceFiles' | 'selectedWorkspaceFile' | 'openWorkspaceFilePreview'
+>) {
+  return (
+    <div className={`ws__pane${workspaceTab === 'files' ? ' ws__pane--active' : ''}`} data-pane="files">
+      <div className="file-tree__head">
+        <span className="file-tree__cwd" title={workspaceFiles.currentPath}>{workspaceFiles.currentPath}</span>
+        <button
+          type="button"
+          className="file-tree__refresh"
+          aria-label="Refresh files"
+          onClick={() => workspaceFiles.refresh()}
+          disabled={workspaceFiles.loading}
+        >
+          <RefreshCcw size={11} />
+        </button>
+      </div>
+      <div className="file-tree">
+        {workspaceFiles.parentPath && (
+          <button
+            type="button"
+            className="file-row file-row--parent"
+            onClick={() => workspaceFiles.goUp()}
+          >
+            <span className="file-row__icon file-row__icon--dir">
+              <FolderOpen size={13} />
+            </span>
+            <span className="file-row__name">..</span>
+            <span className="file-row__meta">parent</span>
+          </button>
+        )}
+        {workspaceFiles.loading && workspaceFiles.items.length === 0 && (
+          <div className="file-row file-row--state">Loading…</div>
+        )}
+        {workspaceFiles.error && (
+          <div className="file-row file-row--state file-row--error">{workspaceFiles.error}</div>
+        )}
+        {!workspaceFiles.loading && !workspaceFiles.error && workspaceFiles.items.length === 0 && (
+          <div className="file-row file-row--state">빈 디렉터리</div>
+        )}
+        {workspaceFiles.items.map((file: WorkspaceFileItem) => (
+          <button
+            key={file.path}
+            type="button"
+            className={`file-row${selectedWorkspaceFile === file.path ? ' file-row--selected' : ''}`}
+            onClick={() => {
+              if (file.isDirectory) {
+                workspaceFiles.cdInto(file);
+              } else {
+                openWorkspaceFilePreview(file);
+              }
+            }}
+          >
+            <span className={`file-row__icon${file.isDirectory ? ' file-row__icon--dir' : ''}`}>
+              {file.isDirectory ? <FolderOpen size={13} /> : <FileText size={13} />}
+            </span>
+            <span className="file-row__name">{file.name}</span>
+            <span className="file-row__meta">{file.isDirectory ? 'dir' : 'file'}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceGitPane({
+  workspaceTab,
+  workspaceGitOverview,
+  workspaceGitLoading,
+  workspaceGitError,
+  refreshWorkspaceGit,
+  activeWorkspacePanelRuntime,
+  cwdFallback,
+  branchFallback,
+}: Pick<
+  WorkspaceSidebarCommonProps,
+  | 'workspaceTab'
+  | 'workspaceGitOverview'
+  | 'workspaceGitLoading'
+  | 'workspaceGitError'
+  | 'refreshWorkspaceGit'
+  | 'activeWorkspacePanelRuntime'
+> & { cwdFallback: string; branchFallback: string }) {
+  return (
+    <div className={`ws__pane${workspaceTab === 'git' ? ' ws__pane--active' : ''}`} data-pane="git">
+      <div className="file-tree__head">
+        <span className="file-tree__cwd" title={workspaceGitOverview?.workspacePath ?? activeWorkspacePanelRuntime?.worktreePath ?? cwdFallback}>
+          {workspaceGitOverview?.branch ?? activeWorkspacePanelRuntime?.branch ?? branchFallback}
+        </span>
+        <button
+          type="button"
+          className="file-tree__refresh"
+          aria-label="Refresh Git"
+          onClick={refreshWorkspaceGit}
+          disabled={workspaceGitLoading}
+        >
+          <RefreshCcw size={11} />
+        </button>
+      </div>
+      <div className="pc-panel-git-summary">
+        <span data-tone={workspaceGitOverview?.isClean ? 'ready' : 'pending'}>{workspaceGitOverview?.isClean ? 'clean' : 'dirty'}</span>
+        <span>staged {workspaceGitOverview?.stagedCount ?? 0}</span>
+        <span>changed {workspaceGitOverview?.unstagedCount ?? 0}</span>
+        <span>untracked {workspaceGitOverview?.untrackedCount ?? 0}</span>
+        <span>ahead {workspaceGitOverview?.ahead ?? 0} / behind {workspaceGitOverview?.behind ?? 0}</span>
+      </div>
+      <div className="file-tree">
+        {workspaceGitLoading && <div className="file-row file-row--state">Loading Git status…</div>}
+        {workspaceGitError && <div className="file-row file-row--state file-row--error">{workspaceGitError}</div>}
+        {!workspaceGitLoading && !workspaceGitError && workspaceGitOverview?.files.length === 0 && (
+          <div className="file-row file-row--state">변경된 파일이 없습니다.</div>
+        )}
+        {workspaceGitOverview?.files.slice(0, 60).map((file) => (
+          <div key={`${file.path}:${file.indexStatus}:${file.workTreeStatus}`} className="pc-panel-git-file">
+            <span>{file.indexStatus}{file.workTreeStatus}</span>
+            <strong title={file.path}>{file.path}</strong>
+            <em>{file.conflicted ? 'conflict' : file.untracked ? 'new' : file.staged ? 'staged' : 'modified'}</em>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceSubagentsPane({
+  workspaceTab,
+  session,
+  activeChat,
+}: Pick<WorkspaceSidebarCommonProps, 'workspaceTab' | 'session' | 'activeChat'>) {
+  return (
+    <div className={`ws__pane${workspaceTab === 'subagents' ? ' ws__pane--active' : ''}`} data-pane="subagents">
+      <SubagentPanel sessionId={session.id} chatId={activeChat?.id ?? null} active={workspaceTab === 'subagents'} />
+    </div>
+  );
+}
+
+function PanelWorkspaceSidebar({
+  workspaceRef,
+  projectName,
+  workspaceTab,
+  activateWorkspaceTab,
+  closeWorkspacePanel,
+  workspaceFiles,
+  selectedWorkspaceFile,
+  openWorkspaceFilePreview,
+  workspaceGitOverview,
+  workspaceGitLoading,
+  workspaceGitError,
+  refreshWorkspaceGit,
+  activeWorkspacePanelRuntime,
+  draftTerminalCommand,
+  contextItems,
+  handleCopy,
+  session,
+  activeChat,
+  projectPath,
+  activeWorkspaceChat,
+  activeWorkspacePanelId,
+  projectId,
+}: PanelWorkspaceSidebarProps) {
+  return (
+    <aside ref={workspaceRef} className="shell__workspace ws ws-pane pc-parallel-workspace" aria-label={`${projectName} workspace`}>
+      <div className="ws__head ws-pane__header">
+        <div className="ws__title ws-pane__title"><PanelRight size={14} />Workspace</div>
+        <div className="ws__actions ws-pane__actions">
+          <button type="button" className="ws__action ws-pane__action btn btn--ghost btn--icon btn--sm" aria-label="Open files" onClick={() => activateWorkspaceTab('files')}>
+            <FileText size={13} />
+          </button>
+          <button type="button" className="ws__action ws-pane__action btn btn--ghost btn--icon btn--sm" aria-label="Close workspace" onClick={closeWorkspacePanel}>
+            <X size={13} />
+          </button>
+        </div>
+      </div>
+      <WorkspaceTabsRow workspaceTab={workspaceTab} activateWorkspaceTab={activateWorkspaceTab} />
+      <div className="ws__status">
+        <div className="ws__status-left">
+          <span className={`ws__model ws__model--${providerFromAgent(activeWorkspaceChat?.agent ?? session.agent)}`}>
+            <span className="ws__model-dot" />{activeWorkspaceChat?.title ?? 'Panel'}
+          </span>
+          <span className="ws__pill"><span className="ws__pill-dot" />{activeWorkspacePanelRuntime?.branch ?? 'project'}</span>
+        </div>
+        <div className="ws__status-right">
+          <span>{activeWorkspacePanelId ? `#${activeWorkspacePanelId.slice(-4)}` : 'no panel'}</span>
+        </div>
+      </div>
+      <div className="ws__body">
+        <div className={`ws__pane${workspaceTab === 'run' ? ' ws__pane--active' : ''}`} data-pane="run">
+          <div className="run-summary">
+            <div className="run-summary__cell"><span className="run-summary__label">Panel</span><span className="run-summary__value">{activeWorkspacePanelId ? activeWorkspacePanelId.slice(-4) : '-'}</span></div>
+            <div className="run-summary__cell"><span className="run-summary__label">Branch</span><span className="run-summary__value">{activeWorkspacePanelRuntime?.branch ?? '-'}</span></div>
+            <div className="run-summary__cell"><span className="run-summary__label">Runtime</span><span className="run-summary__value">{activeWorkspacePanelRuntime?.runtimeSessionId ? 'ready' : 'project'}</span></div>
+          </div>
+          <div className="ws-card ws-card--run">
+            <div className="ws-card__head">
+              <div className="ws-card__title">{activeWorkspaceChat?.title ?? '선택된 패널이 없습니다.'}</div>
+              <div className="ws-card__meta">{activeWorkspacePanelRuntime?.worktreePath ?? projectPath}</div>
+            </div>
+            <div className="ws-empty-state">선택된 패널의 worktree 기준 상태입니다.</div>
+          </div>
+        </div>
+        <WorkspaceFilesPane
+          workspaceTab={workspaceTab}
+          workspaceFiles={workspaceFiles}
+          selectedWorkspaceFile={selectedWorkspaceFile}
+          openWorkspaceFilePreview={openWorkspaceFilePreview}
+        />
+        <WorkspaceGitPane
+          workspaceTab={workspaceTab}
+          workspaceGitOverview={workspaceGitOverview}
+          workspaceGitLoading={workspaceGitLoading}
+          workspaceGitError={workspaceGitError}
+          refreshWorkspaceGit={refreshWorkspaceGit}
+          activeWorkspacePanelRuntime={activeWorkspacePanelRuntime}
+          cwdFallback=""
+          branchFallback="branch pending"
+        />
+        <div className={`ws__pane${workspaceTab === 'terminal' ? ' ws__pane--active' : ''}`} data-pane="terminal">
+          <div className="term">
+            <div className="term__head"><span className="term__tag">bash · selected panel</span><span className="term__dim">{activeWorkspacePanelRuntime?.runtimeSessionId ?? projectId}</span></div>
+            <div className="term__body">
+              <div className="term__line"><span className="term__prompt">~/aris$</span><span>{draftTerminalCommand}</span></div>
+              <div className="term__line"><span className="term__dim">cwd · {activeWorkspacePanelRuntime?.worktreePath ?? projectPath}</span></div>
+            </div>
+          </div>
+        </div>
+        <div className={`ws__pane${workspaceTab === 'context' ? ' ws__pane--active' : ''}`} data-pane="context">
+          <div className="ctx-group">
+            <div className="ctx-group__head"><span className="ctx-group__title">Panel context</span><span className="ctx-group__count">{contextItems.length}</span></div>
+            {contextItems.map((item) => (
+              <button key={item.id} type="button" className="ctx-item" onClick={() => handleCopy(item.name, 'Context item')}>
+                <FileText size={13} className="ctx-item__icon" />
+                <span className="ctx-item__name">{item.name}</span>
+                <span className="ctx-item__tokens">{item.tokens}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+        <WorkspaceSubagentsPane workspaceTab={workspaceTab} session={session} activeChat={activeChat} />
+      </div>
+    </aside>
+  );
+}
+
+function ProjectWorkspaceSidebar({
+  workspaceRef,
+  projectName,
+  workspaceTab,
+  activateWorkspaceTab,
+  closeWorkspacePanel,
+  workspaceFiles,
+  selectedWorkspaceFile,
+  openWorkspaceFilePreview,
+  workspaceGitOverview,
+  workspaceGitLoading,
+  workspaceGitError,
+  refreshWorkspaceGit,
+  activeWorkspacePanelRuntime,
+  draftTerminalCommand,
+  contextItems,
+  handleCopy,
+  session,
+  activeChat,
+  projectPath,
+  setPreviewState,
+  selectedProvider,
+  activeModelLabel,
+  tokenLabel,
+  projectRunActive,
+  handleStopActiveChat,
+  visibleEventsCount,
+  selectedChatTimestamp,
+  runStepItems,
+  historyTurnItems,
+  visibleExpandedTurnId,
+  setExpandedTurnId,
+  handleJumpToTurn,
+  activeAgent,
+  composerMode,
+  terminalSnippets,
+  setDraftTerminalCommand,
+  setPrompt,
+  fileCount,
+}: ProjectWorkspaceSidebarProps) {
+  return (
+    <aside ref={workspaceRef} className="shell__workspace ws ws-pane" aria-label={`${projectName} workspace`}>
+      <div className="ws__head ws-pane__header">
+        <div className="ws__title ws-pane__title"><PanelRight size={14} />Workspace</div>
+        <div className="ws__actions ws-pane__actions">
+          <button type="button" className="ws__action ws-pane__action btn btn--ghost btn--icon btn--sm" aria-label="Open preview" onClick={() => setPreviewState('open')}>
+            <Maximize2 size={13} />
+          </button>
+          <button type="button" className="ws__action ws-pane__action btn btn--ghost btn--icon btn--sm" aria-label="Open files" onClick={() => activateWorkspaceTab('files')}>
+            <FileText size={13} />
+          </button>
+          <button type="button" className="ws__action ws-pane__action btn btn--ghost btn--icon btn--sm" aria-label="Close workspace" onClick={closeWorkspacePanel}>
+            <X size={13} />
+          </button>
+        </div>
+      </div>
+      <WorkspaceTabsRow workspaceTab={workspaceTab} activateWorkspaceTab={activateWorkspaceTab} />
+      <div className="ws__status">
+        <div className="ws__status-left">
+          <span className={`ws__model ws__model--${selectedProvider}`}><span className="ws__model-dot" />{activeModelLabel}</span>
+          <span className="ws__pill"><span className="ws__pill-dot" />{projectStatusLabel(session.status)}</span>
+        </div>
+        <div className="ws__status-right">
+          <span>{tokenLabel}</span>
+          <button
+            type="button"
+            className="ws__stop"
+            aria-label="Stop"
+            disabled={!projectRunActive}
+            onClick={() => { void handleStopActiveChat(); }}
+          >
+            <Square size={10} />
+          </button>
+        </div>
+      </div>
+      <div className="ws__body">
+        <div className={`ws__pane${workspaceTab === 'run' ? ' ws__pane--active' : ''}`} data-pane="run">
+          <div className="run-summary">
+            <div className="run-summary__cell"><span className="run-summary__label">Steps</span><span className="run-summary__value">{visibleEventsCount}</span></div>
+            <div className="run-summary__cell"><span className="run-summary__label">Tokens</span><span className="run-summary__value">{tokenLabel}</span></div>
+            <div className="run-summary__cell"><span className="run-summary__label">Activity</span><span className="run-summary__value">{formatRelativeTime(selectedChatTimestamp)}</span></div>
+          </div>
+          <div className="ws-card ws-card--run">
+            <div className="ws-card__head">
+              <div className="ws-card__title">Run · {activeChat?.id ? `#${activeChat.id.slice(-4)}` : '#0142'}</div>
+              <div className="ws-card__meta">{formatRelativeTime(selectedChatTimestamp)} · {tokenLabel} tokens</div>
+            </div>
+            <div className="run-steps">
+              {runStepItems.length > 0 ? (
+                runStepItems.map((item) => (
+                  <button key={item.id} type="button" className="run-step ws-run-step" onClick={() => handleCopy(item.cmd, 'Run step')}>
+                    <span className="run-step__dot ws-run-step__dot run-step__dot--done ws-run-step__dot--done" />
+                    <div className="run-step__body ws-run-step__body">
+                      <div className="run-step__title ws-run-step__title">{item.title}</div>
+                      <div className="run-step__cmd ws-run-step__time">{item.cmd}</div>
+                    </div>
+                    <span className="run-step__time ws-run-step__time">{item.time}</span>
+                  </button>
+                ))
+              ) : (
+                <div className="ws-empty-state">실행 기록이 없습니다.</div>
+              )}
+            </div>
+          </div>
+          <div className="chist ws-card ws-card--history">
+            <div className="chist__head">
+              <span className="chist__title"><MessageSquareText size={12} />Chat history</span>
+              <span className="chist__meta">{historyTurnItems.length} turns</span>
+            </div>
+            <div className="chist__list">
+              {historyTurnItems.length > 0 ? (
+                historyTurnItems.map((item) => (
+                  <div key={item.id} className="chturn" data-open={visibleExpandedTurnId === item.id ? 'true' : 'false'}>
+                    <button
+                      type="button"
+                      className="chturn__preview"
+                      data-turn-toggle
+                      onClick={() => setExpandedTurnId(visibleExpandedTurnId === item.id ? '__none__' : item.id)}
+                    >
+                      <span className="chturn__avatar">U</span>
+                      <span className="chturn__body">
+                        <span className="chturn__meta">
+                          <span className="chturn__name">You</span>
+                          <span className="chturn__time">{formatRelativeTime(item.timestamp)}</span>
+                          <span className={`chturn__pill ${item.state === 'running' ? 'chturn__pill--run' : 'chturn__pill--ok'}`}>
+                            <span className="chturn__pill-dot" />{item.state}
+                          </span>
+                        </span>
+                        <span className="chturn__text">{item.text}</span>
+                      </span>
+                      <ChevronRight size={12} className="chturn__caret" />
+                    </button>
+                    <div className="chturn__expanded">
+                      <div className="chturn__agent-head">
+                        <span className={`chturn__agent-avatar ${agentAvatarClass(activeAgent)}`}>
+                          <ProviderLogo provider={selectedProvider} />
+                        </span>
+                        <span className="chturn__agent-label"><strong>{agentLabel(activeAgent, activeModelLabel)}</strong></span>
+                        <span className="chturn__agent-final">{item.state === 'running' ? 'In progress' : 'Final'}</span>
+                      </div>
+                      <div className="chturn__agent-text"><MarkdownContent body={item.agentText} /></div>
+                      <div className="chturn__actions">
+                        <button type="button" className="chturn__btn" onClick={() => handleJumpToTurn(item.id)}><ChevronRight size={11} />Jump</button>
+                        <button type="button" className="chturn__btn" data-preview-open onClick={() => setPreviewState('open')}><FileText size={11} />Preview</button>
+                        <button type="button" className="chturn__btn" onClick={() => handleCopy(`${item.text}\n\n${item.agentText}`, 'Turn summary')}><Copy size={11} />Copy</button>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <div className="ws-empty-state">대화 기록이 없습니다.</div>
+              )}
+            </div>
+          </div>
+        </div>
+        <WorkspaceFilesPane
+          workspaceTab={workspaceTab}
+          workspaceFiles={workspaceFiles}
+          selectedWorkspaceFile={selectedWorkspaceFile}
+          openWorkspaceFilePreview={openWorkspaceFilePreview}
+        />
+        <WorkspaceGitPane
+          workspaceTab={workspaceTab}
+          workspaceGitOverview={workspaceGitOverview}
+          workspaceGitLoading={workspaceGitLoading}
+          workspaceGitError={workspaceGitError}
+          refreshWorkspaceGit={refreshWorkspaceGit}
+          activeWorkspacePanelRuntime={activeWorkspacePanelRuntime}
+          cwdFallback={projectPath}
+          branchFallback="project branch"
+        />
+        <div className={`ws__pane${workspaceTab === 'terminal' ? ' ws__pane--active' : ''}`} data-pane="terminal">
+          <div className="term">
+            <div className="term__head">
+              <div className="term__head-left">
+                <span className="term__dots"><span className="term__dot term__dot--r" /><span className="term__dot term__dot--y" /><span className="term__dot term__dot--g" /></span>
+                <span className="term__tag">bash · project chat</span>
+              </div>
+              <span className="term__dim">{composerMode}</span>
+            </div>
+            <div className="term__body">
+              <div className="term__line"><span className="term__prompt">~/aris$</span><span>{draftTerminalCommand}</span></div>
+              <div className="term__line"><span className="term__dim">selected · {selectedWorkspaceFile}</span></div>
+              <div className="term__line"><span className="term__ok">✓</span><span>ready to run in this project context</span></div>
+            </div>
+          </div>
+          <div className="snip-group">
+            <div className="snip-group__head">
+              <span className="snip-group__label"><Terminal size={12} />Snippets</span>
+              <span className="snip-group__count">{terminalSnippets.length}</span>
+            </div>
+            {terminalSnippets.map((snippet) => (
+              <button
+                key={snippet.id}
+                type="button"
+                className="snip-row"
+                onClick={() => {
+                  setDraftTerminalCommand(snippet.cmd);
+                  setPrompt((value) => value || snippet.cmd);
+                }}
+              >
+                <span className="snip-row__name">{snippet.name}</span>
+                <span className="snip-row__cmd">{snippet.cmd}</span>
+                <span className="snip-row__tag">{snippet.tag}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className={`ws__pane${workspaceTab === 'context' ? ' ws__pane--active' : ''}`} data-pane="context">
+          <div className="ctx-summary">
+            <div className="ctx-ring" aria-label={`${tokenLabel} context usage`}>
+              <svg viewBox="0 0 80 80" width="80" height="80" aria-hidden="true">
+                <circle className="ctx-ring__track" cx="40" cy="40" r="34" strokeWidth="6" fill="none" />
+                <circle className="ctx-ring__fill" cx="40" cy="40" r="34" strokeWidth="6" fill="none" strokeDasharray="214" strokeDashoffset="194" strokeLinecap="round" />
+              </svg>
+              <div className="ctx-ring__center">9.2%</div>
+            </div>
+            <div className="ctx-summary__body">
+              <div className="ctx-summary__title">Context usage</div>
+              <div className="ctx-summary__meta">{tokenLabel} / 200k tokens</div>
+              <div className="ctx-summary__split">
+                <div className="ctx-summary__split-cell"><div className="ctx-summary__split-label">Model</div><div className="ctx-summary__split-value">{activeModelLabel}</div></div>
+                <div className="ctx-summary__split-cell"><div className="ctx-summary__split-label">Mode</div><div className="ctx-summary__split-value">{COMPOSER_MODE_COPY[composerMode]}</div></div>
+              </div>
+            </div>
+          </div>
+          <div className="ctx-group">
+            <div className="ctx-group__head"><span className="ctx-group__title">Attached context</span><span className="ctx-group__count">{contextItems.length}</span></div>
+            {contextItems.map((item) => (
+              <button key={item.id} type="button" className="ctx-item" onClick={() => handleCopy(item.name, 'Context item')}>
+                <FileText size={13} className="ctx-item__icon" />
+                <span className="ctx-item__name">{item.name}</span>
+                <span className="ctx-item__tokens">{item.tokens}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+        <WorkspaceSubagentsPane workspaceTab={workspaceTab} session={session} activeChat={activeChat} />
+      </div>
+      <div className="ws__footer">
+        <div className="ws__footer-row"><span className="ws__footer-label">Context usage</span><span className="ws__footer-value">{tokenLabel} / 200k</span></div>
+        <div className="ws__footer-bar"><div className="ws__footer-fill" style={{ width: '9.2%' }} /></div>
+        <div className="ws__footer-meta"><span>project scoped</span><span>{fileCount} files</span></div>
+      </div>
+    </aside>
+  );
+}
+
+export function WorkspaceSidebar(props: WorkspaceSidebarProps) {
+  if (props.variant === 'panel') {
+    return <PanelWorkspaceSidebar {...props} />;
+  }
+  return <ProjectWorkspaceSidebar {...props} />;
+}

--- a/services/aris-web/tests/parallelChatDragSurface.test.ts
+++ b/services/aris-web/tests/parallelChatDragSurface.test.ts
@@ -6,7 +6,11 @@ import { readAppStyles } from './helpers/readAppStyles';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const homeClient = readFileSync(resolve(__dirname, '../app/HomePageClient.tsx'), 'utf8');
-const projectChatSurface = readFileSync(resolve(__dirname, '../components/project-chat/ProjectChatSurface.tsx'), 'utf8');
+const projectChatSurfaceModule = readFileSync(resolve(__dirname, '../components/project-chat/ProjectChatSurface.tsx'), 'utf8');
+const workspaceSidebarSource = readFileSync(resolve(__dirname, '../components/project-chat/workspace/WorkspaceSidebar.tsx'), 'utf8');
+const previewOverlaySource = readFileSync(resolve(__dirname, '../components/project-chat/workspace/PreviewOverlay.tsx'), 'utf8');
+// 사이드바·프리뷰 마크업은 workspace/로 추출됨 — 화면 단위 정적 단언은 세 파일을 하나의 소스로 본다.
+const projectChatSurface = [projectChatSurfaceModule, workspaceSidebarSource, previewOverlaySource].join('\n');
 const projectChatSurfaceUtils = readFileSync(resolve(__dirname, '../components/project-chat/projectChatSurfaceUtils.ts'), 'utf8');
 const uiCss = readAppStyles();
 

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -6,7 +6,11 @@ import { readAppStyles } from './helpers/readAppStyles';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const homeClient = readFileSync(resolve(__dirname, '../app/HomePageClient.tsx'), 'utf8');
-const projectChatSurface = readFileSync(resolve(__dirname, '../components/project-chat/ProjectChatSurface.tsx'), 'utf8');
+const projectChatSurfaceModule = readFileSync(resolve(__dirname, '../components/project-chat/ProjectChatSurface.tsx'), 'utf8');
+const workspaceSidebarSource = readFileSync(resolve(__dirname, '../components/project-chat/workspace/WorkspaceSidebar.tsx'), 'utf8');
+const previewOverlaySource = readFileSync(resolve(__dirname, '../components/project-chat/workspace/PreviewOverlay.tsx'), 'utf8');
+// 사이드바·프리뷰 마크업은 workspace/로 추출됨 — 화면 단위 정적 단언은 세 파일을 하나의 소스로 본다.
+const projectChatSurface = [projectChatSurfaceModule, workspaceSidebarSource, previewOverlaySource].join('\n');
 const projectChatSurfaceUtils = readFileSync(resolve(__dirname, '../components/project-chat/projectChatSurfaceUtils.ts'), 'utf8');
 const projectActionCard = readFileSync(resolve(__dirname, '../components/project-chat/ProjectActionCard.tsx'), 'utf8');
 const projectRunStatusChip = readFileSync(resolve(__dirname, '../components/project-chat/ProjectRunStatusChip.tsx'), 'utf8');


### PR DESCRIPTION
## 배경

사이드바 실동작 전환 설계(#402)의 **PR-0**. `ProjectChatSurface.tsx`(3,829줄, AGENTS.md 800줄 기준 초과)에 일반/병렬 모드 aside가 통째로 중복돼 있어, 이후 6개 PR이 전부 이 영역을 건드리기 전에 충돌 표면을 줄인다.

## 변경 — 기능 변화 없음

- `components/project-chat/workspace/WorkspaceSidebar.tsx` 신설: 일반(`variant="project"`)/병렬(`variant="panel"`) 사이드바를 하나의 모듈로. 두 변형에서 동일했던 탭 행·Files 패널·Git 패널·Subagents 패널은 내부 공유 컴포넌트로 통합, 나머지(상태 스트립·Run·Terminal·Context·푸터)는 변형별 렌더 유지.
- `components/project-chat/workspace/PreviewOverlay.tsx` 신설: Preview 오버레이 + 독 칩 이동.
- `ProjectChatSurface.tsx` 3,829 → 3,404줄. 미사용 임포트 8건 정리.
- 마크업·클래스·핸들러 로직은 바이트 단위 보존 (유일한 표현 변화: `visibleEvents.length`를 `visibleEventsCount` prop으로 전달 — 렌더 결과 동일).

## 테스트

`projectListSurface.test.ts`·`parallelChatDragSurface.test.ts`의 정적 단언이 마크업 이동으로 실패(10건) → 검사 소스를 세 파일 결합(`ProjectChatSurface + WorkspaceSidebar + PreviewOverlay`)으로 확장. 단언 자체는 그대로 두어 "채팅 화면이 이 마크업을 렌더한다"는 의도를 유지. 부정 단언(`not.toContain`) 전수 확인 — 결합으로 오염되는 항목 없음.

## 검증

- `tsc --noEmit` 클린
- vitest 125 파일 / **628 테스트** 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxfd4yi1xRpXZHvjuggvTW
