### PR TITLE
fix(web): 사이드바 가짜 지표 전면 제거 + Git 탭 프로젝트 루트 실동작 (PR-1)

### DIFF
--- a/services/aris-web/app/HomePageClient.tsx
+++ b/services/aris-web/app/HomePageClient.tsx
@@ -370,15 +370,6 @@ function projectStatusBadgeClass(status: SessionStatus): string {
   return 'badge--neutral';
 }
 
-function deriveProjectFileCount(session: SessionSummary, index: number): number {
-  return Math.max(18, (session.totalChats ?? 0) * 7 + index * 11 + 24);
-}
-
-function deriveProjectTokenLabel(session: SessionSummary, index: number): string {
-  const total = Math.max(9.1, (session.totalChats ?? 0) * 11.8 + index * 7.4);
-  return `${total.toFixed(1)}k`;
-}
-
 function buildProjectDetailPath(sessionId: string, view: ProjectView = 'chats', chatId?: string | null): string {
   const params = new URLSearchParams();
   params.set('tab', 'project');
@@ -1453,8 +1444,6 @@ function ProjectDetailSurface({
   const status = statusClass(session.status);
   const totalChats = session.totalChats ?? 0;
   const activeChats = session.status === 'running' || session.status === 'error' ? 1 : 0;
-  const fileCount = deriveProjectFileCount(session, index);
-  const tokenLabel = deriveProjectTokenLabel(session, index);
   const modelLabel = session.model || session.metadata?.runtimeModel || 'default model';
   const recentPreview = createChatPreview(session);
   const [isCreatingHeaderChat, setIsCreatingHeaderChat] = useState(false);
@@ -1500,7 +1489,6 @@ function ProjectDetailSurface({
     return (
       <div className="m-main-scroll m-main-scroll--project-chat-detail">
         <ProjectChatSurface
-          fileCount={fileCount}
           isOperator={isOperator}
           modelLabel={modelLabel}
           onBackToChatList={() => onProjectViewChange('chats')}
@@ -1515,7 +1503,6 @@ function ProjectDetailSurface({
           session={session}
           surfaceMode={surfaceMode}
           themeMode={themeMode}
-          tokenLabel={tokenLabel}
         />
       </div>
     );
@@ -1572,16 +1559,8 @@ function ProjectDetailSurface({
             </div>
           </div>
           <div>
-            <div className="proj-stat-label">Files tracked</div>
-            <div className="proj-stat-value">{fileCount}</div>
-          </div>
-          <div>
             <div className="proj-stat-label">Last activity</div>
             <div className="proj-stat-value">{formatRelativeTime(session.lastActivityAt)}</div>
-          </div>
-          <div>
-            <div className="proj-stat-label">Tokens used</div>
-            <div className="proj-stat-value">{tokenLabel}</div>
           </div>
         </div>
       </section>
@@ -1635,7 +1614,6 @@ function ProjectDetailSurface({
         >
           <FileText size={14} />
           Files
-          <span className="proj-tab__count">{fileCount}</span>
         </button>
         <button
           type="button"
@@ -1658,7 +1636,6 @@ function ProjectDetailSurface({
       <section className="proj-pane">
         {projectView === 'chats' ? (
           <ProjectChatSurface
-            fileCount={fileCount}
             isOperator={isOperator}
             modelLabel={modelLabel}
             onBackToChatList={() => onProjectViewChange('chats')}
@@ -1669,20 +1646,19 @@ function ProjectDetailSurface({
             selectedChatId={selectedChatId}
             session={session}
             surfaceMode={surfaceMode}
-            tokenLabel={tokenLabel}
           />
         ) : projectView === 'files' ? (
           <ProjectPlaceholderPanel
             Icon={FileText}
             title="Files"
-            eyebrow={`${fileCount} tracked files`}
+            eyebrow="Workspace files"
             body={`${projectPath}의 작업 파일과 첨부 맥락을 프로젝트 화면 안에서 이어서 다룰 예정입니다.`}
           />
         ) : projectView === 'context' ? (
           <ProjectPlaceholderPanel
             Icon={Database}
             title="Context"
-            eyebrow="6 linked assets"
+            eyebrow="Linked assets"
             body={`${projectName}의 런타임 메모리, 최근 결정, 작업 지침을 같은 프로젝트 범위로 묶습니다.`}
           />
         ) : (
@@ -1697,7 +1673,7 @@ function ProjectDetailSurface({
               <div className="proj-chat__meta">
                 <span className={`badge badge--dot ${projectStatusBadgeClass(session.status)}`}>{projectStatusLabel(session.status)}</span>
                 <span>{session.agent} · {modelLabel}</span>
-                <span>{tokenLabel} · project scope</span>
+                <span>project scope</span>
               </div>
             </button>
             <article className="proj-card proj-card--recent-chats">
@@ -1941,12 +1917,8 @@ function ProjectSurface({
                   </div>
                 </div>
                 <div className="proj-list-stat">
-                  <div className="proj-list-stat__label">Files</div>
-                  <div className="proj-list-stat__val">{deriveProjectFileCount(session, index)}</div>
-                </div>
-                <div className="proj-list-stat">
-                  <div className="proj-list-stat__label">Tokens</div>
-                  <div className="proj-list-stat__val">{deriveProjectTokenLabel(session, index)}</div>
+                  <div className="proj-list-stat__label">Last activity</div>
+                  <div className="proj-list-stat__val">{formatRelativeTime(session.lastActivityAt)}</div>
                 </div>
               </div>
               <ProjectRecentChatRows

--- a/services/aris-web/app/styles/project-chat/shell.css
+++ b/services/aris-web/app/styles/project-chat/shell.css
@@ -532,6 +532,76 @@
 }
 
 .pc-panel-file span,
+/* Git 탭 파일 행이 diff 열기 버튼이 되면서 필요한 버튼 리셋 */
+button.pc-panel-git-file {
+  width: 100%;
+  border: 0;
+  background: none;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+button.pc-panel-git-file:hover,
+button.pc-panel-git-file:focus-visible {
+  background: var(--bg-hover, rgba(127, 127, 127, 0.08));
+}
+
+.pc-git-diff-card {
+  display: flex;
+  flex-direction: column;
+  max-height: min(80vh, 720px);
+}
+
+.pc-git-diff-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  min-width: 0;
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.pc-git-diff-head strong {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--text-xs);
+}
+
+.pc-git-diff-scope {
+  flex: 0 0 auto;
+  color: var(--text-tertiary);
+  font-size: var(--text-2xs, 10px);
+  text-transform: uppercase;
+}
+
+.pc-git-diff-body {
+  flex: 1 1 auto;
+  overflow: auto;
+  margin: 0;
+  padding: var(--sp-3) var(--sp-4);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.pc-git-diff-line--add {
+  background: rgba(46, 160, 67, 0.15);
+}
+
+.pc-git-diff-line--del {
+  background: rgba(248, 81, 73, 0.15);
+}
+
+.pc-git-diff-line--hunk {
+  color: var(--text-tertiary);
+}
+
 .pc-panel-git-file strong {
   min-width: 0;
   overflow: hidden;

--- a/services/aris-web/components/project-chat/ProjectChatSurface.tsx
+++ b/services/aris-web/components/project-chat/ProjectChatSurface.tsx
@@ -116,6 +116,8 @@ import { ProjectActionCard } from '@/components/project-chat/ProjectActionCard';
 import { ProjectPermissionRequestMessage } from '@/components/project-chat/ProjectPermissionRequestMessage';
 import { buildProjectChatTimelineItems } from '@/components/project-chat/permissionsTimeline';
 import { WorkspaceSidebar } from '@/components/project-chat/workspace/WorkspaceSidebar';
+import { GitDiffOverlay } from '@/components/project-chat/workspace/GitDiffOverlay';
+import { useWorkspaceGit } from '@/components/project-chat/workspace/hooks/useWorkspaceGit';
 import { ProjectPreviewOverlay } from '@/components/project-chat/workspace/PreviewOverlay';
 import { useDensityStore } from './cmd-display/densityStore';
 import { computeAutoDensity } from './cmd-display/densityRules';
@@ -135,8 +137,8 @@ import {
   createProjectChat,
   createProjectPanelId,
   displayProjectName,
-  fetchProjectPanelGitOverview,
   fetchProjectWorkspaceLayout,
+  fetchWorkspaceGitDiff,
   formatRelativeTime,
   getEventText,
   hasProjectChatDragPayload,
@@ -167,12 +169,13 @@ import {
   type ProjectChatEventsResponse,
   type ProjectChatSurfaceMode,
   type ProjectPanelDropHandler,
-  type ProjectPanelGitOverview,
+  type ProjectPanelGitFile,
   type ProjectPanelNodeDragStartHandler,
   type ProjectPanelRuntimeErrors,
   type ProjectWorkspacePanelRuntime,
   type ProjectWorkspacePanelRuntimeMap,
   type ReasoningEffort,
+  type WorkspaceGitDiff,
   type WorkspaceTab,
   isProjectTimestampAfter,
 } from './projectChatSurfaceUtils';
@@ -509,7 +512,6 @@ function ProjectParallelPanelTree({
   panelState,
   recentPreview,
   session,
-  tokenLabel,
   workspaceOpen,
 }: {
   chats: SessionChat[];
@@ -530,7 +532,6 @@ function ProjectParallelPanelTree({
   panelState: ProjectParallelPanelTreeState;
   recentPreview: string;
   session: SessionSummary;
-  tokenLabel: string;
   workspaceOpen: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -574,7 +575,6 @@ function ProjectParallelPanelTree({
         session={session}
         showClose={Object.keys(panelState.panels).length > 1}
         isWorkspaceActive={workspaceOpen && panelState.activePanelId === node.panelId}
-        tokenLabel={tokenLabel}
       />
     );
   }
@@ -610,7 +610,6 @@ function ProjectParallelPanelTree({
           panelState={panelState}
           recentPreview={recentPreview}
           session={session}
-          tokenLabel={tokenLabel}
           workspaceOpen={workspaceOpen}
         />
       </div>
@@ -641,7 +640,6 @@ function ProjectParallelPanelTree({
           panelState={panelState}
           recentPreview={recentPreview}
           session={session}
-          tokenLabel={tokenLabel}
           workspaceOpen={workspaceOpen}
         />
       </div>
@@ -670,7 +668,6 @@ function ProjectParallelChatPane({
   session,
   showClose,
   isWorkspaceActive,
-  tokenLabel,
 }: {
   chat: SessionChat;
   isActivePanel: boolean;
@@ -692,7 +689,6 @@ function ProjectParallelChatPane({
   session: SessionSummary;
   showClose: boolean;
   isWorkspaceActive: boolean;
-  tokenLabel: string;
 }) {
   const projectId = session.id;
   const [events, setEvents] = useState<UiEvent[]>([]);
@@ -1164,7 +1160,6 @@ function ProjectParallelChatPane({
           selectedProvider={selectedProvider}
         />
       </div>
-      <div className="pc-parallel-chat__meta">{tokenLabel}</div>
       {dropEdge && <ProjectParallelDropOverlay edge={dropEdge} />}
     </article>
   );
@@ -1174,7 +1169,6 @@ function ProjectParallelChatPane({
 // ProjectChatSurface
 // ---------------------------------------------------------------------------
 export function ProjectChatSurface({
-  fileCount,
   isOperator,
   modelLabel,
   onBackToChatList,
@@ -1189,9 +1183,7 @@ export function ProjectChatSurface({
   session,
   surfaceMode = 'full',
   themeMode,
-  tokenLabel,
 }: {
-  fileCount: number;
   isOperator: boolean;
   modelLabel: string;
   onBackToChatList: () => void;
@@ -1206,7 +1198,6 @@ export function ProjectChatSurface({
   session: SessionSummary;
   surfaceMode?: ProjectChatSurfaceMode;
   themeMode?: ThemeMode;
-  tokenLabel: string;
 }) {
   const projectId = session.id;
   const [chats, setChats] = useState<SessionChat[]>([]);
@@ -1307,9 +1298,8 @@ export function ProjectChatSurface({
   const activeWorkspaceChat = activeWorkspacePanel
     ? chats.find((candidate) => candidate.id === activeWorkspacePanel.chatId) ?? activeChat
     : activeChat;
-  const [workspaceGitOverview, setWorkspaceGitOverview] = useState<ProjectPanelGitOverview | null>(null);
-  const [workspaceGitLoading, setWorkspaceGitLoading] = useState(false);
-  const [workspaceGitError, setWorkspaceGitError] = useState<string | null>(null);
+  const [workspaceGitDiff, setWorkspaceGitDiff] = useState<WorkspaceGitDiff | null>(null);
+  const [workspaceGitDiffLoading, setWorkspaceGitDiffLoading] = useState(false);
   const visibleEvents = events;
   const persistedPermissions = useMemo(
     () => hydratePersistedPermissions(visibleEvents),
@@ -1498,35 +1488,42 @@ export function ProjectChatSurface({
     projectId,
     workspacePanelId: activeWorkspacePanelId,
   });
-  const refreshWorkspaceGit = useCallback(() => {
-    if (!activeWorkspacePanelId) {
-      setWorkspaceGitOverview(null);
-      setWorkspaceGitError('선택된 병렬 패널이 없습니다.');
-      return;
-    }
-
-    setWorkspaceGitLoading(true);
-    setWorkspaceGitError(null);
-    void fetchProjectPanelGitOverview(projectId, activeWorkspacePanelId)
-      .then(setWorkspaceGitOverview)
-      .catch((gitError) => {
-        setWorkspaceGitOverview(null);
-        setWorkspaceGitError(gitError instanceof Error ? gitError.message : 'Git 정보를 불러오지 못했습니다.');
+  // 패널이 없으면 프로젝트 루트 git status로 폴백한다(과거: 영구 에러 상태).
+  const workspaceGit = useWorkspaceGit(projectId, activeWorkspacePanelId, workspaceTab === 'git');
+  const workspaceGitDiffReqRef = useRef(0);
+  const openWorkspaceGitDiff = useCallback((file: ProjectPanelGitFile) => {
+    const scope: WorkspaceGitDiff['scope'] = file.staged && !file.unstaged && !file.untracked ? 'staged' : 'working';
+    const reqId = workspaceGitDiffReqRef.current + 1;
+    workspaceGitDiffReqRef.current = reqId;
+    setWorkspaceGitDiffLoading(true);
+    setWorkspaceGitDiff(null);
+    void fetchWorkspaceGitDiff(projectId, activeWorkspacePanelId, file.path, scope)
+      .then((next) => {
+        if (reqId === workspaceGitDiffReqRef.current) setWorkspaceGitDiff(next);
       })
-      .finally(() => setWorkspaceGitLoading(false));
+      .catch((diffError) => {
+        if (reqId !== workspaceGitDiffReqRef.current) return;
+        setWorkspaceGitDiff({
+          path: file.path,
+          scope,
+          diff: diffError instanceof Error ? `diff 조회 실패: ${diffError.message}` : 'diff 조회 실패',
+        });
+      })
+      .finally(() => {
+        if (reqId === workspaceGitDiffReqRef.current) setWorkspaceGitDiffLoading(false);
+      });
   }, [activeWorkspacePanelId, projectId]);
+  const closeWorkspaceGitDiff = useCallback(() => {
+    workspaceGitDiffReqRef.current += 1;
+    setWorkspaceGitDiff(null);
+    setWorkspaceGitDiffLoading(false);
+  }, []);
   const densityFor = useDensityStore((s) => s.densityFor);
   const terminalSnippets = [
     { id: 'test', name: 'test target', cmd: 'npm test -- --run tests/projectListSurface.test.ts', tag: 'test' },
     { id: 'mobile', name: 'mobile guard', cmd: 'npm test -- --run tests/mobileOverflowLayout.test.ts', tag: 'mobile' },
     { id: 'typecheck', name: 'typecheck', cmd: 'npx tsc --noEmit', tag: 'type' },
     { id: 'build', name: 'build', cmd: 'npm run build', tag: 'build' },
-  ];
-  const contextItems = [
-    { id: 'ctx-project', name: displayProjectName(session), tokens: tokenLabel },
-    { id: 'ctx-route', name: projectChatRoute, tokens: 'route' },
-    { id: 'ctx-prototype', name: 'design/chat-prototype.html', tokens: 'source' },
-    { id: 'ctx-mode', name: `${COMPOSER_MODE_COPY[composerMode]} mode`, tokens: selectedEffort },
   ];
   const runStepItems = visibleEvents.slice(-4).map((item) => ({
     id: item.id,
@@ -2012,36 +2009,6 @@ export function ProjectChatSurface({
     setParallelPanelRuntimeErrors({});
     void saveProjectWorkspaceLayout(projectId, null).catch(() => undefined);
   }, [parallelLayoutHydrated, parallelLayoutStorageKey, parallelPanelState, projectId, surfaceMode]);
-
-  useEffect(() => {
-    if (workspaceTab !== 'git') return;
-    if (!activeWorkspacePanelId) {
-      setWorkspaceGitOverview(null);
-      setWorkspaceGitError('선택된 병렬 패널이 없습니다.');
-      return;
-    }
-
-    let cancelled = false;
-    setWorkspaceGitLoading(true);
-    setWorkspaceGitError(null);
-    void fetchProjectPanelGitOverview(projectId, activeWorkspacePanelId)
-      .then((overview) => {
-        if (!cancelled) setWorkspaceGitOverview(overview);
-      })
-      .catch((gitError) => {
-        if (!cancelled) {
-          setWorkspaceGitOverview(null);
-          setWorkspaceGitError(gitError instanceof Error ? gitError.message : 'Git 정보를 불러오지 못했습니다.');
-        }
-      })
-      .finally(() => {
-        if (!cancelled) setWorkspaceGitLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [activeWorkspacePanelId, projectId, workspaceTab]);
 
   const handleRepairProjectParallelPanelRuntime = useCallback((panelId: string) => {
     if (!parallelPanelState?.panels[panelId]) return;
@@ -2801,7 +2768,6 @@ export function ProjectChatSurface({
               </div>
               <div className="pc-chat-side-stat"><span>Total chats</span><strong>{chats.length || session.totalChats || 0}</strong></div>
               <div className="pc-chat-side-stat"><span>Active signal</span><strong>{projectStatusLabel(session.status)}</strong></div>
-              <div className="pc-chat-side-stat"><span>Context</span><strong>{tokenLabel}</strong></div>
             </article>
           </aside>
         </div>
@@ -2859,7 +2825,6 @@ export function ProjectChatSurface({
                 panelState={parallelPanelState}
                 recentPreview={recentPreview}
                 session={session}
-                tokenLabel={tokenLabel}
                 workspaceOpen={workspaceOpen}
               />
             </div>
@@ -2874,13 +2839,13 @@ export function ProjectChatSurface({
             workspaceFiles={workspaceFiles}
             selectedWorkspaceFile={selectedWorkspaceFile}
             openWorkspaceFilePreview={openWorkspaceFilePreview}
-            workspaceGitOverview={workspaceGitOverview}
-            workspaceGitLoading={workspaceGitLoading}
-            workspaceGitError={workspaceGitError}
-            refreshWorkspaceGit={refreshWorkspaceGit}
+            workspaceGitOverview={workspaceGit.overview}
+            workspaceGitLoading={workspaceGit.loading}
+            workspaceGitError={workspaceGit.error}
+            refreshWorkspaceGit={workspaceGit.refresh}
             activeWorkspacePanelRuntime={activeWorkspacePanelRuntime}
             draftTerminalCommand={draftTerminalCommand}
-            contextItems={contextItems}
+            onOpenGitDiff={openWorkspaceGitDiff}
             handleCopy={handleCopy}
             session={session}
             activeChat={activeChat}
@@ -2915,7 +2880,7 @@ export function ProjectChatSurface({
                   </time>
                 </span>
               )}
-              <span className="ch__meta">{agentLabel(activeAgent, activeModelLabel)} · {tokenLabel} · {fileCount} files</span>
+              <span className="ch__meta">{agentLabel(activeAgent, activeModelLabel)}</span>
             </div>
             <div className="ch__actions">
               <button type="button" className="ch__action" aria-label="Share chat route" onClick={() => handleCopy(projectChatRoute, 'Chat route')}>
@@ -3300,13 +3265,13 @@ export function ProjectChatSurface({
           workspaceFiles={workspaceFiles}
           selectedWorkspaceFile={selectedWorkspaceFile}
           openWorkspaceFilePreview={openWorkspaceFilePreview}
-          workspaceGitOverview={workspaceGitOverview}
-          workspaceGitLoading={workspaceGitLoading}
-          workspaceGitError={workspaceGitError}
-          refreshWorkspaceGit={refreshWorkspaceGit}
+          workspaceGitOverview={workspaceGit.overview}
+          workspaceGitLoading={workspaceGit.loading}
+          workspaceGitError={workspaceGit.error}
+          refreshWorkspaceGit={workspaceGit.refresh}
           activeWorkspacePanelRuntime={activeWorkspacePanelRuntime}
           draftTerminalCommand={draftTerminalCommand}
-          contextItems={contextItems}
+          onOpenGitDiff={openWorkspaceGitDiff}
           handleCopy={handleCopy}
           session={session}
           activeChat={activeChat}
@@ -3314,7 +3279,6 @@ export function ProjectChatSurface({
           setPreviewState={setPreviewState}
           selectedProvider={selectedProvider}
           activeModelLabel={activeModelLabel}
-          tokenLabel={tokenLabel}
           projectRunActive={projectRunActive}
           handleStopActiveChat={handleStopActiveChat}
           visibleEventsCount={visibleEvents.length}
@@ -3329,7 +3293,6 @@ export function ProjectChatSurface({
           terminalSnippets={terminalSnippets}
           setDraftTerminalCommand={setDraftTerminalCommand}
           setPrompt={setPrompt}
-          fileCount={fileCount}
         />
       </div>
       <ProjectPreviewOverlay
@@ -3347,11 +3310,14 @@ export function ProjectChatSurface({
         workspaceTab={workspaceTab}
         selectedWorkspaceFile={selectedWorkspaceFile}
         projectPath={projectPath}
-        tokenLabel={tokenLabel}
       />
       </>
       )}
       {copyFeedback && <div className="pc-toast" data-copy-feedback role="status">{copyFeedback}</div>}
+      {typeof document !== 'undefined' && (workspaceGitDiff || workspaceGitDiffLoading) && createPortal(
+        <GitDiffOverlay diff={workspaceGitDiff} loading={workspaceGitDiffLoading} onClose={closeWorkspaceGitDiff} />,
+        document.body,
+      )}
       {typeof document !== 'undefined' && (workspaceFilePreview || workspaceFilePreviewLoading) && createPortal(
         <div
           className="pc-file-preview-overlay"

--- a/services/aris-web/components/project-chat/projectChatSurfaceUtils.ts
+++ b/services/aris-web/components/project-chat/projectChatSurfaceUtils.ts
@@ -74,7 +74,13 @@ export type ProjectPanelGitOverview = {
   unstagedCount: number;
   untrackedCount: number;
   conflictedCount: number;
+  trackedFileCount: number;
   files: ProjectPanelGitFile[];
+};
+export type WorkspaceGitDiff = {
+  path: string;
+  scope: 'working' | 'staged';
+  diff: string;
 };
 export type ProjectChatDragStartHandler = (
   event: DragEvent<HTMLElement>,
@@ -423,10 +429,13 @@ export async function saveProjectWorkspaceLayout(
   };
 }
 
-export async function fetchProjectPanelGitOverview(projectId: string, panelId: string): Promise<ProjectPanelGitOverview> {
+// workspacePanelId가 없으면 서버가 프로젝트 루트를 대상으로 해석한다(executionTarget의 project 폴백).
+export async function fetchProjectPanelGitOverview(projectId: string, panelId: string | null): Promise<ProjectPanelGitOverview> {
   const params = new URLSearchParams();
   params.set('kind', 'overview');
-  params.set('workspacePanelId', panelId);
+  if (panelId) {
+    params.set('workspacePanelId', panelId);
+  }
   const response = await fetch(
     withAppBasePath(`/api/runtime/sessions/${encodeURIComponent(projectId)}/git?${params.toString()}`),
     { cache: 'no-store' },
@@ -434,6 +443,30 @@ export async function fetchProjectPanelGitOverview(projectId: string, panelId: s
   const body = (await response.json().catch(() => ({}))) as ProjectPanelGitOverview & { error?: string };
   if (!response.ok) {
     throw new Error(body.error ?? 'Git 정보를 불러오지 못했습니다.');
+  }
+  return body;
+}
+
+export async function fetchWorkspaceGitDiff(
+  projectId: string,
+  panelId: string | null,
+  filePath: string,
+  scope: WorkspaceGitDiff['scope'],
+): Promise<WorkspaceGitDiff> {
+  const params = new URLSearchParams();
+  params.set('kind', 'diff');
+  params.set('path', filePath);
+  params.set('scope', scope);
+  if (panelId) {
+    params.set('workspacePanelId', panelId);
+  }
+  const response = await fetch(
+    withAppBasePath(`/api/runtime/sessions/${encodeURIComponent(projectId)}/git?${params.toString()}`),
+    { cache: 'no-store' },
+  );
+  const body = (await response.json().catch(() => ({}))) as WorkspaceGitDiff & { error?: string };
+  if (!response.ok) {
+    throw new Error(body.error ?? 'diff를 불러오지 못했습니다.');
   }
   return body;
 }

--- a/services/aris-web/components/project-chat/workspace/GitDiffOverlay.tsx
+++ b/services/aris-web/components/project-chat/workspace/GitDiffOverlay.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Loader2, X } from 'lucide-react';
+import type { WorkspaceGitDiff } from '../projectChatSurfaceUtils';
+
+function diffLineClass(line: string): string {
+  if (line.startsWith('+') && !line.startsWith('+++')) return ' pc-git-diff-line--add';
+  if (line.startsWith('-') && !line.startsWith('---')) return ' pc-git-diff-line--del';
+  if (line.startsWith('@@')) return ' pc-git-diff-line--hunk';
+  return '';
+}
+
+export function GitDiffOverlay({
+  diff,
+  loading,
+  onClose,
+}: {
+  diff: WorkspaceGitDiff | null;
+  loading: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="pc-file-preview-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Git diff"
+      onClick={onClose}
+    >
+      <div className="pc-file-preview-card pc-git-diff-card" onClick={(event) => event.stopPropagation()}>
+        <div className="pc-git-diff-head">
+          <strong title={diff?.path}>{diff?.path ?? 'diff'}</strong>
+          {diff ? <span className="pc-git-diff-scope">{diff.scope}</span> : null}
+          <button type="button" className="pc-file-preview-close" aria-label="닫기" onClick={onClose}>
+            <X size={14} />
+          </button>
+        </div>
+        {loading && !diff ? (
+          <div className="pc-file-preview-state">
+            <Loader2 size={16} className="pc-file-preview-spin" />
+            diff를 불러오는 중…
+          </div>
+        ) : diff && diff.diff.trim() ? (
+          <pre className="pc-git-diff-body">
+            {diff.diff.split('\n').map((line, index) => (
+              <div key={index} className={`pc-git-diff-line${diffLineClass(line)}`}>{line || ' '}</div>
+            ))}
+          </pre>
+        ) : (
+          <div className="pc-file-preview-state">
+            표시할 diff가 없습니다. 신규(untracked) 파일은 Files 탭에서 내용을 확인하세요.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/services/aris-web/components/project-chat/workspace/PreviewOverlay.tsx
+++ b/services/aris-web/components/project-chat/workspace/PreviewOverlay.tsx
@@ -38,7 +38,6 @@ export type ProjectPreviewOverlayProps = {
   workspaceTab: WorkspaceTab;
   selectedWorkspaceFile: string;
   projectPath: string;
-  tokenLabel: string;
 };
 
 export function ProjectPreviewOverlay({
@@ -56,7 +55,6 @@ export function ProjectPreviewOverlay({
   workspaceTab,
   selectedWorkspaceFile,
   projectPath,
-  tokenLabel,
 }: ProjectPreviewOverlayProps) {
   return (
     <>
@@ -91,7 +89,7 @@ export function ProjectPreviewOverlay({
               </aside>
               <main className="preview-page__main">
                 <h2 className="preview-page__h">{activeChat?.title ?? 'Project chat'}</h2>
-                <p className="preview-page__sub">{agentLabel(activeAgent, activeModelLabel)} · {COMPOSER_MODE_COPY[composerMode]} · {tokenLabel}</p>
+                <p className="preview-page__sub">{agentLabel(activeAgent, activeModelLabel)} · {COMPOSER_MODE_COPY[composerMode]}</p>
                 <div className="preview-page__cards">
                   <div className="preview-page__card">
                     <div className="preview-page__card-t">Workspace</div>

--- a/services/aris-web/components/project-chat/workspace/WorkspaceSidebar.tsx
+++ b/services/aris-web/components/project-chat/workspace/WorkspaceSidebar.tsx
@@ -35,12 +35,12 @@ import {
   type ExpandedTurnState,
   type ModelProvider,
   type PreviewState,
+  type ProjectPanelGitFile,
   type ProjectPanelGitOverview,
   type ProjectWorkspacePanelRuntime,
   type WorkspaceTab,
 } from '../projectChatSurfaceUtils';
 
-export type WorkspaceContextItem = { id: string; name: string; tokens: string };
 export type WorkspaceRunStepItem = { id: string; title: string; cmd: string; time: string };
 export type WorkspaceHistoryTurnItem = {
   id: string;
@@ -66,7 +66,7 @@ type WorkspaceSidebarCommonProps = {
   refreshWorkspaceGit: () => void;
   activeWorkspacePanelRuntime: ProjectWorkspacePanelRuntime | null;
   draftTerminalCommand: string;
-  contextItems: WorkspaceContextItem[];
+  onOpenGitDiff: (file: ProjectPanelGitFile) => void;
   handleCopy: (value: string, label: string) => void;
   session: SessionSummary;
   activeChat: SessionChat | null;
@@ -85,7 +85,6 @@ type ProjectWorkspaceSidebarProps = WorkspaceSidebarCommonProps & {
   setPreviewState: (state: PreviewState) => void;
   selectedProvider: ModelProvider;
   activeModelLabel: string;
-  tokenLabel: string;
   projectRunActive: boolean;
   handleStopActiveChat: () => Promise<void>;
   visibleEventsCount: number;
@@ -100,7 +99,6 @@ type ProjectWorkspaceSidebarProps = WorkspaceSidebarCommonProps & {
   terminalSnippets: WorkspaceTerminalSnippet[];
   setDraftTerminalCommand: (value: string) => void;
   setPrompt: Dispatch<SetStateAction<string>>;
-  fileCount: number;
 };
 
 export type WorkspaceSidebarProps = PanelWorkspaceSidebarProps | ProjectWorkspaceSidebarProps;
@@ -201,6 +199,7 @@ function WorkspaceGitPane({
   activeWorkspacePanelRuntime,
   cwdFallback,
   branchFallback,
+  onOpenGitDiff,
 }: Pick<
   WorkspaceSidebarCommonProps,
   | 'workspaceTab'
@@ -209,7 +208,11 @@ function WorkspaceGitPane({
   | 'workspaceGitError'
   | 'refreshWorkspaceGit'
   | 'activeWorkspacePanelRuntime'
-> & { cwdFallback: string; branchFallback: string }) {
+> & {
+  cwdFallback: string;
+  branchFallback: string;
+  onOpenGitDiff: (file: ProjectPanelGitFile) => void;
+}) {
   return (
     <div className={`ws__pane${workspaceTab === 'git' ? ' ws__pane--active' : ''}`} data-pane="git">
       <div className="file-tree__head">
@@ -240,11 +243,17 @@ function WorkspaceGitPane({
           <div className="file-row file-row--state">변경된 파일이 없습니다.</div>
         )}
         {workspaceGitOverview?.files.slice(0, 60).map((file) => (
-          <div key={`${file.path}:${file.indexStatus}:${file.workTreeStatus}`} className="pc-panel-git-file">
+          <button
+            key={`${file.path}:${file.indexStatus}:${file.workTreeStatus}`}
+            type="button"
+            className="pc-panel-git-file pc-panel-git-file--action"
+            title={`${file.path} diff 보기`}
+            onClick={() => onOpenGitDiff(file)}
+          >
             <span>{file.indexStatus}{file.workTreeStatus}</span>
             <strong title={file.path}>{file.path}</strong>
             <em>{file.conflicted ? 'conflict' : file.untracked ? 'new' : file.staged ? 'staged' : 'modified'}</em>
-          </div>
+          </button>
         ))}
       </div>
     </div>
@@ -278,7 +287,7 @@ function PanelWorkspaceSidebar({
   refreshWorkspaceGit,
   activeWorkspacePanelRuntime,
   draftTerminalCommand,
-  contextItems,
+  onOpenGitDiff,
   handleCopy,
   session,
   activeChat,
@@ -342,6 +351,7 @@ function PanelWorkspaceSidebar({
           activeWorkspacePanelRuntime={activeWorkspacePanelRuntime}
           cwdFallback=""
           branchFallback="branch pending"
+          onOpenGitDiff={onOpenGitDiff}
         />
         <div className={`ws__pane${workspaceTab === 'terminal' ? ' ws__pane--active' : ''}`} data-pane="terminal">
           <div className="term">
@@ -354,14 +364,8 @@ function PanelWorkspaceSidebar({
         </div>
         <div className={`ws__pane${workspaceTab === 'context' ? ' ws__pane--active' : ''}`} data-pane="context">
           <div className="ctx-group">
-            <div className="ctx-group__head"><span className="ctx-group__title">Panel context</span><span className="ctx-group__count">{contextItems.length}</span></div>
-            {contextItems.map((item) => (
-              <button key={item.id} type="button" className="ctx-item" onClick={() => handleCopy(item.name, 'Context item')}>
-                <FileText size={13} className="ctx-item__icon" />
-                <span className="ctx-item__name">{item.name}</span>
-                <span className="ctx-item__tokens">{item.tokens}</span>
-              </button>
-            ))}
+            <div className="ctx-group__head"><span className="ctx-group__title">Panel context</span></div>
+            <div className="ws-empty-state">토큰 사용량 실측 수집을 준비 중입니다. 수집이 연결되면 이 자리에 패널 컨텍스트 사용량이 표시됩니다.</div>
           </div>
         </div>
         <WorkspaceSubagentsPane workspaceTab={workspaceTab} session={session} activeChat={activeChat} />
@@ -385,7 +389,7 @@ function ProjectWorkspaceSidebar({
   refreshWorkspaceGit,
   activeWorkspacePanelRuntime,
   draftTerminalCommand,
-  contextItems,
+  onOpenGitDiff,
   handleCopy,
   session,
   activeChat,
@@ -393,7 +397,6 @@ function ProjectWorkspaceSidebar({
   setPreviewState,
   selectedProvider,
   activeModelLabel,
-  tokenLabel,
   projectRunActive,
   handleStopActiveChat,
   visibleEventsCount,
@@ -408,7 +411,6 @@ function ProjectWorkspaceSidebar({
   terminalSnippets,
   setDraftTerminalCommand,
   setPrompt,
-  fileCount,
 }: ProjectWorkspaceSidebarProps) {
   return (
     <aside ref={workspaceRef} className="shell__workspace ws ws-pane" aria-label={`${projectName} workspace`}>
@@ -433,7 +435,6 @@ function ProjectWorkspaceSidebar({
           <span className="ws__pill"><span className="ws__pill-dot" />{projectStatusLabel(session.status)}</span>
         </div>
         <div className="ws__status-right">
-          <span>{tokenLabel}</span>
           <button
             type="button"
             className="ws__stop"
@@ -449,13 +450,12 @@ function ProjectWorkspaceSidebar({
         <div className={`ws__pane${workspaceTab === 'run' ? ' ws__pane--active' : ''}`} data-pane="run">
           <div className="run-summary">
             <div className="run-summary__cell"><span className="run-summary__label">Steps</span><span className="run-summary__value">{visibleEventsCount}</span></div>
-            <div className="run-summary__cell"><span className="run-summary__label">Tokens</span><span className="run-summary__value">{tokenLabel}</span></div>
             <div className="run-summary__cell"><span className="run-summary__label">Activity</span><span className="run-summary__value">{formatRelativeTime(selectedChatTimestamp)}</span></div>
           </div>
           <div className="ws-card ws-card--run">
             <div className="ws-card__head">
-              <div className="ws-card__title">Run · {activeChat?.id ? `#${activeChat.id.slice(-4)}` : '#0142'}</div>
-              <div className="ws-card__meta">{formatRelativeTime(selectedChatTimestamp)} · {tokenLabel} tokens</div>
+              <div className="ws-card__title">Run · {activeChat?.id ? `#${activeChat.id.slice(-4)}` : '—'}</div>
+              <div className="ws-card__meta">{formatRelativeTime(selectedChatTimestamp)}</div>
             </div>
             <div className="run-steps">
               {runStepItems.length > 0 ? (
@@ -540,6 +540,7 @@ function ProjectWorkspaceSidebar({
           activeWorkspacePanelRuntime={activeWorkspacePanelRuntime}
           cwdFallback={projectPath}
           branchFallback="project branch"
+          onOpenGitDiff={onOpenGitDiff}
         />
         <div className={`ws__pane${workspaceTab === 'terminal' ? ' ws__pane--active' : ''}`} data-pane="terminal">
           <div className="term">
@@ -580,16 +581,8 @@ function ProjectWorkspaceSidebar({
         </div>
         <div className={`ws__pane${workspaceTab === 'context' ? ' ws__pane--active' : ''}`} data-pane="context">
           <div className="ctx-summary">
-            <div className="ctx-ring" aria-label={`${tokenLabel} context usage`}>
-              <svg viewBox="0 0 80 80" width="80" height="80" aria-hidden="true">
-                <circle className="ctx-ring__track" cx="40" cy="40" r="34" strokeWidth="6" fill="none" />
-                <circle className="ctx-ring__fill" cx="40" cy="40" r="34" strokeWidth="6" fill="none" strokeDasharray="214" strokeDashoffset="194" strokeLinecap="round" />
-              </svg>
-              <div className="ctx-ring__center">9.2%</div>
-            </div>
             <div className="ctx-summary__body">
-              <div className="ctx-summary__title">Context usage</div>
-              <div className="ctx-summary__meta">{tokenLabel} / 200k tokens</div>
+              <div className="ctx-summary__title">Context</div>
               <div className="ctx-summary__split">
                 <div className="ctx-summary__split-cell"><div className="ctx-summary__split-label">Model</div><div className="ctx-summary__split-value">{activeModelLabel}</div></div>
                 <div className="ctx-summary__split-cell"><div className="ctx-summary__split-label">Mode</div><div className="ctx-summary__split-value">{COMPOSER_MODE_COPY[composerMode]}</div></div>
@@ -597,22 +590,17 @@ function ProjectWorkspaceSidebar({
             </div>
           </div>
           <div className="ctx-group">
-            <div className="ctx-group__head"><span className="ctx-group__title">Attached context</span><span className="ctx-group__count">{contextItems.length}</span></div>
-            {contextItems.map((item) => (
-              <button key={item.id} type="button" className="ctx-item" onClick={() => handleCopy(item.name, 'Context item')}>
-                <FileText size={13} className="ctx-item__icon" />
-                <span className="ctx-item__name">{item.name}</span>
-                <span className="ctx-item__tokens">{item.tokens}</span>
-              </button>
-            ))}
+            <div className="ctx-group__head"><span className="ctx-group__title">Context usage</span></div>
+            <div className="ws-empty-state">토큰 사용량 실측 수집을 준비 중입니다. 수집이 연결되면 이 자리에 컨텍스트 사용량이 표시됩니다.</div>
           </div>
         </div>
         <WorkspaceSubagentsPane workspaceTab={workspaceTab} session={session} activeChat={activeChat} />
       </div>
       <div className="ws__footer">
-        <div className="ws__footer-row"><span className="ws__footer-label">Context usage</span><span className="ws__footer-value">{tokenLabel} / 200k</span></div>
-        <div className="ws__footer-bar"><div className="ws__footer-fill" style={{ width: '9.2%' }} /></div>
-        <div className="ws__footer-meta"><span>project scoped</span><span>{fileCount} files</span></div>
+        <div className="ws__footer-meta">
+          <span>project scoped</span>
+          <span>{workspaceGitOverview ? `${workspaceGitOverview.trackedFileCount} files` : '— files'}</span>
+        </div>
       </div>
     </aside>
   );

--- a/services/aris-web/components/project-chat/workspace/hooks/useWorkspaceGit.ts
+++ b/services/aris-web/components/project-chat/workspace/hooks/useWorkspaceGit.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  fetchProjectPanelGitOverview,
+  type ProjectPanelGitOverview,
+} from '../../projectChatSurfaceUtils';
+
+export type WorkspaceGitApi = {
+  overview: ProjectPanelGitOverview | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+};
+
+// workspacePanelId가 null이면 프로젝트 루트 git status를 조회한다.
+// 마운트 시 1회(푸터의 tracked files 수치용) + Git 탭 활성화 시 + 수동 refresh로 갱신한다.
+export function useWorkspaceGit(
+  projectId: string,
+  workspacePanelId: string | null,
+  gitTabActive: boolean,
+): WorkspaceGitApi {
+  const [overview, setOverview] = useState<ProjectPanelGitOverview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const reqRef = useRef(0);
+
+  const load = useCallback(() => {
+    const reqId = reqRef.current + 1;
+    reqRef.current = reqId;
+    setLoading(true);
+    setError(null);
+    void fetchProjectPanelGitOverview(projectId, workspacePanelId)
+      .then((next) => {
+        if (reqId !== reqRef.current) return;
+        setOverview(next);
+      })
+      .catch((gitError) => {
+        if (reqId !== reqRef.current) return;
+        setOverview(null);
+        setError(gitError instanceof Error ? gitError.message : 'Git 정보를 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (reqId === reqRef.current) setLoading(false);
+      });
+  }, [projectId, workspacePanelId]);
+
+  useEffect(() => {
+    load();
+    return () => {
+      reqRef.current += 1;
+    };
+  }, [load]);
+
+  useEffect(() => {
+    if (gitTabActive) {
+      load();
+    }
+    // load는 (projectId, panelId) 변경 시 위 효과가 이미 커버 — 탭 재진입 갱신만 담당한다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gitTabActive]);
+
+  return { overview, loading, error, refresh: load };
+}

--- a/services/aris-web/lib/git/sidebar.ts
+++ b/services/aris-web/lib/git/sidebar.ts
@@ -34,6 +34,7 @@ export type GitSidebarOverview = {
   unstagedCount: number;
   untrackedCount: number;
   conflictedCount: number;
+  trackedFileCount: number;
   files: GitFileEntry[];
 };
 
@@ -216,7 +217,7 @@ function formatGitOutput(stdout: string, stderr: string, fallback: string): stri
 export async function getGitSidebarOverview(projectPath: string): Promise<GitSidebarOverview> {
   const resolved = await resolveGitWorkspace(projectPath);
 
-  const [statusResult, branchResult, upstreamResult, aheadBehindResult] = await Promise.all([
+  const [statusResult, branchResult, upstreamResult, aheadBehindResult, trackedFilesResult] = await Promise.all([
     runGitCommand(resolved.runtimePath, ['status', '--porcelain=v1', '-z', '--untracked-files=all']),
     runGitCommand(resolved.runtimePath, ['branch', '--show-current']),
     runGitCommand(resolved.runtimePath, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}']).catch(() => ({
@@ -225,6 +226,10 @@ export async function getGitSidebarOverview(projectPath: string): Promise<GitSid
     })),
     runGitCommand(resolved.runtimePath, ['rev-list', '--left-right', '--count', '@{upstream}...HEAD']).catch(() => ({
       stdout: '0 0',
+      stderr: '',
+    })),
+    runGitCommand(resolved.runtimePath, ['ls-files', '--cached']).catch(() => ({
+      stdout: '',
       stderr: '',
     })),
   ]);
@@ -247,6 +252,7 @@ export async function getGitSidebarOverview(projectPath: string): Promise<GitSid
     unstagedCount,
     untrackedCount,
     conflictedCount,
+    trackedFileCount: trackedFilesResult.stdout.split('\n').filter(Boolean).length,
     files,
   };
 }

--- a/services/aris-web/tests/gitSidebarErrors.test.ts
+++ b/services/aris-web/tests/gitSidebarErrors.test.ts
@@ -129,6 +129,7 @@ describe('git sidebar runtime errors', () => {
       'branch --show-current',
       'rev-parse --abbrev-ref --symbolic-full-name @{upstream}',
       'rev-list --left-right --count @{upstream}...HEAD',
+      'ls-files --cached',
     ]);
   });
 });

--- a/services/aris-web/tests/parallelChatDragSurface.test.ts
+++ b/services/aris-web/tests/parallelChatDragSurface.test.ts
@@ -120,7 +120,7 @@ describe('project parallel chat drag surface', () => {
     expect(projectChatSurface).toContain('workspacePanelId: panelId');
     expect(projectChatSurface).toContain('workspacePanelId: activeWorkspacePanelId');
     expect(projectChatSurface).toContain('useWorkspaceFiles');
-    expect(projectChatSurface).toContain('fetchProjectPanelGitOverview');
+    expect(projectChatSurface).toContain('useWorkspaceGit(projectId, activeWorkspacePanelId');
     expect(projectChatSurface).toContain('pc-parallel-workspace');
     expect(projectChatSurface).toContain('onOpenPanelWorkspaceTab');
     expect(projectChatSurface).toContain("data-tab=\"git\"");

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -465,7 +465,8 @@ describe('project list surface', () => {
   it('keeps the workspace metrics while restyling run details as chat-screen-v1 cards', () => {
     expect(projectChatSurface).toContain('<div className="run-summary">');
     expect(projectChatSurface).toContain('<span className="run-summary__label">Steps</span>');
-    expect(projectChatSurface).toContain('<span className="run-summary__label">Tokens</span>');
+    // Tokens 셀은 실측 usage 파이프라인이 붙기 전까지 표시하지 않는다(가짜 지표 금지).
+    expect(projectChatSurface).not.toContain('<span className="run-summary__label">Tokens</span>');
     expect(projectChatSurface).toContain('<span className="run-summary__label">Activity</span>');
     expect(projectChatSurface).toContain('className="ws-card ws-card--run"');
     expect(projectChatSurface).toContain('className="chist ws-card ws-card--history"');
@@ -482,6 +483,21 @@ describe('project list surface', () => {
     expect(uiCss).toContain('.pc-proto .ws-run-step {');
     expect(uiCss).toContain('.pc-proto .ws-empty-state {');
     expect(uiCss).toContain('grid-template-columns: auto minmax(0, 1fr) auto;');
+  });
+
+  it('keeps fabricated metrics out of the workspace surfaces', () => {
+    // 가짜 수치(수식으로 지어낸 토큰/파일 수, 하드코딩 링/게이지) 재유입 방지.
+    expect(homeClient).not.toContain('deriveProjectTokenLabel');
+    expect(homeClient).not.toContain('deriveProjectFileCount');
+    expect(projectChatSurface).not.toContain('9.2%');
+    expect(projectChatSurface).not.toContain("'#0142'");
+    expect(projectChatSurface).not.toContain('/ 200k');
+    expect(projectChatSurface).not.toContain('design/chat-prototype.html');
+    expect(projectChatSurface).not.toContain('tokenLabel');
+    expect(projectChatSurface).not.toContain('fileCount');
+    // Git 탭은 패널이 없으면 프로젝트 루트로 폴백한다 — 영구 에러 문구 금지.
+    expect(projectChatSurface).not.toContain('선택된 병렬 패널이 없습니다.');
+    expect(projectChatSurface).toContain('trackedFileCount');
   });
 
   it('renders functional workspace panes instead of one static Run panel', () => {


### PR DESCRIPTION
## 배경

사이드바 실동작 전환 설계(#402)의 **PR-1**. 점검에서 확인된 가짜 지표(수식으로 지어낸 토큰/파일 수, 하드코딩 9.2% 링·게이지)와 일반 모드에서 영구 죽어 있던 Git 탭을 처리한다. 원칙: **실데이터가 준비되기 전까지는 표시 자체를 제거한다.**

## 가짜 지표 제거

- `deriveProjectTokenLabel`/`deriveProjectFileCount`(`totalChats*11.8+index*7.4` 류) 삭제. 소비처 전부 정리:
  - 홈 프로젝트 카드/리스트의 "Files tracked"·"Tokens used" 타일 → 실측인 Chats·Last activity만 유지
  - 채팅 헤더 `ch__meta`, 사이드바 상태바, Run 요약 Tokens 셀, Run 카드 meta, 프리뷰 페이지
  - 병렬 패널 meta 라인(`pc-parallel-chat__meta`)
- Context 탭: 하드코딩 링(9.2%/`strokeDashoffset=194`)·`/ 200k`·목업 "Attached context"(문자 그대로 `design/chat-prototype.html`이 남아 있던) 제거 → Model/Mode 실데이터 + "실측 수집 준비 중" empty state (PR-5에서 실측 연결)
- 푸터: 가짜 게이지(width 9.2%) 제거, 파일 수는 git overview의 `trackedFileCount` 실측으로 대체
- Run 카드 `'#0142'` fallback → `—`

## Git 탭 실동작

- **`useWorkspaceGit` 훅 신설**: `workspacePanelId`가 없으면 서버의 프로젝트 루트 폴백(`resolveProjectTarget`)을 그대로 사용. 일반 채팅 화면에서 `선택된 병렬 패널이 없습니다` 영구 에러가 사라지고 프로젝트 루트 git status가 뜬다. 마운트 시(푸터 파일 수용) + Git 탭 활성화 시 + 수동 refresh 갱신.
- **파일 행 클릭 → diff 오버레이**: 기존 `kind=diff` API 연결(staged/working 자동 스코프), +/-/hunk 라인 하이라이트, untracked는 안내 문구. stale-response 가드 포함.
- `getGitSidebarOverview`에 `trackedFileCount` 추가(`git ls-files --cached`, 기존 병렬 exec에 1개 추가).

## 테스트

- 신설: "keeps fabricated metrics out of the workspace surfaces" — derive 함수·9.2%·`#0142`·`/ 200k`·prototype 참조·영구 에러 문구의 재유입 방지
- 갱신: run-summary 단언(Tokens 셀은 실측 전 미표시), git 명령 시퀀스(`ls-files --cached` 추가), git 헬퍼 단언(`useWorkspaceGit` 경유)
- `tsc` 클린, vitest 125 파일/**629 테스트** 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxfd4yi1xRpXZHvjuggvTW
