### PR TITLE
feat(web): Run 탭 실상태·Chat history 턴 페어링 실데이터화 (PR-2)

### DIFF
--- a/services/aris-web/components/project-chat/ProjectChatSurface.tsx
+++ b/services/aris-web/components/project-chat/ProjectChatSurface.tsx
@@ -144,7 +144,9 @@ import {
   hasProjectChatDragPayload,
   isProjectChatTimelineNearBottom,
   mergeProjectChatEvents,
+  isWorkspaceRunStepEvent,
   normalizeReasoningEffort,
+  pairChatTurns,
   projectStatusBadgeClass,
   projectStatusLabel,
   providerFromAgent,
@@ -1316,8 +1318,6 @@ export function ProjectChatSurface({
   }, [providerOptions, selectedProvider, selectedModelId]);
   const activeModelLabel = activeOption.label || runtimeModelLabel;
   const activeAgent: SessionSummary['agent'] = selectedProvider;
-  const userTurns = visibleEvents.filter((item) => readEventRole(item) === 'user');
-  const representativeAgentEvent = visibleEvents.find((item) => readEventRole(item) !== 'user');
   const activeRunStartedAt = submittedRunStartedAt ?? runtimeRunStartedAt;
   const projectRunIndicator = resolveProjectRunIndicator({
     events,
@@ -1525,13 +1525,18 @@ export function ProjectChatSurface({
     { id: 'typecheck', name: 'typecheck', cmd: 'npx tsc --noEmit', tag: 'type' },
     { id: 'build', name: 'build', cmd: 'npm run build', tag: 'build' },
   ];
-  const runStepItems = visibleEvents.slice(-4).map((item) => ({
+  const runStepEvents = visibleEvents.filter(isWorkspaceRunStepEvent);
+  const runStepItems = runStepEvents.map((item, index) => ({
     id: item.id,
     title: item.title || item.kind,
     cmd: eventCommand(item),
     time: formatRelativeTime(item.timestamp),
-    state: 'done' as const,
+    // 실행 계획 정보가 이벤트에 없어 pending은 표현 불가 — 런 활성 중 최신 작업만 running.
+    running: projectRunActive && index === runStepEvents.length - 1,
   }));
+  const runDurationLabel = projectRunIndicator
+    ? formatElapsedDuration(projectRunIndicator.startedAt, projectRunNowMs)
+    : null;
   const showTransientFeedback = (message: string) => {
     setCopyFeedback(message);
     window.setTimeout(() => {
@@ -1791,24 +1796,31 @@ export function ProjectChatSurface({
     }, 1800);
   };
 
-  const handleJumpToTurn = (turnId: string) => {
-    setExpandedTurnId(turnId);
-    setHighlightedMessageId(turnId);
+  const handleJumpToEvent = (eventId: string) => {
+    setExpandedTurnId(eventId);
+    setHighlightedMessageId(eventId);
     suppressChromeScroll(1000);
-    timelineRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+    const escaped = typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(eventId) : eventId;
+    const target = timelineRef.current?.querySelector(`[data-event-id="${escaped}"]`);
+    if (target instanceof HTMLElement) {
+      target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    } else {
+      // 밀도 스택으로 접힌 이벤트 등 앵커가 없으면 타임라인 상단으로.
+      timelineRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+    }
     window.setTimeout(() => {
       setHighlightedMessageId(null);
     }, 1800);
   };
-  const historyTurnItems = userTurns.slice(-3).map((item, turnIndex) => ({
-    id: item.id,
-    timestamp: item.timestamp,
-    text: getEventText(item),
-    open: turnIndex === 0,
-    state: turnIndex === 0 ? 'running' : 'answered',
-    agentText: representativeAgentEvent ? getEventText(representativeAgentEvent) : '프로젝트 맥락을 기준으로 응답을 준비합니다.',
+  const historyTurnItems = pairChatTurns(visibleEvents, 10).map((turn) => ({
+    id: turn.id,
+    timestamp: turn.timestamp,
+    text: turn.text,
+    state: turn.isLatest && projectRunActive ? 'running' : 'answered',
+    agentText: turn.agentText
+      ?? (turn.isLatest && projectRunActive ? '응답을 생성하는 중…' : '이 턴에는 텍스트 응답이 없습니다.'),
   }));
-  const defaultExpandedTurnId = historyTurnItems[0]?.id ?? null;
+  const defaultExpandedTurnId = historyTurnItems.at(-1)?.id ?? null;
   const visibleExpandedTurnId = expandedTurnId === '__none__'
     ? null
     : expandedTurnId ?? defaultExpandedTurnId;
@@ -2644,7 +2656,7 @@ export function ProjectChatSurface({
       flushStack();
       const permission = timelineItem.permission;
       rendered.push(
-        <div key={permission.id} className={`msg msg--permission${highlightedMessageId === permission.id ? ' msg--highlight' : ''}`}>
+        <div key={permission.id} data-event-id={permission.id} className={`msg msg--permission${highlightedMessageId === permission.id ? ' msg--highlight' : ''}`}>
           <ProjectPermissionRequestMessage
             permission={permission}
             disabled={!isOperator}
@@ -2675,7 +2687,7 @@ export function ProjectChatSurface({
 
     if (runStatusEvent) {
       rendered.push(
-        <div key={item.id} className={`msg msg--run-status${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
+        <div key={item.id} data-event-id={item.id} className={`msg msg--run-status${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
           <ProjectRunStatusChip event={item} />
         </div>,
       );
@@ -2684,7 +2696,7 @@ export function ProjectChatSurface({
 
     if (d.kind === 'action') {
       rendered.push(
-        <div key={item.id} className={`msg msg--action${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
+        <div key={item.id} data-event-id={item.id} className={`msg msg--action${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
           <ProjectActionCard
             event={item}
             density={d.density}
@@ -2700,7 +2712,7 @@ export function ProjectChatSurface({
 
     // Default (non-action) branch — preserve the existing JSX for user/agent/terminal messages.
     rendered.push(
-      <div key={item.id} className={`msg${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
+      <div key={item.id} data-event-id={item.id} className={`msg${highlightedMessageId === item.id ? ' msg--highlight' : ''}`}>
         {renderNonAction(item)}
       </div>,
     );
@@ -3281,13 +3293,13 @@ export function ProjectChatSurface({
           activeModelLabel={activeModelLabel}
           projectRunActive={projectRunActive}
           handleStopActiveChat={handleStopActiveChat}
-          visibleEventsCount={visibleEvents.length}
+          runDurationLabel={runDurationLabel}
           selectedChatTimestamp={selectedChatTimestamp}
           runStepItems={runStepItems}
           historyTurnItems={historyTurnItems}
           visibleExpandedTurnId={visibleExpandedTurnId}
           setExpandedTurnId={setExpandedTurnId}
-          handleJumpToTurn={handleJumpToTurn}
+          handleJumpToEvent={handleJumpToEvent}
           activeAgent={activeAgent}
           composerMode={composerMode}
           terminalSnippets={terminalSnippets}

--- a/services/aris-web/components/project-chat/projectChatSurfaceUtils.ts
+++ b/services/aris-web/components/project-chat/projectChatSurfaceUtils.ts
@@ -630,3 +630,57 @@ export function resolveProjectRunIndicator({
   }
   return null;
 }
+
+const WORKSPACE_RUN_STEP_KINDS = new Set<UiEvent['kind']>([
+  'run_execution',
+  'exec_execution',
+  'git_execution',
+  'docker_execution',
+  'command_execution',
+  'file_list',
+  'file_read',
+  'file_write',
+]);
+
+// Run 탭 스텝은 작업성 이벤트만 센다 — 텍스트 응답·think·run_status 제외.
+export function isWorkspaceRunStepEvent(event: UiEvent): boolean {
+  return WORKSPACE_RUN_STEP_KINDS.has(event.kind);
+}
+
+export type ProjectChatTurnPair = {
+  id: string;
+  timestamp: string;
+  text: string;
+  agentText: string | null;
+  isLatest: boolean;
+};
+
+// 사용자 턴별 응답 페어링: 각 user 이벤트에 "다음 user 이벤트 전의 마지막
+// 에이전트 text_reply"를 묶는다. terminal 응답은 에이전트 답변이 아니므로 제외.
+export function pairChatTurns(events: UiEvent[], limit: number): ProjectChatTurnPair[] {
+  const turns: ProjectChatTurnPair[] = [];
+  let current: ProjectChatTurnPair | null = null;
+  for (const event of events) {
+    const role = readEventRole(event);
+    if (role === 'user') {
+      current = {
+        id: event.id,
+        timestamp: event.timestamp,
+        text: getEventText(event),
+        agentText: null,
+        isLatest: false,
+      };
+      turns.push(current);
+      continue;
+    }
+    if (!current || role === 'terminal') continue;
+    if (event.kind === 'text_reply') {
+      current.agentText = getEventText(event);
+    }
+  }
+  const latest = turns.at(-1);
+  if (latest) {
+    latest.isLatest = true;
+  }
+  return turns.slice(-limit);
+}

--- a/services/aris-web/components/project-chat/workspace/WorkspaceSidebar.tsx
+++ b/services/aris-web/components/project-chat/workspace/WorkspaceSidebar.tsx
@@ -41,7 +41,13 @@ import {
   type WorkspaceTab,
 } from '../projectChatSurfaceUtils';
 
-export type WorkspaceRunStepItem = { id: string; title: string; cmd: string; time: string };
+export type WorkspaceRunStepItem = {
+  id: string;
+  title: string;
+  cmd: string;
+  time: string;
+  running: boolean;
+};
 export type WorkspaceHistoryTurnItem = {
   id: string;
   timestamp: string;
@@ -87,13 +93,13 @@ type ProjectWorkspaceSidebarProps = WorkspaceSidebarCommonProps & {
   activeModelLabel: string;
   projectRunActive: boolean;
   handleStopActiveChat: () => Promise<void>;
-  visibleEventsCount: number;
+  runDurationLabel: string | null;
   selectedChatTimestamp: string;
   runStepItems: WorkspaceRunStepItem[];
   historyTurnItems: WorkspaceHistoryTurnItem[];
   visibleExpandedTurnId: string | null;
   setExpandedTurnId: (value: ExpandedTurnState) => void;
-  handleJumpToTurn: (turnId: string) => void;
+  handleJumpToEvent: (eventId: string) => void;
   activeAgent: SessionSummary['agent'];
   composerMode: ComposerMode;
   terminalSnippets: WorkspaceTerminalSnippet[];
@@ -399,13 +405,13 @@ function ProjectWorkspaceSidebar({
   activeModelLabel,
   projectRunActive,
   handleStopActiveChat,
-  visibleEventsCount,
+  runDurationLabel,
   selectedChatTimestamp,
   runStepItems,
   historyTurnItems,
   visibleExpandedTurnId,
   setExpandedTurnId,
-  handleJumpToTurn,
+  handleJumpToEvent,
   activeAgent,
   composerMode,
   terminalSnippets,
@@ -449,7 +455,8 @@ function ProjectWorkspaceSidebar({
       <div className="ws__body">
         <div className={`ws__pane${workspaceTab === 'run' ? ' ws__pane--active' : ''}`} data-pane="run">
           <div className="run-summary">
-            <div className="run-summary__cell"><span className="run-summary__label">Steps</span><span className="run-summary__value">{visibleEventsCount}</span></div>
+            <div className="run-summary__cell"><span className="run-summary__label">Steps</span><span className="run-summary__value">{runStepItems.length}</span></div>
+            <div className="run-summary__cell"><span className="run-summary__label">Duration</span><span className="run-summary__value">{runDurationLabel ?? '—'}</span></div>
             <div className="run-summary__cell"><span className="run-summary__label">Activity</span><span className="run-summary__value">{formatRelativeTime(selectedChatTimestamp)}</span></div>
           </div>
           <div className="ws-card ws-card--run">
@@ -460,8 +467,8 @@ function ProjectWorkspaceSidebar({
             <div className="run-steps">
               {runStepItems.length > 0 ? (
                 runStepItems.map((item) => (
-                  <button key={item.id} type="button" className="run-step ws-run-step" onClick={() => handleCopy(item.cmd, 'Run step')}>
-                    <span className="run-step__dot ws-run-step__dot run-step__dot--done ws-run-step__dot--done" />
+                  <button key={item.id} type="button" className="run-step ws-run-step" title="타임라인에서 보기" onClick={() => handleJumpToEvent(item.id)}>
+                    <span className={`run-step__dot ws-run-step__dot ${item.running ? 'run-step__dot--running ws-run-step__dot--running' : 'run-step__dot--done ws-run-step__dot--done'}`} />
                     <div className="run-step__body ws-run-step__body">
                       <div className="run-step__title ws-run-step__title">{item.title}</div>
                       <div className="run-step__cmd ws-run-step__time">{item.cmd}</div>
@@ -512,8 +519,7 @@ function ProjectWorkspaceSidebar({
                       </div>
                       <div className="chturn__agent-text"><MarkdownContent body={item.agentText} /></div>
                       <div className="chturn__actions">
-                        <button type="button" className="chturn__btn" onClick={() => handleJumpToTurn(item.id)}><ChevronRight size={11} />Jump</button>
-                        <button type="button" className="chturn__btn" data-preview-open onClick={() => setPreviewState('open')}><FileText size={11} />Preview</button>
+                        <button type="button" className="chturn__btn" onClick={() => handleJumpToEvent(item.id)}><ChevronRight size={11} />Jump</button>
                         <button type="button" className="chturn__btn" onClick={() => handleCopy(`${item.text}\n\n${item.agentText}`, 'Turn summary')}><Copy size={11} />Copy</button>
                       </div>
                     </div>

--- a/services/aris-web/tests/projectChatTurnPairs.test.ts
+++ b/services/aris-web/tests/projectChatTurnPairs.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import type { UiEvent } from '@/lib/happy/types';
+import { isWorkspaceRunStepEvent, pairChatTurns } from '@/components/project-chat/projectChatSurfaceUtils';
+
+let seq = 0;
+
+function event(input: {
+  role?: 'user' | 'terminal';
+  kind?: UiEvent['kind'];
+  body?: string;
+}): UiEvent {
+  seq += 1;
+  return {
+    id: `evt-${seq}`,
+    timestamp: `2026-07-11T00:00:${String(seq).padStart(2, '0')}.000Z`,
+    kind: input.kind ?? 'text_reply',
+    title: `event ${seq}`,
+    body: input.body ?? `body ${seq}`,
+    meta: input.role ? { role: input.role } : { role: 'assistant' },
+  };
+}
+
+describe('pairChatTurns', () => {
+  it('pairs each user turn with the last agent text reply before the next user turn', () => {
+    const user1 = event({ role: 'user', body: '첫 질문' });
+    const reply1a = event({ kind: 'text_reply', body: '중간 답변' });
+    const reply1b = event({ kind: 'text_reply', body: '최종 답변' });
+    const user2 = event({ role: 'user', body: '둘째 질문' });
+    const reply2 = event({ kind: 'text_reply', body: '둘째 답변' });
+
+    const turns = pairChatTurns([user1, reply1a, reply1b, user2, reply2], 10);
+
+    expect(turns).toHaveLength(2);
+    expect(turns[0]).toMatchObject({ id: user1.id, text: '첫 질문', agentText: '최종 답변', isLatest: false });
+    expect(turns[1]).toMatchObject({ id: user2.id, text: '둘째 질문', agentText: '둘째 답변', isLatest: true });
+  });
+
+  it('does not use terminal output or work events as the agent reply', () => {
+    const user = event({ role: 'user', body: '질문' });
+    const work = event({ kind: 'command_execution', body: 'npm test 실행' });
+    const terminal = event({ role: 'terminal', kind: 'text_reply', body: '터미널 출력' });
+
+    const turns = pairChatTurns([user, work, terminal], 10);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].agentText).toBeNull();
+  });
+
+  it('marks only the newest turn as latest and applies the limit from the tail', () => {
+    const events: UiEvent[] = [];
+    for (let index = 0; index < 12; index += 1) {
+      events.push(event({ role: 'user', body: `질문 ${index}` }));
+      events.push(event({ kind: 'text_reply', body: `답변 ${index}` }));
+    }
+
+    const turns = pairChatTurns(events, 10);
+
+    expect(turns).toHaveLength(10);
+    expect(turns[0].text).toBe('질문 2');
+    expect(turns.filter((turn) => turn.isLatest)).toHaveLength(1);
+    expect(turns.at(-1)?.text).toBe('질문 11');
+    expect(turns.at(-1)?.isLatest).toBe(true);
+  });
+
+  it('ignores agent replies that arrive before any user turn', () => {
+    const strayReply = event({ kind: 'text_reply', body: '떠돌이 답변' });
+    const user = event({ role: 'user', body: '질문' });
+
+    const turns = pairChatTurns([strayReply, user], 10);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].agentText).toBeNull();
+  });
+});
+
+describe('isWorkspaceRunStepEvent', () => {
+  it('counts work events and excludes replies and thinking', () => {
+    expect(isWorkspaceRunStepEvent(event({ kind: 'command_execution' }))).toBe(true);
+    expect(isWorkspaceRunStepEvent(event({ kind: 'file_write' }))).toBe(true);
+    expect(isWorkspaceRunStepEvent(event({ kind: 'text_reply' }))).toBe(false);
+    expect(isWorkspaceRunStepEvent(event({ kind: 'think' }))).toBe(false);
+    expect(isWorkspaceRunStepEvent(event({ kind: 'unknown' }))).toBe(false);
+  });
+});

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -474,7 +474,9 @@ describe('project list surface', () => {
     expect(projectChatSurface).toContain('className="ws-card__title">Run ·');
     expect(projectChatSurface).toContain('className="ws-card__meta"');
     expect(projectChatSurface).toContain('className="run-step ws-run-step"');
-    expect(projectChatSurface).toContain('className="run-step__dot ws-run-step__dot run-step__dot--done ws-run-step__dot--done"');
+    // 스텝 dot은 런 활성 중 최신 작업이 running, 나머지는 done — 실상태 반영.
+    expect(projectChatSurface).toContain("item.running ? 'run-step__dot--running ws-run-step__dot--running' : 'run-step__dot--done ws-run-step__dot--done'");
+    expect(projectChatSurface).toContain('<span className="run-summary__label">Duration</span>');
     expect(projectChatSurface).toContain('className="run-step__body ws-run-step__body"');
     expect(projectChatSurface).toContain('className="run-step__time ws-run-step__time"');
     expect(projectChatSurface).toContain('className="ws-empty-state"');


### PR DESCRIPTION
## 배경

사이드바 실동작 전환 설계(#402)의 **PR-2**. Run 탭의 가짜 상태(dot 항상 done, 4건 제한)와 Chat history의 왜곡(최고 턴 항상 "running", 모든 턴에 동일 응답 복제)을 실데이터로 교체한다.

## Run 탭

- **스텝 소스**: 전체 이벤트 최근 4건 → 작업성 이벤트 전체(`isWorkspaceRunStepEvent`: run/exec/git/docker/command 실행 + file read/write/list). 텍스트 응답·think는 스텝이 아니다.
- **dot 실상태**: 런 활성 중 최신 작업만 `--running`(기존 pulse CSS 재사용), 나머지 `--done`. 이벤트에 실행 계획 정보가 없어 스펙의 `pending`은 표현 불가(제외 명시).
- **Duration 셀 신설**: `projectRunIndicator.startedAt`부터 실측 경과. 컴포저 런 칩이 쓰던 1초 tick(`projectRunNowMs`)에 편승 — 새 타이머 없음.
- **스텝 클릭 = 타임라인 점프**(기존: 복사만). 커맨드 복사는 타임라인의 액션 카드에 이미 있다.

## Chat history

- **`pairChatTurns` 순수 함수**: 각 user 턴에 "다음 user 이벤트 전 마지막 에이전트 `text_reply`"를 페어링. terminal 출력은 에이전트 답변이 아니므로 제외. 기존 구현은 타임라인의 **첫** 에이전트 이벤트 하나를 **모든 턴에** 붙였다.
- **state 실측**: 마지막 턴 && 런 활성일 때만 `running`. 기존은 가장 오래된 턴이 무조건 "running"이었다.
- 최근 3턴 → **10턴**, 기본 펼침은 최신 턴. 응답 없는 턴은 상태별 안내 문구.
- 목업 Preview 버튼 제거(PR-6에서 실물로 복귀).

## Jump 실동작

타임라인 msg 래퍼 4종에 `data-event-id` 앵커를 달고, Jump/스텝 클릭 시 해당 이벤트로 `scrollIntoView({block:'center'})` + 하이라이트. 기존 구현은 무조건 타임라인 최상단으로 스크롤했다. 밀도 스택으로 접힌 이벤트는 앵커가 없어 상단 폴백.

## 검증

- 신규 단위 테스트 5건(`projectChatTurnPairs.test.ts`): 턴 페어링, 마지막 응답 선택, terminal/작업 이벤트 제외, latest 단일성, limit, 스텝 판별
- 정적 단언 갱신: dot 실상태 표현식·Duration 셀 강제
- `tsc` 클린, vitest 126 파일/**634 테스트** 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxfd4yi1xRpXZHvjuggvTW
