### PR TITLE
feat(web): 사이드바 Terminal 원샷 러너 + Files 탭 git 배지 (PR-3)

### DIFF
--- a/services/aris-web/app/styles/project-chat/workspace.css
+++ b/services/aris-web/app/styles/project-chat/workspace.css
@@ -491,6 +491,143 @@
   flex-shrink: 0;
 }
 
+/* 사이드바 터미널 원샷 러너 (실행 콘솔) */
+.pc-proto .term__err {
+  color: #E5877E;
+}
+
+.pc-proto .term__clear {
+  border: 0;
+  background: none;
+  color: var(--text-tertiary);
+  font-size: var(--text-2xs, 10px);
+  cursor: pointer;
+}
+
+.pc-proto .term__clear:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.pc-proto .term__entry {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 2px 0;
+}
+
+.pc-proto .term__output {
+  margin: 0;
+  max-height: 220px;
+  overflow: auto;
+  padding: 4px 0 4px 14px;
+  color: var(--text-secondary);
+  font-size: var(--text-2xs, 10px);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.pc-proto .term__input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.pc-proto .term__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  outline: none;
+}
+
+.pc-proto .term__input::placeholder {
+  color: var(--text-tertiary);
+}
+
+/* Files 탭 git 상태 배지 */
+.pc-proto .file-row__badge {
+  flex: 0 0 auto;
+  min-width: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  text-align: center;
+  font-size: var(--text-2xs, 10px);
+  font-weight: 600;
+  color: #C9CDD6;
+  background: rgba(127, 127, 127, 0.18);
+}
+
+.pc-proto .file-row__badge[data-tone='modified'] {
+  color: #E8C06B;
+  background: rgba(232, 192, 107, 0.14);
+}
+
+.pc-proto .file-row__badge[data-tone='new'] {
+  color: #8BCF9A;
+  background: rgba(46, 160, 67, 0.14);
+}
+
+.pc-proto .file-row__badge[data-tone='staged'] {
+  color: #7FB4FF;
+  background: rgba(47, 107, 255, 0.16);
+}
+
+.pc-proto .file-row__badge[data-tone='conflict'] {
+  color: #E5877E;
+  background: rgba(248, 81, 73, 0.16);
+}
+
+/* 저장 스니펫 */
+.pc-proto .snip-group__save {
+  border: 0;
+  background: none;
+  color: var(--b-500, #2F6BFF);
+  font-size: var(--text-2xs, 10px);
+  cursor: pointer;
+}
+
+.pc-proto .snip-group__save:disabled {
+  color: var(--text-tertiary);
+  cursor: default;
+}
+
+.pc-proto .snip-row--saved {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+}
+
+.pc-proto .snip-row--saved .snip-row__insert {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  border: 0;
+  background: none;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.pc-proto .snip-row__remove {
+  flex: 0 0 auto;
+  border: 0;
+  background: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+
+.pc-proto .snip-row__remove:hover {
+  color: #E5877E;
+}
+
 .pc-proto .term__ok {
   color: #8BCF9A;
 }

--- a/services/aris-web/components/project-chat/ProjectChatSurface.tsx
+++ b/services/aris-web/components/project-chat/ProjectChatSurface.tsx
@@ -118,6 +118,8 @@ import { buildProjectChatTimelineItems } from '@/components/project-chat/permiss
 import { WorkspaceSidebar } from '@/components/project-chat/workspace/WorkspaceSidebar';
 import { GitDiffOverlay } from '@/components/project-chat/workspace/GitDiffOverlay';
 import { useWorkspaceGit } from '@/components/project-chat/workspace/hooks/useWorkspaceGit';
+import { useTerminalRunner } from '@/components/project-chat/workspace/hooks/useTerminalRunner';
+import { useSavedTerminalSnippets } from '@/components/project-chat/workspace/hooks/useSavedTerminalSnippets';
 import { ProjectPreviewOverlay } from '@/components/project-chat/workspace/PreviewOverlay';
 import { useDensityStore } from './cmd-display/densityStore';
 import { computeAutoDensity } from './cmd-display/densityRules';
@@ -1285,7 +1287,7 @@ export function ProjectChatSurface({
   } | null>(null);
   const [workspaceFilePreviewLoading, setWorkspaceFilePreviewLoading] = useState(false);
   const [workspaceFilePreviewSaving, setWorkspaceFilePreviewSaving] = useState(false);
-  const [draftTerminalCommand, setDraftTerminalCommand] = useState('npm test -- --run tests/projectListSurface.test.ts');
+  const [draftTerminalCommand, setDraftTerminalCommand] = useState('');
   const [previewDevice, setPreviewDevice] = useState<'1200' | '768' | '390'>('1200');
   const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
   const [showJumpToLatest, setShowJumpToLatest] = useState(false);
@@ -1490,6 +1492,17 @@ export function ProjectChatSurface({
   });
   // 패널이 없으면 프로젝트 루트 git status로 폴백한다(과거: 영구 에러 상태).
   const workspaceGit = useWorkspaceGit(projectId, activeWorkspacePanelId, workspaceTab === 'git');
+  const mergeTerminalEvents = useCallback((submitted: UiEvent[]) => {
+    setEvents((previous) => mergeProjectChatEvents([...previous, ...submitted]));
+  }, []);
+  const workspaceTerminal = useTerminalRunner({
+    projectId,
+    chatId: activeWorkspaceChat?.id ?? activeChat?.id ?? null,
+    workspacePanelId: activeWorkspacePanelId,
+    // 패널 채팅 이벤트는 해당 패널의 폴링이 수거한다 — 메인 타임라인에만 즉시 병합.
+    onEvents: activeWorkspacePanelId ? undefined : mergeTerminalEvents,
+  });
+  const savedTerminalSnippets = useSavedTerminalSnippets(projectId);
   const workspaceGitDiffReqRef = useRef(0);
   const openWorkspaceGitDiff = useCallback((file: ProjectPanelGitFile) => {
     const scope: WorkspaceGitDiff['scope'] = file.staged && !file.unstaged && !file.untracked ? 'staged' : 'working';
@@ -2857,6 +2870,8 @@ export function ProjectChatSurface({
             refreshWorkspaceGit={workspaceGit.refresh}
             activeWorkspacePanelRuntime={activeWorkspacePanelRuntime}
             draftTerminalCommand={draftTerminalCommand}
+            setDraftTerminalCommand={setDraftTerminalCommand}
+            terminal={workspaceTerminal}
             onOpenGitDiff={openWorkspaceGitDiff}
             handleCopy={handleCopy}
             session={session}
@@ -3283,6 +3298,8 @@ export function ProjectChatSurface({
           refreshWorkspaceGit={workspaceGit.refresh}
           activeWorkspacePanelRuntime={activeWorkspacePanelRuntime}
           draftTerminalCommand={draftTerminalCommand}
+          setDraftTerminalCommand={setDraftTerminalCommand}
+          terminal={workspaceTerminal}
           onOpenGitDiff={openWorkspaceGitDiff}
           handleCopy={handleCopy}
           session={session}
@@ -3303,8 +3320,7 @@ export function ProjectChatSurface({
           activeAgent={activeAgent}
           composerMode={composerMode}
           terminalSnippets={terminalSnippets}
-          setDraftTerminalCommand={setDraftTerminalCommand}
-          setPrompt={setPrompt}
+          savedSnippets={savedTerminalSnippets}
         />
       </div>
       <ProjectPreviewOverlay

--- a/services/aris-web/components/project-chat/projectChatSurfaceUtils.ts
+++ b/services/aris-web/components/project-chat/projectChatSurfaceUtils.ts
@@ -684,3 +684,41 @@ export function pairChatTurns(events: UiEvent[], limit: number): ProjectChatTurn
   }
   return turns.slice(-limit);
 }
+
+export type WorkspaceFileBadge = {
+  label: string;
+  tone: 'conflict' | 'new' | 'staged' | 'modified';
+};
+
+// /workspace 가상 경로를 저장소 상대 경로로 환원한다.
+export function relativeWorkspacePath(path: string): string {
+  return path.replace(/^\/workspace\/?/, '');
+}
+
+// Files 탭 행에 붙일 git 상태 배지. 워크스페이스 루트가 저장소 루트의 하위
+// 폴더일 수 있어(git 경로는 저장소 루트 기준) suffix 매칭을 폴백으로 둔다.
+export function matchWorkspaceFileBadge(
+  files: ProjectPanelGitFile[],
+  itemPath: string,
+  isDirectory: boolean,
+): WorkspaceFileBadge | null {
+  const rel = relativeWorkspacePath(itemPath);
+  if (!rel) return null;
+
+  if (isDirectory) {
+    const prefix = `${rel}/`;
+    let count = files.filter((file) => file.path.startsWith(prefix)).length;
+    if (count === 0) {
+      count = files.filter((file) => file.path.includes(`/${prefix}`)).length;
+    }
+    return count > 0 ? { label: String(count), tone: 'modified' } : null;
+  }
+
+  const match = files.find((file) => file.path === rel)
+    ?? files.find((file) => file.path.endsWith(`/${rel}`));
+  if (!match) return null;
+  if (match.conflicted) return { label: 'C', tone: 'conflict' };
+  if (match.untracked) return { label: 'U', tone: 'new' };
+  if (match.staged && !match.unstaged) return { label: 'A', tone: 'staged' };
+  return { label: 'M', tone: 'modified' };
+}

--- a/services/aris-web/components/project-chat/workspace/WorkspaceSidebar.tsx
+++ b/services/aris-web/components/project-chat/workspace/WorkspaceSidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Dispatch, RefObject, SetStateAction } from 'react';
+import type { RefObject } from 'react';
 import {
   Bot,
   ChevronRight,
@@ -24,11 +24,14 @@ import { MarkdownContent } from '@/components/chat/MarkdownContent';
 import { GitActionMark } from '@/components/project-chat/helpers/actionMarks';
 import type { SessionChat, SessionSummary } from '@/lib/happy/types';
 import type { WorkspaceFileItem, WorkspaceFilesApi } from '@/lib/hooks/useWorkspaceFiles';
+import type { WorkspaceTerminalApi } from './hooks/useTerminalRunner';
+import type { SavedTerminalSnippetsApi } from './hooks/useSavedTerminalSnippets';
 import {
   COMPOSER_MODE_COPY,
   agentAvatarClass,
   agentLabel,
   formatRelativeTime,
+  matchWorkspaceFileBadge,
   projectStatusLabel,
   providerFromAgent,
   type ComposerMode,
@@ -72,6 +75,8 @@ type WorkspaceSidebarCommonProps = {
   refreshWorkspaceGit: () => void;
   activeWorkspacePanelRuntime: ProjectWorkspacePanelRuntime | null;
   draftTerminalCommand: string;
+  setDraftTerminalCommand: (value: string) => void;
+  terminal: WorkspaceTerminalApi;
   onOpenGitDiff: (file: ProjectPanelGitFile) => void;
   handleCopy: (value: string, label: string) => void;
   session: SessionSummary;
@@ -103,8 +108,7 @@ type ProjectWorkspaceSidebarProps = WorkspaceSidebarCommonProps & {
   activeAgent: SessionSummary['agent'];
   composerMode: ComposerMode;
   terminalSnippets: WorkspaceTerminalSnippet[];
-  setDraftTerminalCommand: (value: string) => void;
-  setPrompt: Dispatch<SetStateAction<string>>;
+  savedSnippets: SavedTerminalSnippetsApi;
 };
 
 export type WorkspaceSidebarProps = PanelWorkspaceSidebarProps | ProjectWorkspaceSidebarProps;
@@ -130,9 +134,10 @@ function WorkspaceFilesPane({
   workspaceFiles,
   selectedWorkspaceFile,
   openWorkspaceFilePreview,
+  workspaceGitOverview,
 }: Pick<
   WorkspaceSidebarCommonProps,
-  'workspaceTab' | 'workspaceFiles' | 'selectedWorkspaceFile' | 'openWorkspaceFilePreview'
+  'workspaceTab' | 'workspaceFiles' | 'selectedWorkspaceFile' | 'openWorkspaceFilePreview' | 'workspaceGitOverview'
 >) {
   return (
     <div className={`ws__pane${workspaceTab === 'files' ? ' ws__pane--active' : ''}`} data-pane="files">
@@ -171,26 +176,32 @@ function WorkspaceFilesPane({
         {!workspaceFiles.loading && !workspaceFiles.error && workspaceFiles.items.length === 0 && (
           <div className="file-row file-row--state">빈 디렉터리</div>
         )}
-        {workspaceFiles.items.map((file: WorkspaceFileItem) => (
-          <button
-            key={file.path}
-            type="button"
-            className={`file-row${selectedWorkspaceFile === file.path ? ' file-row--selected' : ''}`}
-            onClick={() => {
-              if (file.isDirectory) {
-                workspaceFiles.cdInto(file);
-              } else {
-                openWorkspaceFilePreview(file);
-              }
-            }}
-          >
-            <span className={`file-row__icon${file.isDirectory ? ' file-row__icon--dir' : ''}`}>
-              {file.isDirectory ? <FolderOpen size={13} /> : <FileText size={13} />}
-            </span>
-            <span className="file-row__name">{file.name}</span>
-            <span className="file-row__meta">{file.isDirectory ? 'dir' : 'file'}</span>
-          </button>
-        ))}
+        {workspaceFiles.items.map((file: WorkspaceFileItem) => {
+          const badge = workspaceGitOverview
+            ? matchWorkspaceFileBadge(workspaceGitOverview.files, file.path, file.isDirectory)
+            : null;
+          return (
+            <button
+              key={file.path}
+              type="button"
+              className={`file-row${selectedWorkspaceFile === file.path ? ' file-row--selected' : ''}`}
+              onClick={() => {
+                if (file.isDirectory) {
+                  workspaceFiles.cdInto(file);
+                } else {
+                  openWorkspaceFilePreview(file);
+                }
+              }}
+            >
+              <span className={`file-row__icon${file.isDirectory ? ' file-row__icon--dir' : ''}`}>
+                {file.isDirectory ? <FolderOpen size={13} /> : <FileText size={13} />}
+              </span>
+              <span className="file-row__name">{file.name}</span>
+              {badge && <span className="file-row__badge" data-tone={badge.tone}>{badge.label}</span>}
+              <span className="file-row__meta">{file.isDirectory ? 'dir' : 'file'}</span>
+            </button>
+          );
+        })}
       </div>
     </div>
   );
@@ -266,6 +277,80 @@ function WorkspaceGitPane({
   );
 }
 
+function WorkspaceTerminalConsole({
+  terminal,
+  draftTerminalCommand,
+  setDraftTerminalCommand,
+  disabled,
+  tag,
+  contextLine,
+}: Pick<WorkspaceSidebarCommonProps, 'terminal' | 'draftTerminalCommand' | 'setDraftTerminalCommand'> & {
+  disabled: boolean;
+  tag: string;
+  contextLine: string | null;
+}) {
+  return (
+    <div className="term">
+      <div className="term__head">
+        <div className="term__head-left">
+          <span className="term__dots"><span className="term__dot term__dot--r" /><span className="term__dot term__dot--y" /><span className="term__dot term__dot--g" /></span>
+          <span className="term__tag">{tag}</span>
+        </div>
+        <button
+          type="button"
+          className="term__clear"
+          onClick={terminal.clear}
+          disabled={terminal.entries.length === 0}
+        >
+          Clear
+        </button>
+      </div>
+      <div className="term__body">
+        {contextLine ? <div className="term__line"><span className="term__dim">{contextLine}</span></div> : null}
+        {terminal.entries.length === 0 ? (
+          <div className="term__line"><span className="term__dim">명령을 입력하면 워크스페이스에서 실행됩니다 (30초 제한 · 출력 12k 잘림 · 결과는 타임라인에 기록).</span></div>
+        ) : null}
+        {terminal.entries.map((entry) => (
+          <div key={entry.id} className="term__entry">
+            <div className="term__line"><span className="term__prompt">$</span><span>{entry.command}</span></div>
+            {entry.output ? <pre className="term__output">{entry.output}</pre> : null}
+            {entry.running ? (
+              <div className="term__line"><span className="term__dim">실행 중…</span></div>
+            ) : entry.error ? (
+              <div className="term__line"><span className="term__err">✗</span><span className="term__dim">{entry.error}</span></div>
+            ) : (
+              <div className="term__line">
+                {entry.exitCode === 0 ? <span className="term__ok">✓</span> : <span className="term__err">✗</span>}
+                <span className="term__dim">exit {entry.exitCode ?? '?'}</span>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <form
+        className="term__input-row"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const command = draftTerminalCommand.trim();
+          if (!command || terminal.running || disabled) return;
+          terminal.run(command);
+          setDraftTerminalCommand('');
+        }}
+      >
+        <span className="term__prompt">$</span>
+        <input
+          className="term__input"
+          value={draftTerminalCommand}
+          onChange={(event) => setDraftTerminalCommand(event.target.value)}
+          placeholder={disabled ? '채팅을 선택하면 실행할 수 있습니다' : '명령 입력 후 Enter'}
+          disabled={disabled || terminal.running}
+          aria-label="터미널 명령"
+        />
+      </form>
+    </div>
+  );
+}
+
 function WorkspaceSubagentsPane({
   workspaceTab,
   session,
@@ -293,6 +378,8 @@ function PanelWorkspaceSidebar({
   refreshWorkspaceGit,
   activeWorkspacePanelRuntime,
   draftTerminalCommand,
+  setDraftTerminalCommand,
+  terminal,
   onOpenGitDiff,
   handleCopy,
   session,
@@ -347,6 +434,7 @@ function PanelWorkspaceSidebar({
           workspaceFiles={workspaceFiles}
           selectedWorkspaceFile={selectedWorkspaceFile}
           openWorkspaceFilePreview={openWorkspaceFilePreview}
+          workspaceGitOverview={workspaceGitOverview}
         />
         <WorkspaceGitPane
           workspaceTab={workspaceTab}
@@ -360,13 +448,14 @@ function PanelWorkspaceSidebar({
           onOpenGitDiff={onOpenGitDiff}
         />
         <div className={`ws__pane${workspaceTab === 'terminal' ? ' ws__pane--active' : ''}`} data-pane="terminal">
-          <div className="term">
-            <div className="term__head"><span className="term__tag">bash · selected panel</span><span className="term__dim">{activeWorkspacePanelRuntime?.runtimeSessionId ?? projectId}</span></div>
-            <div className="term__body">
-              <div className="term__line"><span className="term__prompt">~/aris$</span><span>{draftTerminalCommand}</span></div>
-              <div className="term__line"><span className="term__dim">cwd · {activeWorkspacePanelRuntime?.worktreePath ?? projectPath}</span></div>
-            </div>
-          </div>
+          <WorkspaceTerminalConsole
+            terminal={terminal}
+            draftTerminalCommand={draftTerminalCommand}
+            setDraftTerminalCommand={setDraftTerminalCommand}
+            disabled={!activeWorkspaceChat}
+            tag="bash · selected panel"
+            contextLine={`cwd · ${activeWorkspacePanelRuntime?.worktreePath ?? projectPath}`}
+          />
         </div>
         <div className={`ws__pane${workspaceTab === 'context' ? ' ws__pane--active' : ''}`} data-pane="context">
           <div className="ctx-group">
@@ -395,6 +484,8 @@ function ProjectWorkspaceSidebar({
   refreshWorkspaceGit,
   activeWorkspacePanelRuntime,
   draftTerminalCommand,
+  setDraftTerminalCommand,
+  terminal,
   onOpenGitDiff,
   handleCopy,
   session,
@@ -415,8 +506,7 @@ function ProjectWorkspaceSidebar({
   activeAgent,
   composerMode,
   terminalSnippets,
-  setDraftTerminalCommand,
-  setPrompt,
+  savedSnippets,
 }: ProjectWorkspaceSidebarProps) {
   return (
     <aside ref={workspaceRef} className="shell__workspace ws ws-pane" aria-label={`${projectName} workspace`}>
@@ -536,6 +626,7 @@ function ProjectWorkspaceSidebar({
           workspaceFiles={workspaceFiles}
           selectedWorkspaceFile={selectedWorkspaceFile}
           openWorkspaceFilePreview={openWorkspaceFilePreview}
+          workspaceGitOverview={workspaceGitOverview}
         />
         <WorkspaceGitPane
           workspaceTab={workspaceTab}
@@ -549,39 +640,57 @@ function ProjectWorkspaceSidebar({
           onOpenGitDiff={onOpenGitDiff}
         />
         <div className={`ws__pane${workspaceTab === 'terminal' ? ' ws__pane--active' : ''}`} data-pane="terminal">
-          <div className="term">
-            <div className="term__head">
-              <div className="term__head-left">
-                <span className="term__dots"><span className="term__dot term__dot--r" /><span className="term__dot term__dot--y" /><span className="term__dot term__dot--g" /></span>
-                <span className="term__tag">bash · project chat</span>
-              </div>
-              <span className="term__dim">{composerMode}</span>
-            </div>
-            <div className="term__body">
-              <div className="term__line"><span className="term__prompt">~/aris$</span><span>{draftTerminalCommand}</span></div>
-              <div className="term__line"><span className="term__dim">selected · {selectedWorkspaceFile}</span></div>
-              <div className="term__line"><span className="term__ok">✓</span><span>ready to run in this project context</span></div>
-            </div>
-          </div>
+          <WorkspaceTerminalConsole
+            terminal={terminal}
+            draftTerminalCommand={draftTerminalCommand}
+            setDraftTerminalCommand={setDraftTerminalCommand}
+            disabled={!activeChat}
+            tag="bash · project chat"
+            contextLine={null}
+          />
           <div className="snip-group">
             <div className="snip-group__head">
               <span className="snip-group__label"><Terminal size={12} />Snippets</span>
-              <span className="snip-group__count">{terminalSnippets.length}</span>
+              <button
+                type="button"
+                className="snip-group__save"
+                onClick={() => savedSnippets.save(draftTerminalCommand)}
+                disabled={!draftTerminalCommand.trim()}
+              >
+                현재 명령 저장
+              </button>
             </div>
             {terminalSnippets.map((snippet) => (
               <button
                 key={snippet.id}
                 type="button"
                 className="snip-row"
-                onClick={() => {
-                  setDraftTerminalCommand(snippet.cmd);
-                  setPrompt((value) => value || snippet.cmd);
-                }}
+                onClick={() => setDraftTerminalCommand(snippet.cmd)}
               >
                 <span className="snip-row__name">{snippet.name}</span>
                 <span className="snip-row__cmd">{snippet.cmd}</span>
                 <span className="snip-row__tag">{snippet.tag}</span>
               </button>
+            ))}
+            {savedSnippets.snippets.map((snippet) => (
+              <div key={snippet.id} className="snip-row snip-row--saved">
+                <button
+                  type="button"
+                  className="snip-row__insert"
+                  onClick={() => setDraftTerminalCommand(snippet.cmd)}
+                >
+                  <span className="snip-row__name">saved</span>
+                  <span className="snip-row__cmd">{snippet.cmd}</span>
+                </button>
+                <button
+                  type="button"
+                  className="snip-row__remove"
+                  aria-label="스니펫 삭제"
+                  onClick={() => savedSnippets.remove(snippet.id)}
+                >
+                  <X size={11} />
+                </button>
+              </div>
             ))}
           </div>
         </div>

--- a/services/aris-web/components/project-chat/workspace/hooks/useSavedTerminalSnippets.ts
+++ b/services/aris-web/components/project-chat/workspace/hooks/useSavedTerminalSnippets.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { readLocalStorage, writeLocalStorage } from '@/lib/browser/localStorage';
+
+export type SavedTerminalSnippet = {
+  id: string;
+  cmd: string;
+};
+
+export type SavedTerminalSnippetsApi = {
+  snippets: SavedTerminalSnippet[];
+  save: (cmd: string) => void;
+  remove: (id: string) => void;
+};
+
+function storageKey(projectId: string): string {
+  return `aris.term-snippets.${projectId}`;
+}
+
+function parseSnippets(raw: string | null): SavedTerminalSnippet[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((item): item is SavedTerminalSnippet => !!item
+        && typeof item === 'object'
+        && typeof (item as SavedTerminalSnippet).id === 'string'
+        && typeof (item as SavedTerminalSnippet).cmd === 'string')
+      .slice(0, 20);
+  } catch {
+    return [];
+  }
+}
+
+// 프로젝트별 사용자 저장 스니펫 — localStorage 보관(DB 동기화는 범위 외).
+export function useSavedTerminalSnippets(projectId: string): SavedTerminalSnippetsApi {
+  const [snippets, setSnippets] = useState<SavedTerminalSnippet[]>([]);
+
+  useEffect(() => {
+    setSnippets(parseSnippets(readLocalStorage(storageKey(projectId))));
+  }, [projectId]);
+
+  const persist = useCallback((next: SavedTerminalSnippet[]) => {
+    setSnippets(next);
+    writeLocalStorage(storageKey(projectId), JSON.stringify(next));
+  }, [projectId]);
+
+  const save = useCallback((cmd: string) => {
+    const trimmed = cmd.trim();
+    if (!trimmed) return;
+    setSnippets((current) => {
+      if (current.some((item) => item.cmd === trimmed)) return current;
+      const next = [...current, { id: `saved-${Date.now()}-${current.length}`, cmd: trimmed }].slice(-20);
+      writeLocalStorage(storageKey(projectId), JSON.stringify(next));
+      return next;
+    });
+  }, [projectId]);
+
+  const remove = useCallback((id: string) => {
+    setSnippets((current) => {
+      const next = current.filter((item) => item.id !== id);
+      writeLocalStorage(storageKey(projectId), JSON.stringify(next));
+      return next;
+    });
+  }, [projectId]);
+
+  return { snippets, save, remove };
+}

--- a/services/aris-web/components/project-chat/workspace/hooks/useTerminalRunner.ts
+++ b/services/aris-web/components/project-chat/workspace/hooks/useTerminalRunner.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import type { UiEvent } from '@/lib/happy/types';
+import { withAppBasePath } from '@/lib/routing/appPath';
+import { buildProjectRuntimeTerminalPath } from '@/lib/projectRuntimeAdapter';
+import { terminalOutput } from '../../projectChatSurfaceUtils';
+
+export type WorkspaceTerminalEntry = {
+  id: string;
+  command: string;
+  output: string;
+  exitCode: number | null;
+  running: boolean;
+  error: string | null;
+};
+
+export type WorkspaceTerminalApi = {
+  entries: WorkspaceTerminalEntry[];
+  running: boolean;
+  run: (command: string) => void;
+  clear: () => void;
+};
+
+function readExitCode(event: UiEvent | undefined): number | null {
+  const value = event?.meta?.exitCode;
+  return typeof value === 'number' ? value : null;
+}
+
+// 사이드바 Terminal 탭의 원샷 커맨드 러너. 컴포저 Terminal 모드와 같은
+// 엔드포인트를 쓴다 — 백엔드가 30초 타임아웃 bash로 실행하고 결과를 채팅
+// 이벤트로 영구 저장한다(감사 추적). 여기 entries는 화면 표시용 사본이다.
+export function useTerminalRunner(input: {
+  projectId: string;
+  chatId: string | null;
+  workspacePanelId: string | null;
+  onEvents?: (events: UiEvent[]) => void;
+}): WorkspaceTerminalApi {
+  const { projectId, chatId, workspacePanelId, onEvents } = input;
+  const [entries, setEntries] = useState<WorkspaceTerminalEntry[]>([]);
+  const [running, setRunning] = useState(false);
+  const entrySeqRef = useRef(0);
+
+  const run = useCallback((command: string) => {
+    const trimmed = command.trim();
+    if (!trimmed || running) return;
+    entrySeqRef.current += 1;
+    const entryId = `term-${entrySeqRef.current}`;
+    if (!chatId) {
+      setEntries((previous) => [...previous, {
+        id: entryId,
+        command: trimmed,
+        output: '',
+        exitCode: null,
+        running: false,
+        error: '명령을 실행하려면 먼저 채팅을 선택하세요.',
+      }]);
+      return;
+    }
+    setRunning(true);
+    setEntries((previous) => [...previous, {
+      id: entryId,
+      command: trimmed,
+      output: '',
+      exitCode: null,
+      running: true,
+      error: null,
+    }]);
+    void fetch(withAppBasePath(buildProjectRuntimeTerminalPath(projectId)), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chatId,
+        command: trimmed,
+        ...(workspacePanelId ? { workspacePanelId } : {}),
+      }),
+    })
+      .then(async (response) => {
+        const body = (await response.json().catch(() => ({}))) as { events?: UiEvent[]; error?: string };
+        if (!response.ok || !body.events?.length) {
+          throw new Error(body.error ?? '터미널 명령 실행에 실패했습니다.');
+        }
+        const resultEvent = body.events[body.events.length - 1];
+        setEntries((previous) => previous.map((entry) => (entry.id === entryId
+          ? {
+              ...entry,
+              running: false,
+              output: terminalOutput(resultEvent),
+              exitCode: readExitCode(resultEvent),
+            }
+          : entry)));
+        onEvents?.(body.events);
+      })
+      .catch((error) => {
+        setEntries((previous) => previous.map((entry) => (entry.id === entryId
+          ? {
+              ...entry,
+              running: false,
+              error: error instanceof Error ? error.message : '터미널 명령 실행에 실패했습니다.',
+            }
+          : entry)));
+      })
+      .finally(() => setRunning(false));
+  }, [chatId, onEvents, projectId, running, workspacePanelId]);
+
+  const clear = useCallback(() => {
+    setEntries([]);
+  }, []);
+
+  return { entries, running, run, clear };
+}

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -502,6 +502,14 @@ describe('project list surface', () => {
     expect(projectChatSurface).toContain('trackedFileCount');
   });
 
+  it('runs sidebar terminal commands through the real terminal endpoint', () => {
+    // Terminal 탭은 그림이 아니라 원샷 러너다 — 정적 목업 문구 재유입 방지.
+    expect(projectChatSurface).toContain('useTerminalRunner({');
+    expect(projectChatSurface).toContain('className="term__input"');
+    expect(projectChatSurface).not.toContain('ready to run in this project context');
+    expect(projectChatSurface).toContain('matchWorkspaceFileBadge');
+  });
+
   it('renders functional workspace panes instead of one static Run panel', () => {
     expect(projectChatSurface).toContain("workspaceTab === 'run'");
     expect(projectChatSurface).toContain("workspaceTab === 'files'");

--- a/services/aris-web/tests/workspaceFileBadge.test.ts
+++ b/services/aris-web/tests/workspaceFileBadge.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  matchWorkspaceFileBadge,
+  relativeWorkspacePath,
+  type ProjectPanelGitFile,
+} from '@/components/project-chat/projectChatSurfaceUtils';
+
+function gitFile(path: string, overrides: Partial<ProjectPanelGitFile> = {}): ProjectPanelGitFile {
+  return {
+    path,
+    indexStatus: ' ',
+    workTreeStatus: 'M',
+    staged: false,
+    unstaged: true,
+    untracked: false,
+    conflicted: false,
+    ...overrides,
+  };
+}
+
+describe('matchWorkspaceFileBadge', () => {
+  const files = [
+    gitFile('src/app.ts'),
+    gitFile('src/new.ts', { untracked: true, unstaged: false, workTreeStatus: '?' }),
+    gitFile('src/staged.ts', { staged: true, unstaged: false, indexStatus: 'A', workTreeStatus: ' ' }),
+    gitFile('docs/conflict.md', { conflicted: true }),
+  ];
+
+  it('labels files by their git state', () => {
+    expect(matchWorkspaceFileBadge(files, '/workspace/src/app.ts', false)).toEqual({ label: 'M', tone: 'modified' });
+    expect(matchWorkspaceFileBadge(files, '/workspace/src/new.ts', false)).toEqual({ label: 'U', tone: 'new' });
+    expect(matchWorkspaceFileBadge(files, '/workspace/src/staged.ts', false)).toEqual({ label: 'A', tone: 'staged' });
+    expect(matchWorkspaceFileBadge(files, '/workspace/docs/conflict.md', false)).toEqual({ label: 'C', tone: 'conflict' });
+    expect(matchWorkspaceFileBadge(files, '/workspace/src/clean.ts', false)).toBeNull();
+  });
+
+  it('counts changed files under a directory', () => {
+    expect(matchWorkspaceFileBadge(files, '/workspace/src', true)).toEqual({ label: '3', tone: 'modified' });
+    expect(matchWorkspaceFileBadge(files, '/workspace/docs', true)).toEqual({ label: '1', tone: 'modified' });
+    expect(matchWorkspaceFileBadge(files, '/workspace/lib', true)).toBeNull();
+  });
+
+  it('falls back to suffix matching when the workspace root is a repo subfolder', () => {
+    // git 경로는 저장소 루트 기준(services/aris-web/...), 워크스페이스는 그 하위.
+    const nested = [gitFile('services/aris-web/src/app.ts')];
+    expect(matchWorkspaceFileBadge(nested, '/workspace/src/app.ts', false)).toEqual({ label: 'M', tone: 'modified' });
+    expect(matchWorkspaceFileBadge(nested, '/workspace/src', true)).toEqual({ label: '1', tone: 'modified' });
+  });
+
+  it('normalizes the /workspace virtual prefix', () => {
+    expect(relativeWorkspacePath('/workspace/a/b.ts')).toBe('a/b.ts');
+    expect(relativeWorkspacePath('/workspace')).toBe('');
+  });
+});


### PR DESCRIPTION
## 배경

사이드바 실동작 전환 설계(#402)의 **PR-3**. Terminal 탭은 정적 3줄짜리 그림이었고("✓ ready to run in this project context"), Files 탭에는 스펙이 요구한 diff 배지가 없었다.

## Terminal 탭 — 원샷 커맨드 러너

점검에서 확인했듯 **백엔드 실행 엔드포인트는 이미 있었다**(`POST /v1/chats/:chatId/terminal/commands` — bash 30초 타임아웃, 출력 12k 잘림, 결과를 채팅 이벤트로 영구 기록). 컴포저의 Terminal 모드가 이미 쓰는 웹 라우트를 사이드바에도 연결했다.

- **`useTerminalRunner` 훅**: 명령 실행 → 출력·exit code 표시(`✓ exit 0` / `✗ exit N`), 실행 중 상태, 에러 처리, Clear
- **입력줄**: 하단 `$` 프롬프트 input, Enter 실행. 채팅 미선택 시 비활성
- **타임라인 일관성**: 성공 응답의 결과 이벤트를 메인 타임라인에 즉시 병합(컴포저와 동일 패턴). 병렬 패널 명령은 해당 패널 폴링이 수거하도록 메인 병합 제외 — 패널 명령이 메인 채팅 타임라인을 오염시키지 않는다
- **병렬 모드 cwd**: `workspacePanelId`를 전달하면 기존 라우트가 패널 워크트리로 cwd를 해석한다(`resolveWorkspacePanelExecutionTargetWithRuntime` — 런타임 미생성 시 자동 보장까지 기구현). 컴포저 Terminal 모드가 프로덕션에서 이미 지나는 경로라 별도 백엔드 변경 없음
- **스니펫**: 클릭 = 입력줄 삽입(기존의 컴포저 프롬프트 오염 제거). "현재 명령 저장" → 프로젝트별 `localStorage`(최대 20개), 삭제 지원
- 하드코딩 기본 draft(`npm test -- --run tests/projectListSurface.test.ts`) 제거

## Files 탭 — git 상태 배지

- `matchWorkspaceFileBadge`: Git overview의 파일 목록과 `/workspace` 가상 경로를 매칭해 파일 행에 **M/U/A/C** 배지, 디렉터리 행에 하위 변경 파일 수 배지
- 워크스페이스 루트가 저장소 루트의 하위 폴더인 경우(git 경로는 저장소 기준) suffix 매칭 폴백
- git 정보가 없거나 로딩 전이면 배지 없이 기존 렌더 — 순수 장식 레이어

## 검증

- 신규 단위 테스트: 배지 매처 4건(상태 라벨·디렉터리 집계·suffix 폴백·경로 정규화)
- 정적 단언: 러너 연결 강제 + 목업 문구(`ready to run...`) 재유입 방지
- `tsc` 클린, vitest 127 파일/**639 테스트** 통과
- 참고: 패널 워크트리 cwd는 기존 라우트의 기구현 경로를 그대로 재사용(컴포저 Terminal 모드로 프로덕션 검증된 경로). 사이드바 경유 실기기 확인은 배포 후 실사용에서 수행

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxfd4yi1xRpXZHvjuggvTW
