### PR TITLE
feat(web): Context 탭·푸터·상태바 실측 토큰 usage 표시 (PR-5)

### DIFF
--- a/services/aris-web/app/styles/project-chat/workspace.css
+++ b/services/aris-web/app/styles/project-chat/workspace.css
@@ -491,6 +491,14 @@
   flex-shrink: 0;
 }
 
+/* 실측 usage 분해 행 — 버튼이 아닌 정적 행 */
+.pc-proto .ctx-item--static {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  cursor: default;
+}
+
 /* 사이드바 터미널 원샷 러너 (실행 콘솔) */
 .pc-proto .term__err {
   color: #E5877E;

--- a/services/aris-web/components/project-chat/ProjectChatSurface.tsx
+++ b/services/aris-web/components/project-chat/ProjectChatSurface.tsx
@@ -1219,7 +1219,7 @@ export function ProjectChatSurface({
   const [projectRunNowMs, setProjectRunNowMs] = useState(() => Date.now());
   const [error, setError] = useState<string | null>(null);
   const activeChat = selectedChatId ? chats.find((chat) => chat.id === selectedChatId) ?? null : null;
-  const { isRunning: runtimeRunning } = useSessionRuntime(projectId, selectedChatId, Boolean(selectedChatId));
+  const { isRunning: runtimeRunning, usage: chatUsage } = useSessionRuntime(projectId, selectedChatId, Boolean(selectedChatId));
   const {
     displayPermissions,
     loadingPermissionId,
@@ -1302,6 +1302,14 @@ export function ProjectChatSurface({
   const activeWorkspaceChat = activeWorkspacePanel
     ? chats.find((candidate) => candidate.id === activeWorkspacePanel.chatId) ?? activeChat
     : activeChat;
+  // 병렬 모드 사이드바의 usage는 활성 패널 채팅 기준. 일반 모드에서는 이 훅이
+  // 비활성이라 추가 폴링이 없고, 병렬 모드에서만 활성 패널 1건에 폴링이 붙는다.
+  const { usage: workspacePanelUsage } = useSessionRuntime(
+    activeWorkspacePanelRuntime?.runtimeSessionId ?? projectId,
+    activeWorkspaceChat?.id ?? null,
+    Boolean(activeWorkspacePanelId && activeWorkspaceChat),
+  );
+  const workspaceUsage = activeWorkspacePanelId ? workspacePanelUsage : chatUsage;
   const [workspaceGitDiff, setWorkspaceGitDiff] = useState<WorkspaceGitDiff | null>(null);
   const [workspaceGitDiffLoading, setWorkspaceGitDiffLoading] = useState(false);
   const visibleEvents = events;
@@ -2872,6 +2880,7 @@ export function ProjectChatSurface({
             draftTerminalCommand={draftTerminalCommand}
             setDraftTerminalCommand={setDraftTerminalCommand}
             terminal={workspaceTerminal}
+            usage={workspaceUsage}
             onOpenGitDiff={openWorkspaceGitDiff}
             handleCopy={handleCopy}
             session={session}
@@ -3300,6 +3309,7 @@ export function ProjectChatSurface({
           draftTerminalCommand={draftTerminalCommand}
           setDraftTerminalCommand={setDraftTerminalCommand}
           terminal={workspaceTerminal}
+          usage={workspaceUsage}
           onOpenGitDiff={openWorkspaceGitDiff}
           handleCopy={handleCopy}
           session={session}

--- a/services/aris-web/components/project-chat/projectChatSurfaceUtils.ts
+++ b/services/aris-web/components/project-chat/projectChatSurfaceUtils.ts
@@ -722,3 +722,24 @@ export function matchWorkspaceFileBadge(
   if (match.staged && !match.unstaged) return { label: 'A', tone: 'staged' };
   return { label: 'M', tone: 'modified' };
 }
+
+
+export function formatTokenCount(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value) || value < 0) return '—';
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+  return String(Math.round(value));
+}
+
+// 컨텍스트 사용률 = 마지막 턴의 총 토큰(입력+캐시+출력) / 모델 컨텍스트 윈도.
+// 누적 total이 아니라 lastTurn을 쓰는 이유: 누적치는 캐시 재사용 때문에 윈도를
+// 수십 배 초과할 수 있어 "지금 컨텍스트가 얼마나 찼나"와 무관하다.
+export function computeContextUsageRatio(usage: {
+  contextWindow: number | null;
+  lastTurn: { totalTokens: number } | null;
+} | null | undefined): number | null {
+  if (!usage?.contextWindow || usage.contextWindow <= 0) return null;
+  const lastTurnTokens = usage.lastTurn?.totalTokens;
+  if (lastTurnTokens == null || lastTurnTokens < 0) return null;
+  return Math.min(1, lastTurnTokens / usage.contextWindow);
+}

--- a/services/aris-web/components/project-chat/workspace/WorkspaceSidebar.tsx
+++ b/services/aris-web/components/project-chat/workspace/WorkspaceSidebar.tsx
@@ -22,7 +22,7 @@ import { ProviderLogo } from '@/components/ui/ProviderLogo';
 import { SubagentPanel } from '@/components/project-chat/SubagentPanel';
 import { MarkdownContent } from '@/components/chat/MarkdownContent';
 import { GitActionMark } from '@/components/project-chat/helpers/actionMarks';
-import type { SessionChat, SessionSummary } from '@/lib/happy/types';
+import type { ChatUsageStats, SessionChat, SessionSummary } from '@/lib/happy/types';
 import type { WorkspaceFileItem, WorkspaceFilesApi } from '@/lib/hooks/useWorkspaceFiles';
 import type { WorkspaceTerminalApi } from './hooks/useTerminalRunner';
 import type { SavedTerminalSnippetsApi } from './hooks/useSavedTerminalSnippets';
@@ -30,7 +30,9 @@ import {
   COMPOSER_MODE_COPY,
   agentAvatarClass,
   agentLabel,
+  computeContextUsageRatio,
   formatRelativeTime,
+  formatTokenCount,
   matchWorkspaceFileBadge,
   projectStatusLabel,
   providerFromAgent,
@@ -77,6 +79,7 @@ type WorkspaceSidebarCommonProps = {
   draftTerminalCommand: string;
   setDraftTerminalCommand: (value: string) => void;
   terminal: WorkspaceTerminalApi;
+  usage: ChatUsageStats | null;
   onOpenGitDiff: (file: ProjectPanelGitFile) => void;
   handleCopy: (value: string, label: string) => void;
   session: SessionSummary;
@@ -277,6 +280,74 @@ function WorkspaceGitPane({
   );
 }
 
+const CTX_RING_CIRCUMFERENCE = 214;
+
+// 실측 usage가 있으면 링(마지막 턴 컨텍스트 점유율)과 토큰 분해를 렌더한다.
+function WorkspaceContextUsage({ usage }: { usage: ChatUsageStats | null }) {
+  const ratio = computeContextUsageRatio(usage);
+  if (!usage) {
+    return (
+      <div className="ctx-group">
+        <div className="ctx-group__head"><span className="ctx-group__title">Context usage</span></div>
+        <div className="ws-empty-state">토큰 사용량이 아직 수집되지 않았습니다. 다음 런부터 실측치가 표시됩니다.</div>
+      </div>
+    );
+  }
+  const percentLabel = ratio !== null ? `${(ratio * 100).toFixed(1)}%` : '—';
+  return (
+    <>
+      <div className="ctx-summary">
+        {ratio !== null && (
+          <div className="ctx-ring" aria-label={`컨텍스트 사용률 ${percentLabel}`}>
+            <svg viewBox="0 0 80 80" width="80" height="80" aria-hidden="true">
+              <circle className="ctx-ring__track" cx="40" cy="40" r="34" strokeWidth="6" fill="none" />
+              <circle
+                className="ctx-ring__fill"
+                cx="40"
+                cy="40"
+                r="34"
+                strokeWidth="6"
+                fill="none"
+                strokeDasharray={CTX_RING_CIRCUMFERENCE}
+                strokeDashoffset={CTX_RING_CIRCUMFERENCE * (1 - ratio)}
+                strokeLinecap="round"
+              />
+            </svg>
+            <div className="ctx-ring__center">{percentLabel}</div>
+          </div>
+        )}
+        <div className="ctx-summary__body">
+          <div className="ctx-summary__title">Context usage</div>
+          <div className="ctx-summary__meta">
+            {usage.lastTurn ? `${formatTokenCount(usage.lastTurn.totalTokens)} / ${formatTokenCount(usage.contextWindow)} tokens` : `윈도 ${formatTokenCount(usage.contextWindow)} tokens`}
+          </div>
+          <div className="ctx-summary__split">
+            <div className="ctx-summary__split-cell"><div className="ctx-summary__split-label">Model</div><div className="ctx-summary__split-value">{usage.model ?? '—'}</div></div>
+            <div className="ctx-summary__split-cell"><div className="ctx-summary__split-label">Provider</div><div className="ctx-summary__split-value">{usage.provider}</div></div>
+          </div>
+        </div>
+      </div>
+      <div className="ctx-group">
+        <div className="ctx-group__head"><span className="ctx-group__title">누적 사용량</span><span className="ctx-group__count">{formatTokenCount(usage.total.totalTokens)}</span></div>
+        <div className="ctx-item ctx-item--static">
+          <span className="ctx-item__name">Input (cached 포함)</span>
+          <span className="ctx-item__tokens">{formatTokenCount(usage.total.inputTokens + usage.total.cachedInputTokens)}</span>
+        </div>
+        <div className="ctx-item ctx-item--static">
+          <span className="ctx-item__name">Output</span>
+          <span className="ctx-item__tokens">{formatTokenCount(usage.total.outputTokens)}</span>
+        </div>
+        {usage.total.reasoningOutputTokens != null && (
+          <div className="ctx-item ctx-item--static">
+            <span className="ctx-item__name">Reasoning</span>
+            <span className="ctx-item__tokens">{formatTokenCount(usage.total.reasoningOutputTokens)}</span>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
 function WorkspaceTerminalConsole({
   terminal,
   draftTerminalCommand,
@@ -380,6 +451,7 @@ function PanelWorkspaceSidebar({
   draftTerminalCommand,
   setDraftTerminalCommand,
   terminal,
+  usage,
   onOpenGitDiff,
   handleCopy,
   session,
@@ -458,10 +530,7 @@ function PanelWorkspaceSidebar({
           />
         </div>
         <div className={`ws__pane${workspaceTab === 'context' ? ' ws__pane--active' : ''}`} data-pane="context">
-          <div className="ctx-group">
-            <div className="ctx-group__head"><span className="ctx-group__title">Panel context</span></div>
-            <div className="ws-empty-state">토큰 사용량 실측 수집을 준비 중입니다. 수집이 연결되면 이 자리에 패널 컨텍스트 사용량이 표시됩니다.</div>
-          </div>
+          <WorkspaceContextUsage usage={usage} />
         </div>
         <WorkspaceSubagentsPane workspaceTab={workspaceTab} session={session} activeChat={activeChat} />
       </div>
@@ -486,6 +555,7 @@ function ProjectWorkspaceSidebar({
   draftTerminalCommand,
   setDraftTerminalCommand,
   terminal,
+  usage,
   onOpenGitDiff,
   handleCopy,
   session,
@@ -531,6 +601,7 @@ function ProjectWorkspaceSidebar({
           <span className="ws__pill"><span className="ws__pill-dot" />{projectStatusLabel(session.status)}</span>
         </div>
         <div className="ws__status-right">
+          {usage && <span title="누적 토큰">{formatTokenCount(usage.total.totalTokens)}</span>}
           <button
             type="button"
             className="ws__stop"
@@ -704,14 +775,25 @@ function ProjectWorkspaceSidebar({
               </div>
             </div>
           </div>
-          <div className="ctx-group">
-            <div className="ctx-group__head"><span className="ctx-group__title">Context usage</span></div>
-            <div className="ws-empty-state">토큰 사용량 실측 수집을 준비 중입니다. 수집이 연결되면 이 자리에 컨텍스트 사용량이 표시됩니다.</div>
-          </div>
+          <WorkspaceContextUsage usage={usage} />
         </div>
         <WorkspaceSubagentsPane workspaceTab={workspaceTab} session={session} activeChat={activeChat} />
       </div>
       <div className="ws__footer">
+        {usage?.lastTurn && usage.contextWindow ? (
+          <>
+            <div className="ws__footer-row">
+              <span className="ws__footer-label">Context usage</span>
+              <span className="ws__footer-value">{formatTokenCount(usage.lastTurn.totalTokens)} / {formatTokenCount(usage.contextWindow)}</span>
+            </div>
+            <div className="ws__footer-bar">
+              <div
+                className="ws__footer-fill"
+                style={{ width: `${((computeContextUsageRatio(usage) ?? 0) * 100).toFixed(1)}%` }}
+              />
+            </div>
+          </>
+        ) : null}
         <div className="ws__footer-meta">
           <span>project scoped</span>
           <span>{workspaceGitOverview ? `${workspaceGitOverview.trackedFileCount} files` : '— files'}</span>

--- a/services/aris-web/lib/happy/types.ts
+++ b/services/aris-web/lib/happy/types.ts
@@ -72,6 +72,24 @@ export type ChatImageAttachment = {
   previewUrl: string;
 };
 
+export type ChatUsageTotals = {
+  totalTokens: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  reasoningOutputTokens?: number;
+};
+
+// 백엔드 Chat.usageStats(Json)의 미러 — GET /v1/sessions/:id/runtime 응답에 동봉된다.
+export type ChatUsageStats = {
+  provider: 'codex' | 'claude' | 'gemini';
+  model: string | null;
+  contextWindow: number | null;
+  total: ChatUsageTotals;
+  lastTurn: ChatUsageTotals | null;
+  updatedAt: string;
+};
+
 export type UiEventKind =
   | 'text_reply'
   | 'run_execution'

--- a/services/aris-web/lib/hooks/useSessionRuntime.ts
+++ b/services/aris-web/lib/hooks/useSessionRuntime.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { redirectToLoginWithNext } from '@/lib/hooks/authRedirect';
+import type { ChatUsageStats } from '@/lib/happy/types';
 import {
   buildRuntimeEventChannelUrl,
   shouldRefreshRuntimeForRuntimeMessage,
@@ -8,6 +9,7 @@ import {
 
 const RUNTIME_POLL_INTERVAL_MS = 3000;
 const runtimeStateCache = new Map<string, boolean>();
+const runtimeUsageCache = new Map<string, ChatUsageStats | null>();
 const isDocumentVisible = () => typeof document === 'undefined' || document.visibilityState === 'visible';
 
 type RuntimePollResolutionInput =
@@ -52,6 +54,7 @@ export function resolveRuntimePollResolution(input: RuntimePollResolutionInput):
 export function useSessionRuntime(sessionId: string, chatId?: string | null, enabled = true) {
   const cacheKey = `${sessionId}:${chatId?.trim() || '__default__'}`;
   const [isRunning, setIsRunning] = useState(() => runtimeStateCache.get(cacheKey) ?? false);
+  const [usage, setUsage] = useState<ChatUsageStats | null>(() => runtimeUsageCache.get(cacheKey) ?? null);
   const [runtimeError, setRuntimeError] = useState<string | null>(null);
   const lastKnownRunningRef = useRef(runtimeStateCache.get(cacheKey) ?? false);
 
@@ -62,6 +65,7 @@ export function useSessionRuntime(sessionId: string, chatId?: string | null, ena
     let realtimeSocket: WebSocket | null = null;
     lastKnownRunningRef.current = runtimeStateCache.get(cacheKey) ?? false;
     setIsRunning(lastKnownRunningRef.current);
+    setUsage(runtimeUsageCache.get(cacheKey) ?? null);
     setRuntimeError(null);
 
     if (!enabled) {
@@ -104,8 +108,11 @@ export function useSessionRuntime(sessionId: string, chatId?: string | null, ena
         if (!response.ok) {
           throw new Error(`Runtime status sync failed (${response.status})`);
         }
-        const body = (await response.json()) as { isRunning?: boolean };
+        const body = (await response.json()) as { isRunning?: boolean; usage?: ChatUsageStats | null };
         if (!disposed) {
+          const nextUsage = body.usage ?? null;
+          runtimeUsageCache.set(cacheKey, nextUsage);
+          setUsage(nextUsage);
           const resolution = resolveRuntimePollResolution({
             previousIsRunning: lastKnownRunningRef.current,
             nextIsRunning: Boolean(body.isRunning),
@@ -179,5 +186,5 @@ export function useSessionRuntime(sessionId: string, chatId?: string | null, ena
     };
   }, [cacheKey, sessionId, chatId, enabled]);
 
-  return { isRunning, runtimeError };
+  return { isRunning, runtimeError, usage };
 }

--- a/services/aris-web/tests/projectListSurface.test.ts
+++ b/services/aris-web/tests/projectListSurface.test.ts
@@ -510,6 +510,16 @@ describe('project list surface', () => {
     expect(projectChatSurface).toContain('matchWorkspaceFileBadge');
   });
 
+  it('renders context usage from measured stats instead of hardcoded values', () => {
+    // 링/게이지는 실측 usage에서 계산 — 하드코딩 수치 재유입 방지.
+    expect(projectChatSurface).toContain('computeContextUsageRatio');
+    expect(projectChatSurface).toContain('strokeDashoffset={CTX_RING_CIRCUMFERENCE * (1 - ratio)}');
+    expect(projectChatSurface).toContain('usage: chatUsage');
+    expect(projectChatSurface).not.toContain('strokeDashoffset="194"');
+    // 프리뷰 목업(PR-6에서 실물화)은 예외 — 사이드바 소스에는 하드코딩 % 금지.
+    expect(workspaceSidebarSource).not.toMatch(/width: '\d+(\.\d+)?%'/);
+  });
+
   it('renders functional workspace panes instead of one static Run panel', () => {
     expect(projectChatSurface).toContain("workspaceTab === 'run'");
     expect(projectChatSurface).toContain("workspaceTab === 'files'");

--- a/services/aris-web/tests/workspaceUsageDisplay.test.ts
+++ b/services/aris-web/tests/workspaceUsageDisplay.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { computeContextUsageRatio, formatTokenCount } from '@/components/project-chat/projectChatSurfaceUtils';
+
+describe('formatTokenCount', () => {
+  it('formats token counts with k/M units', () => {
+    expect(formatTokenCount(0)).toBe('0');
+    expect(formatTokenCount(982)).toBe('982');
+    expect(formatTokenCount(12_400)).toBe('12.4k');
+    expect(formatTokenCount(258_400)).toBe('258.4k');
+    expect(formatTokenCount(5_569_014)).toBe('5.6M');
+  });
+
+  it('renders a dash for missing values', () => {
+    expect(formatTokenCount(null)).toBe('—');
+    expect(formatTokenCount(undefined)).toBe('—');
+    expect(formatTokenCount(Number.NaN)).toBe('—');
+    expect(formatTokenCount(-1)).toBe('—');
+  });
+});
+
+describe('computeContextUsageRatio', () => {
+  it('uses last-turn tokens over the context window', () => {
+    // 실측값: lastTurn 107,594 / window 258,400 ≈ 41.6%
+    const ratio = computeContextUsageRatio({
+      contextWindow: 258_400,
+      lastTurn: { totalTokens: 107_594 },
+    });
+    expect(ratio).toBeCloseTo(0.4164, 3);
+  });
+
+  it('clamps to 1 and rejects unusable inputs', () => {
+    expect(computeContextUsageRatio({ contextWindow: 100, lastTurn: { totalTokens: 250 } })).toBe(1);
+    expect(computeContextUsageRatio({ contextWindow: null, lastTurn: { totalTokens: 10 } })).toBeNull();
+    expect(computeContextUsageRatio({ contextWindow: 100, lastTurn: null })).toBeNull();
+    expect(computeContextUsageRatio(null)).toBeNull();
+    expect(computeContextUsageRatio(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## 배경

사이드바 실동작 전환 설계(#402)의 **PR-5**. PR-4(#407)가 수집하는 `Chat.usageStats`를 UI에 연결해, PR-1에서 제거한 가짜 지표 자리를 실측치로 채운다.

## 변경

- **`useSessionRuntime` 확장**: 기존 3초 runtime 폴링 응답에 동봉된 `usage`를 함께 반환. **신규 네트워크 요청 없음.** 키별 캐시로 탭 전환 시 워밍. 병렬 모드 사이드바는 활성 패널 채팅 대상 훅 1개를 추가로 사용(일반 모드에서는 `enabled=false`라 폴링 없음).
- **Context 탭** (`WorkspaceContextUsage`, 일반·병렬 공용):
  - 링 % = `lastTurn.totalTokens / contextWindow` — SVG `strokeDashoffset` 실계산. 누적치가 아닌 lastTurn을 쓰는 이유: 캐시 재사용 때문에 누적 입력은 윈도의 수십 배가 될 수 있어 "지금 컨텍스트가 얼마나 찼나"와 무관
  - 누적 분해: Input(cached 포함)/Output/Reasoning(코덱스), 누적 총토큰, 모델·프로바이더
  - usage 미수집 채팅은 정직한 empty state("다음 런부터 실측치가 표시됩니다")
- **푸터**: `used / window` + 게이지 width 실계산 (기존: `width: '9.2%'` 하드코딩이었던 자리)
- **상태바**: 누적 총토큰(`5.6M`/`128.4k` 포맷), usage 있을 때만 표시

## 배포 순서 주의

이 PR(웹)은 백엔드보다 먼저 배포해도 안전하다 — 구 백엔드 응답에는 `usage` 필드가 없고 UI는 `usage ?? null` → empty state로 처리한다. 반대로 **백엔드(PR-4) 배포는 DB 마이그레이션(`20260711120000_add_chat_usage_stats`) 적용이 선행**돼야 한다.

## 검증

- 단위 4건: `formatTokenCount`(k/M 포맷·결측), `computeContextUsageRatio`(실측값 41.6% 검산·클램프·거부)
- 정적 단언: `strokeDashoffset` 실계산 강제, 사이드바 소스 하드코딩 `%` 금지
- `tsc` 클린, vitest 128 파일/**644 테스트** 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxfd4yi1xRpXZHvjuggvTW
